### PR TITLE
mungegithub: Fix PR List options

### DIFF
--- a/mungegithub/pulls/pulls.go
+++ b/mungegithub/pulls/pulls.go
@@ -74,7 +74,9 @@ func MungePullRequests(client *github.Client, pullMungers, org, project string, 
 	for {
 		glog.V(4).Infof("Fetching page %d", page)
 		listOpts := &github.PullRequestListOptions{
-			Sort:        "desc",
+			State:       "open",
+			Sort:        "created",
+			Direction:   "asc",
 			ListOptions: github.ListOptions{PerPage: 100, Page: page},
 		}
 		prs, response, err := client.PullRequests.List(org, project, listOpts)


### PR DESCRIPTION
Sort: desc

Is not valid according to
https://godoc.org/github.com/google/go-github/github#PullRequestListOptions

So we have been sorting ascending. Continue to do that, but at least
make the options correct/obvious. If we want descending that's fine, but
this PR has NO actual change to the operation of the code