### PR TITLE
Ansible: add to cert all master ip's (dirty fix)

### DIFF
--- a/ansible/roles/kubernetes/tasks/gen_certs.yml
+++ b/ansible/roles/kubernetes/tasks/gen_certs.yml
@@ -29,7 +29,7 @@
   args:
     creates: "{{ kube_cert_dir }}/server.crt"
   environment:
-    MASTER_IP: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+    MASTER_IP: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | join (',IP:') }}"
     MASTER_NAME: "{{ inventory_hostname }}"
     DNS_DOMAIN: "{{ dns_domain }}"
     SERVICE_CLUSTER_IP_RANGE: "{{ kube_service_addresses }}"


### PR DESCRIPTION
Allow nodes to be connected to the non-default interface