### PR TITLE
Ansible: install kubernetes from github releases

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -4,6 +4,7 @@
 #
 # localBuild - requires make release to have been run to build local binaries
 # packageManager - will install packages from your distribution using yum/dnf/apt
+# ghReleases - will download binaries from github releases
 source_type: localBuild
 
 # will be used as the Internal dns domain name if DNS is enabled. Services

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -7,8 +7,8 @@
 # ghReleases - will download binaries from github releases
 source_type: localBuild
 
-# This version will be used only when installing kubernetes from github releases
-kubernetes_version: v1.0.4
+# This version will be used only when installing kubernetes from github releases. When unspecified will install latest stable version
+#kubernetes_version: v1.0.4
 
 # will be used as the Internal dns domain name if DNS is enabled. Services
 # will be discoverable under <service-name>.<namespace>.svc.<domainname>, e.g.

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -7,6 +7,9 @@
 # ghReleases - will download binaries from github releases
 source_type: localBuild
 
+# This version will be used only when installing kubernetes from github releases
+kubernetes_version: v1.0.4
+
 # will be used as the Internal dns domain name if DNS is enabled. Services
 # will be discoverable under <service-name>.<namespace>.svc.<domainname>, e.g.
 # myservice.default.svc.cluster.local

--- a/ansible/roles/master/defaults/main.yml
+++ b/ansible/roles/master/defaults/main.yml
@@ -2,4 +2,4 @@
 kubernetes_version: v1.0.4
 kubernetes_download_filename: "kubernetes-{{ kubernetes_version }}.tar.gz"
 kubernetes_download_url: "https://github.com/kubernetes/kubernetes/releases/download/{{ kubernetes_version }}/kubernetes.tar.gz"
-kubernetes_download_dir: /usr/local/src
+kubernetes_download_dir: /var/run/kube

--- a/ansible/roles/master/defaults/main.yml
+++ b/ansible/roles/master/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-kubernetes_version: v1.0.4
 kubernetes_download_filename: "kubernetes-{{ kubernetes_version }}.tar.gz"
 kubernetes_download_url: "https://github.com/kubernetes/kubernetes/releases/download/{{ kubernetes_version }}/kubernetes.tar.gz"
-kubernetes_download_dir: /var/run/kube
+kubernetes_download_dir: /var/cache/kube

--- a/ansible/roles/master/defaults/main.yml
+++ b/ansible/roles/master/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-kubernetes_version: v1.0.3
+kubernetes_version: v1.0.4
 kubernetes_download_filename: "kubernetes-{{ kubernetes_version }}.tar.gz"
 kubernetes_download_url: "https://github.com/kubernetes/kubernetes/releases/download/{{ kubernetes_version }}/kubernetes.tar.gz"
 kubernetes_download_dir: /usr/local/src

--- a/ansible/roles/master/defaults/main.yml
+++ b/ansible/roles/master/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+kubernetes_version: v1.0.3
+kubernetes_download_filename: "kubernetes-{{ kubernetes_version }}.tar.gz"
+kubernetes_download_url: "https://github.com/kubernetes/kubernetes/releases/download/{{ kubernetes_version }}/kubernetes.tar.gz"
+kubernetes_download_dir: /usr/local/src

--- a/ansible/roles/master/tasks/ghReleasesInstall.yml
+++ b/ansible/roles/master/tasks/ghReleasesInstall.yml
@@ -1,0 +1,42 @@
+---
+- name: download kubernetes from github
+  get_url: url={{ kubernetes_download_url }} dest={{ kubernetes_download_dir }}/{{ kubernetes_download_filename }}
+
+- name: unarchive kubernetes
+  unarchive: copy=no
+             src={{ kubernetes_download_dir }}/{{ kubernetes_download_filename }}
+             dest={{ kubernetes_download_dir }}
+
+- name: unarchive kubernetes-server
+  unarchive: copy=no
+             src={{ kubernetes_download_dir }}/kubernetes/server/kubernetes-server-linux-amd64.tar.gz
+             dest={{ kubernetes_download_dir }}
+
+- name: copy kubernetes master binaries
+  shell: cp {{ kubernetes_download_dir }}/kubernetes/server/bin/{{ item }} /usr/bin
+  args:
+    creates: "/usr/bin/{{ item }}"
+  with_items:
+    - kube-apiserver
+    - kube-scheduler
+    - kube-controller-manager
+    - kubectl
+  notify: restart daemons
+
+- name: Copy master service files
+  copy:
+    src: ../init/systemd/{{ item }}
+    dest: /etc/systemd/system/
+    mode: 644
+  with_items:
+    - kube-apiserver.service
+    - kube-scheduler.service
+    - kube-controller-manager.service
+  notify: reload systemd
+
+- name: Copy systemd tmpfile for apiserver
+  copy:
+    src: ../init/systemd/tmpfiles.d/
+    dest: /etc/tmpfiles.d/
+    mode: 644
+  notify: reload systemd

--- a/ansible/roles/master/tasks/ghReleasesInstall.yml
+++ b/ansible/roles/master/tasks/ghReleasesInstall.yml
@@ -1,4 +1,17 @@
 ---
