### PR TITLE
Add rules for flannel and kube-proxy traffic and re-enable support for firewalld

### DIFF
--- a/ansible/roles/flannel/handlers/main.yml
+++ b/ansible/roles/flannel/handlers/main.yml
@@ -5,16 +5,17 @@
     - stop docker
     - delete docker0
     - start docker
-  when: inventory_hostname in groups['nodes']
 
 - name: stop docker
   service: name=docker state=stopped
+  when: '"docker0" in ansible_interfaces'
 
 - name: delete docker0
   command: ip link delete docker0
-  ignore_errors: yes
+  when: '"docker0" in ansible_interfaces'
 
 - name: start docker
   service: name=docker state=started
-  # This might fail if docker isn't installed yet
-  ignore_errors: yes
+  # NB: even if docker0 is deleted above, ansible_interfaces is not affected
+  # since it is set once at the beginning of the role
+  when: '"docker0" in ansible_interfaces'

--- a/ansible/roles/flannel/tasks/firewalld.yml
+++ b/ansible/roles/flannel/tasks/firewalld.yml
@@ -1,0 +1,26 @@
+---
+- name: Open firewalld vxlan port for flanneld
+  firewalld: port=8472/udp permanent=false state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+
+- name: Save firewalld vxlan port for flanneld
+  firewalld: port=8472/udp permanent=true state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+
+  # unfortunately, the ansible firewalld module doesn't support direct rules so
+  # we have to manually invoke firewall-cmd
+- name: Open flanneld subnet traffic
+  command: /bin/firewall-cmd --direct --add-rule ipv4 filter FORWARD 1
+           -i flannel.1 -o docker0 -j ACCEPT
+           -m comment --comment "flannel subnet"
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+
+- name: Save flanneld subnet traffic
+  command: /bin/firewall-cmd --permanent --direct --add-rule ipv4 filter FORWARD 1
+           -i flannel.1 -o docker0 -j ACCEPT
+           -m comment --comment "flannel subnet"
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes

--- a/ansible/roles/flannel/tasks/iptables.yml
+++ b/ansible/roles/flannel/tasks/iptables.yml
@@ -1,0 +1,19 @@
+---
+- name: Get iptables rules
+  command: iptables -L --wait
+  register: iptablesrules
+  always_run: yes
+
+- name: Enable iptables at boot
+  service: name=iptables enabled=yes state=started
+
+- name: Open vxlan port with iptables
+  command: /sbin/iptables -I INPUT 1 -p udp --dport 8472
+           -j ACCEPT -m comment --comment "vxlan"
+
+- name: Allow flanneld subnet traffic with iptables
+  command: /sbin/iptables -I FORWARD 1 -i flannel.1 -o docker0
+           -j ACCEPT -m comment --comment "flannel subnet"
+
+- name: Save iptables rules
+  command: service iptables save

--- a/ansible/roles/flannel/tasks/main.yml
+++ b/ansible/roles/flannel/tasks/main.yml
@@ -3,3 +3,9 @@
 
 - include: client.yml
   when: inventory_hostname in groups['masters'] + groups['nodes']
+
+- include: firewalld.yml
+  when: has_firewalld
+
+- include: iptables.yml
+  when: not has_firewalld and has_iptables

--- a/ansible/roles/node/tasks/firewalld.yml
+++ b/ansible/roles/node/tasks/firewalld.yml
@@ -1,10 +1,7 @@
 ---
-# https://bugzilla.redhat.com/show_bug.cgi?id=1033606 and I think others say firewalld+docker == bad
-- name: disable firewalld
-  service: name=firewalld enabled=no state=stopped
+- name: Open firewalld port for the kubelet
+  firewalld: port=10250/tcp permanent=false state=enabled
 
-#- name: Open firewalld port for the kubelet
-#firewalld: port=10250/tcp permanent=false state=enabled
+- name: Save firewalld port for the kubelet
+  firewalld: port=10250/tcp permanent=true state=enabled
 
-#- name: Save firewalld port for the kubelet
-#firewalld: port=10250/tcp permanent=true state=enabled

--- a/ansible/roles/node/tasks/firewalld.yml
+++ b/ansible/roles/node/tasks/firewalld.yml
@@ -5,3 +5,10 @@
 - name: Save firewalld port for the kubelet
   firewalld: port=10250/tcp permanent=true state=enabled
 
+- name: Open redirected service traffic
+  command: /bin/firewall-cmd --direct --add-rule ipv4 filter INPUT 1
+           -i docker0 -j ACCEPT -m comment --comment "kube-proxy redirects"
+
+- name: Save redirected service traffic
+  command: /bin/firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT 1
+           -i docker0 -j ACCEPT -m comment --comment "kube-proxy redirects"

--- a/ansible/roles/node/tasks/iptables.yml
+++ b/ansible/roles/node/tasks/iptables.yml
@@ -11,6 +11,10 @@
   command: /sbin/iptables -I INPUT 1 -p tcp --dport 10250 -j ACCEPT -m comment --comment "kubelet"
   when: "'kubelet' not in iptablesrules.stdout"
 
+- name: Allow redirected service traffic
+  command: /sbin/iptables -I INPUT 1 -i docker0
+      -j ACCEPT -m comment --comment "kube-proxy redirects"
+
 - name: Save iptables rules
   command: service iptables save
   when: "'kubelet' not in iptablesrules.stdout"


### PR DESCRIPTION
Small patches to get flannel to work on Atomic.
