### PR TITLE
mungegithub: sizer: Skip generated files

### DIFF
--- a/mungegithub/.gitignore
+++ b/mungegithub/.gitignore
@@ -1,0 +1,1 @@
+mungegithub

--- a/mungegithub/issues/issues.go
+++ b/mungegithub/issues/issues.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/contrib/mungegithub/opts"
+
 	"github.com/golang/glog"
 	"github.com/google/go-github/github"
 )
@@ -51,7 +53,7 @@ func RegisterMunger(munger Munger) error {
 	return nil
 }
 
-func MungeIssues(client *github.Client, issueMungers, org, project string, minIssueNumber int, dryrun bool) error {
+func MungeIssues(client *github.Client, issueMungers string, o opts.MungeOptions) error {
 	mungers, err := getMungers(strings.Split(issueMungers, ","))
 	if err != nil {
 		return err
@@ -63,11 +65,11 @@ func MungeIssues(client *github.Client, issueMungers, org, project string, minIs
 			Sort:        "desc",
 			ListOptions: github.ListOptions{PerPage: 100, Page: page},
 		}
-		list, response, err := client.Issues.ListByRepo(org, project, listOpts)
+		list, response, err := client.Issues.ListByRepo(o.Org, o.Project, listOpts)
 		if err != nil {
 			return err
 		}
-		if err := mungeIssueList(list, client, org, project, mungers, minIssueNumber, dryrun); err != nil {
+		if err := mungeIssueList(list, client, o.Org, o.Project, mungers, o.MinIssueNumber, o.Dryrun); err != nil {
 			return err
 		}
 		if response.LastPage == 0 || response.LastPage == page {

--- a/mungegithub/opts/opts.go
+++ b/mungegithub/opts/opts.go
@@ -1,0 +1,9 @@
+package opts
+
+type MungeOptions struct {
+	MinPRNumber    int
+	MinIssueNumber int
+	Dryrun         bool
+	Org            string
+	Project        string
+}

--- a/mungegithub/pulls/blunderbuss.go
+++ b/mungegithub/pulls/blunderbuss.go
@@ -88,11 +88,6 @@ func (b *BlunderbussMunger) MungePullRequest(client *github.Client, pr *github.P
 			glog.Warningf("Skipping invalid commit for %d: %#v", *pr.Number, commit)
 			continue
 		}
-		commit, _, err := client.Repositories.GetCommit(*commit.Author.Login, opts.Project, *commit.SHA)
-		if err != nil {
-			glog.Errorf("Can't load commit %s %s %s", *commit.Author.Login, opts.Project, *commit.SHA)
-			continue
-		}
 		for _, file := range commit.Files {
 			fileOwners := b.config.FindOwners(*file.Filename)
 			if len(fileOwners) == 0 {

--- a/mungegithub/pulls/pulls.go
+++ b/mungegithub/pulls/pulls.go
@@ -111,6 +111,15 @@ func mungePullRequestList(list []github.PullRequest, client *github.Client, mung
 		if err != nil {
 			return err
 		}
+		filledCommits := []github.RepositoryCommit{}
+		for _, c := range commits {
+			commit, _, err := client.Repositories.GetCommit(opts.Org, opts.Project, *c.SHA)
+			if err != nil {
+				glog.Errorf("Can't load commit %s %s %s", opts.Org, opts.Project, *commit.SHA)
+				continue
+			}
+			filledCommits = append(filledCommits, *commit)
+		}
 		events, _, err := client.Issues.ListIssueEvents(opts.Org, opts.Project, *pr.Number, &github.ListOptions{})
 		if err != nil {
 			return err
@@ -120,7 +129,7 @@ func mungePullRequestList(list []github.PullRequest, client *github.Client, mung
 			return err
 		}
 		for _, munger := range mungers {
-			munger.MungePullRequest(client, pr, issue, commits, events, opts)
+			munger.MungePullRequest(client, pr, issue, filledCommits, events, opts)
 		}
 	}
 	return nil

--- a/mungegithub/pulls/pulls.go
+++ b/mungegithub/pulls/pulls.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/contrib/mungegithub/opts"
+
 	"github.com/golang/glog"
 	"github.com/google/go-github/github"
 )
@@ -34,7 +36,7 @@ type Munger interface {
 	//   * The commits for the PR
 	//   * The events on the PR
 	//   * dryrun, if true, the munger should take no action, and only report what it would have done.
-	MungePullRequest(client *github.Client, org, user string, pr *github.PullRequest, issue *github.Issue, commits []github.RepositoryCommit, events []github.IssueEvent, dryrun bool)
+	MungePullRequest(client *github.Client, pr *github.PullRequest, issue *github.Issue, commits []github.RepositoryCommit, events []github.IssueEvent, opts opts.MungeOptions)
 	Name() string
 }
 
@@ -64,7 +66,7 @@ func RegisterMungerOrDie(munger Munger) {
 	}
 }
 
-func MungePullRequests(client *github.Client, pullMungers, org, project string, minPRNumber int, dryrun bool) error {
+func MungePullRequests(client *github.Client, pullMungers string, opts opts.MungeOptions) error {
 	mungers, err := getMungers(strings.Split(pullMungers, ","))
 	if err != nil {
 		return err
@@ -77,11 +79,11 @@ func MungePullRequests(client *github.Client, pullMungers, org, project string, 
 			Sort:        "desc",
 			ListOptions: github.ListOptions{PerPage: 100, Page: page},
 		}
-		prs, response, err := client.PullRequests.List(org, project, listOpts)
+		prs, response, err := client.PullRequests.List(opts.Org, opts.Project, listOpts)
 		if err != nil {
 			return err
 		}
-		if err := mungePullRequestList(prs, client, org, project, mungers, minPRNumber, dryrun); err != nil {
+		if err := mungePullRequestList(prs, client, mungers, opts); err != nil {
 			return err
 		}
 		if response.LastPage == 0 || response.LastPage == page {
@@ -92,33 +94,33 @@ func MungePullRequests(client *github.Client, pullMungers, org, project string, 
 	return nil
 }
 
-func mungePullRequestList(list []github.PullRequest, client *github.Client, org, project string, mungers []Munger, minPRNumber int, dryrun bool) error {
+func mungePullRequestList(list []github.PullRequest, client *github.Client, mungers []Munger, opts opts.MungeOptions) error {
 	for ix := range list {
 		pr := &list[ix]
 		glog.V(2).Infof("-=-=-=-=%d-=-=-=-=-", *pr.Number)
-		if *pr.Number < minPRNumber {
-			glog.V(3).Infof("skipping %d less %d", *pr.Number, minPRNumber)
+		if *pr.Number < opts.MinPRNumber {
+			glog.V(3).Infof("skipping %d less %d", *pr.Number, opts.MinPRNumber)
 			continue
 		}
-		if p, _, err := client.PullRequests.Get(org, project, *pr.Number); err != nil {
+		if p, _, err := client.PullRequests.Get(opts.Org, opts.Project, *pr.Number); err != nil {
 			return err
 		} else {
 			*pr = *p
 		}
-		commits, _, err := client.PullRequests.ListCommits(org, project, *pr.Number, &github.ListOptions{})
+		commits, _, err := client.PullRequests.ListCommits(opts.Org, opts.Project, *pr.Number, &github.ListOptions{})
 		if err != nil {
 			return err
 		}
-		events, _, err := client.Issues.ListIssueEvents(org, project, *pr.Number, &github.ListOptions{})
+		events, _, err := client.Issues.ListIssueEvents(opts.Org, opts.Project, *pr.Number, &github.ListOptions{})
 		if err != nil {
 			return err
 		}
-		issue, _, err := client.Issues.Get(org, project, *pr.Number)
+		issue, _, err := client.Issues.Get(opts.Org, opts.Project, *pr.Number)
 		if err != nil {
 			return err
 		}
 		for _, munger := range mungers {
-			munger.MungePullRequest(client, org, project, pr, issue, commits, events, dryrun)
+			munger.MungePullRequest(client, pr, issue, commits, events, opts)
 		}
 	}
 	return nil

--- a/mungegithub/pulls/size.go
+++ b/mungegithub/pulls/size.go
@@ -18,6 +18,7 @@ package pulls
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/contrib/mungegithub/opts"
 
@@ -51,6 +52,16 @@ func (PRSizeMunger) MungePullRequest(client *github.Client, pr *github.PullReque
 
 	adds := *pr.Additions
 	dels := *pr.Deletions
+
+	for _, c := range commits {
+		for _, f := range c.Files {
+			if strings.HasPrefix(*f.Filename, "Godeps/") {
+				adds = adds - *f.Additions
+				dels = dels - *f.Deletions
+				continue
+			}
+		}
+	}
 
 	newSize := calculateSize(adds, dels)
 	newLabel := labelSizePrefix + newSize


### PR DESCRIPTION
We automatically generated deep copies, conversions, docs, bash completions, swagger stuff. Humans don't look at those things closely, so stop counting them in the 'size' of a PR.

To be honest, this doesn't currently ignore the 'docs' but there is an open PR in kubernetes which redoes how we generate docs so this will hopefully start working once that lands. (currently we scatter the '.generated_docs' files all over the repo instead of just one file at the root of the repo, this expects it to be in the root)