+- name: grab latest version from github
+  shell: curl -sI https://github.com/kubernetes/kubernetes/releases/latest | grep Location | rev | cut -d "/" -f 1 | rev
+  register: kubernetes_version_cmd_result
+  when: kubernetes_version is undefined
+
+- name: set kubernetes_version fact
+  set_fact:
+    kubernetes_version: "{{ kubernetes_version_cmd_result.stdout }}"
+  when: kubernetes_version is undefined
+
+- name: make sure the kubernetes download directory exits
+  file: path="{{ kubernetes_download_dir }}" state=directory
+
 - name: download kubernetes from github
   get_url: url={{ kubernetes_download_url }} dest={{ kubernetes_download_dir }}/{{ kubernetes_download_filename }}
 

--- a/ansible/roles/master/tasks/main.yml
+++ b/ansible/roles/master/tasks/main.yml
@@ -9,6 +9,11 @@
   tags:
     - binary-update
 
+- include: ghReleasesInstall.yml
+  when: source_type == "ghReleases"
+  tags:
+    - binary-update
+
 - name: write the config file for the api server
   template: src=apiserver.j2 dest={{ kube_config_dir }}/apiserver
   notify:

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -2,4 +2,4 @@
 kubernetes_version: v1.0.4
 kubernetes_download_filename: "kubernetes-{{ kubernetes_version }}.tar.gz"
 kubernetes_download_url: "https://github.com/kubernetes/kubernetes/releases/download/{{ kubernetes_version }}/kubernetes.tar.gz"
-kubernetes_download_dir: /usr/local/src
+kubernetes_download_dir: /var/run/kube

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-kubernetes_version: v1.0.4
 kubernetes_download_filename: "kubernetes-{{ kubernetes_version }}.tar.gz"
 kubernetes_download_url: "https://github.com/kubernetes/kubernetes/releases/download/{{ kubernetes_version }}/kubernetes.tar.gz"
-kubernetes_download_dir: /var/run/kube
+kubernetes_download_dir: /var/cache/kube

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-kubernetes_version: v1.0.3
+kubernetes_version: v1.0.4
 kubernetes_download_filename: "kubernetes-{{ kubernetes_version }}.tar.gz"
 kubernetes_download_url: "https://github.com/kubernetes/kubernetes/releases/download/{{ kubernetes_version }}/kubernetes.tar.gz"
 kubernetes_download_dir: /usr/local/src

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+kubernetes_version: v1.0.3
+kubernetes_download_filename: "kubernetes-{{ kubernetes_version }}.tar.gz"
+kubernetes_download_url: "https://github.com/kubernetes/kubernetes/releases/download/{{ kubernetes_version }}/kubernetes.tar.gz"
+kubernetes_download_dir: /usr/local/src

--- a/ansible/roles/node/tasks/ghReleasesInstall.yml
+++ b/ansible/roles/node/tasks/ghReleasesInstall.yml
@@ -1,0 +1,38 @@
+---
+- name: download kubernetes from github
+  get_url: url={{ kubernetes_download_url }} dest={{ kubernetes_download_dir }}/{{ kubernetes_download_filename }}
+
+- name: unarchive kubernetes
+  unarchive: copy=no
+             src={{ kubernetes_download_dir }}/{{ kubernetes_download_filename }}
+             dest={{ kubernetes_download_dir }}
+
+- name: unarchive kubernetes-server
+  unarchive: copy=no
+             src={{ kubernetes_download_dir }}/kubernetes/server/kubernetes-server-linux-amd64.tar.gz
+             dest={{ kubernetes_download_dir }}
+
+- name: copy kubernetes node binaries
+  shell: cp {{ kubernetes_download_dir }}/kubernetes/server/bin/{{ item }} /usr/bin
+  args:
+    creates: "/usr/bin/{{ item }}"
+  with_items:
+    - kubelet
+    - kube-proxy
+    - kubectl
+  notify: restart daemons
+
+- name: Copy node service files
+  copy:
+    src: ../init/systemd/{{ item }}
+    dest: /etc/systemd/system/
+    mode: 644
+  with_items:
+    - kube-proxy.service
+    - kubelet.service
+  notify: reload systemd
+
+- name: Create the /var/lib/kubelet working directory
+  file:
+    path: /var/lib/kubelet
+    state: directory

--- a/ansible/roles/node/tasks/ghReleasesInstall.yml
+++ b/ansible/roles/node/tasks/ghReleasesInstall.yml
@@ -1,4 +1,17 @@
 ---
+- name: grab latest version from github
+  shell: curl -sI https://github.com/kubernetes/kubernetes/releases/latest | grep Location | rev | cut -d "/" -f 1 | rev
+  register: kubernetes_version_cmd_result
+  when: kubernetes_version is undefined
+
+- name: set kubernetes_version fact
+  set_fact:
+    kubernetes_version: "{{ kubernetes_version_cmd_result.stdout }}"
+  when: kubernetes_version is undefined
+
+- name: make sure the kubernetes download directory exits
+  file: path="{{ kubernetes_download_dir }}" state=directory
+
 - name: download kubernetes from github
   get_url: url={{ kubernetes_download_url }} dest={{ kubernetes_download_dir }}/{{ kubernetes_download_filename }}
 

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -13,6 +13,11 @@
   tags:
     - binary-update
 
+- include: ghReleasesInstall.yml
+  when: source_type == "ghReleases"
+  tags:
+    - binary-update
+
 - name: Make sure manifest directory exists
   file: path={{ kube_manifest_dir }} state=directory
 


### PR DESCRIPTION
This commit will enable the option of installing kubernetes components by downloading archives from github releases in ansible playbook. To enable this set `source_type: ghReleases` in `group_vars/all.yml`.
The default version of kubernetes is set to `v1.0.3` but it can be overridden by setting `kubernetes_version` variable
