### PR TITLE
Add a PR-size munger for github

### DIFF
--- a/mungegithub/Makefile
+++ b/mungegithub/Makefile
@@ -1,7 +1,7 @@
 all: push
 
-mungegithub: mungegithub.go
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./mungegithub.go
+mungegithub:
+	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' ./mungegithub.go
 
 container: mungegithub
 	docker build -t gcr.io/google_containers/mungegithub:0.3 .

--- a/mungegithub/pulls/pulls.go
+++ b/mungegithub/pulls/pulls.go
@@ -95,6 +95,11 @@ func MungePullRequests(client *github.Client, pullMungers, org, project string, 
 func mungePullRequestList(list []github.PullRequest, client *github.Client, org, project string, mungers []Munger, minPRNumber int, dryrun bool) error {
 	for ix := range list {
 		pr := &list[ix]
+		if p, _, err := client.PullRequests.Get(org, project, *pr.Number); err != nil {
+			return err
+		} else {
+			*pr = *p
+		}
 		for _, munger := range mungers {
 			glog.V(2).Infof("-=-=-=-=%d-=-=-=-=-", *pr.Number)
 			if *pr.Number < minPRNumber {
@@ -125,4 +130,14 @@ func HasLabel(labels []github.Label, name string) bool {
 		}
 	}
 	return false
+}
+
+func GetLabelsWithPrefix(labels []github.Label, prefix string) []string {
+	var ret []string
+	for _, label := range labels {
+		if label.Name != nil && strings.HasPrefix(*label.Name, prefix) {
+			ret = append(ret, *label.Name)
+		}
+	}
+	return ret
 }

--- a/mungegithub/pulls/size.go
+++ b/mungegithub/pulls/size.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pulls
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/google/go-github/github"
+)
+
+type PRSizeMunger struct{}
+
+func init() {
+	RegisterMungerOrDie(PRSizeMunger{})
+}
+
+func (PRSizeMunger) Name() string { return "size" }
+
+const labelSizePrefix = "size/"
+
+func (PRSizeMunger) MungePullRequest(client *github.Client, org, project string, pr *github.PullRequest, issue *github.Issue, commits []github.RepositoryCommit, events []github.IssueEvent, dryrun bool) {
+	if pr.Number == nil {
+		glog.Warningf("PR has no Number: %+v", *pr)
+		return
+	}
+	if pr.Additions == nil {
+		glog.Warningf("PR %d has nil Additions", *pr.Number)
+		return
+	}
+	if pr.Deletions == nil {
+		glog.Warningf("PR %d has nil Deletions", *pr.Number)
+		return
+	}
+
+	adds := *pr.Additions
+	dels := *pr.Deletions
+
+	newSize := calculateSize(adds, dels)
+	newLabel := labelSizePrefix + newSize
+
+	existing := GetLabelsWithPrefix(issue.Labels, labelSizePrefix)
+	needsUpdate := true
+	for _, l := range existing {
+		if l == newLabel {
+			needsUpdate = false
+			continue
+		}
+		if dryrun {
+			glog.Infof("PR #%d: would have removed label %s", *pr.Number, l)
+		} else {
+			if _, err := client.Issues.RemoveLabelForIssue(org, project, *pr.Number, l); err != nil {
+				glog.Errorf("PR #%d: error removing label %q: %v", *pr.Number, l, err)
+			}
+		}
+	}
+	if needsUpdate {
+		if dryrun {
+			glog.Infof("PR #%d: would have added label %s", *pr.Number, newLabel)
+		} else {
+			if _, _, err := client.Issues.AddLabelsToIssue(org, project, *pr.Number, []string{newLabel}); err != nil {
+				glog.Errorf("PR #%d: error adding label %q: %v", *pr.Number, newLabel, err)
+			}
+			body := fmt.Sprintf("Labelling this PR as %s", newLabel)
+			if _, _, err := client.Issues.CreateComment(org, project, *pr.Number, &github.IssueComment{Body: &body}); err != nil {
+				glog.Errorf("PR #%d: error adding comment: %v", *pr.Number, err)
+			}
+		}
+	}
+}
+
+const (
+	sizeXS  = "XS"
+	sizeS   = "S"
+	sizeM   = "M"
+	sizeL   = "L"
+	sizeXL  = "XL"
+	sizeXXL = "XXL"
+)
+
+func calculateSize(adds, dels int) string {
+	lines := adds + dels
+
+	// This is a totally arbitrary heuristic and is open for tweaking.
+	if lines < 10 {
+		return sizeXS
+	}
+	if lines < 30 {
+		return sizeS
+	}
+	if lines < 100 {
+		return sizeM
+	}
+	if lines < 500 {
+		return sizeL
+	}
+	if lines < 1000 {
+		return sizeXL
+	}
+	return sizeXXL
+}


### PR DESCRIPTION
This analyzes the additions/deletions stats and adds a label about the size of
the PR.  The heuristic is totally arbitratry for now.

This makes PR munging much slower because it has to get every PR to get the
stats.  C'est la vie.

@brendandburns @lavalamp 