### PR TITLE
ansible: factor out kube_cert_ip

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -17,6 +17,9 @@ kube_config_dir: /etc/kubernetes
 # This is where all the cert scripts and certs will be located
 kube_cert_dir: "{{ kube_config_dir }}/certs"
 
+# The IP(s) for which the certificate will be valid
+kube_cert_ip: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | join (',IP:') }}"
+
 # This is where all of the bearer tokens will be stored
 kube_token_dir: "{{ kube_config_dir }}/tokens"
 

--- a/ansible/roles/kubernetes/tasks/gen_certs.yml
+++ b/ansible/roles/kubernetes/tasks/gen_certs.yml
@@ -29,7 +29,7 @@
   args:
     creates: "{{ kube_cert_dir }}/server.crt"
   environment:
-    MASTER_IP: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | join (',IP:') }}"
+    MASTER_IP: "{{ kube_cert_ip }}"
     MASTER_NAME: "{{ inventory_hostname }}"
     DNS_DOMAIN: "{{ dns_domain }}"
     SERVICE_CLUSTER_IP_RANGE: "{{ kube_service_addresses }}"


### PR DESCRIPTION
This will help users more easily specify the IP addresses for which the
certificate should be valid. The make-ca-cert.sh script allows for many
"magic strings" such as '_use_aws_external_ip_', which can automatically
query the metadata service to retrieve the public IP. This modification
makes changing that setting much easier (and less likely to change).