### PR TITLE
Break out of the loop on errors, don't continue.

### DIFF
--- a/submit-queue/github/github.go
+++ b/submit-queue/github/github.go
@@ -287,7 +287,7 @@ func ForEachCandidatePRDo(client *github.Client, user, project string, fn PRFunc
 		}
 		if err := fn(client, pr, issue); err != nil {
 			glog.Errorf("Failed to run user function: %v", err)
-			continue
+			break
 		}
 		if once {
 			break


### PR DESCRIPTION
This has the net effect of retrying the PR that just failed (or any other older PR if it exists) rather than moving on to the next PR.

In particular, this means that if the Jenkins pre-condition fails, we will sit on that PR until it is green, rather than moving on.

In general, this should do a better job of prioritizing older PRs.