### PR TITLE
Small iptables fixes

### DIFF
--- a/ansible/roles/etcd/tasks/iptables.yml
+++ b/ansible/roles/etcd/tasks/iptables.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get iptables rules
-  command: iptables -L
+  command: iptables -L --wait
   register: iptablesrules
   always_run: yes
 

--- a/ansible/roles/master/tasks/iptables.yml
+++ b/ansible/roles/master/tasks/iptables.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get iptables rules
-  command: iptables -L
+  command: iptables -L --wait
   register: iptablesrules
   always_run: yes
 

--- a/ansible/roles/node/tasks/iptables.yml
+++ b/ansible/roles/node/tasks/iptables.yml
@@ -10,8 +10,6 @@
 - name: Open kubelet port with iptables
   command: /sbin/iptables -I INPUT 1 -p tcp --dport 10250 -j ACCEPT -m comment --comment "kubelet"
   when: "'kubelet' not in iptablesrules.stdout"
-  notify:
-    - restart iptables
 
 - name: Save iptables rules
   command: service iptables save

--- a/ansible/roles/node/tasks/iptables.yml
+++ b/ansible/roles/node/tasks/iptables.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get iptables rules
-  command: iptables -L
+  command: iptables -L --wait
   register: iptablesrules
   always_run: yes
 


### PR DESCRIPTION
The first patch ensures that we wait for the lock even when only listing iptables entries. Otherwise we may sometimes get a busy lock error.

The second patch removes an unnecessary iptables restart, which coincidentally resolves some issues it caused.
