### PR TITLE
OpenContrail playbook

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,3 +1,4 @@
 myinventory
 inventory
 *.swp
+*~

--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -25,9 +25,17 @@
     - nodes
   sudo: yes
   roles:
-    - flannel
+    - { role: flannel, when: networking == 'flannel' }
   tags:
     - flannel
+
+# install opencontrail
+- hosts: all
+  sudo: yes
+  roles:
+    - { role: opencontrail, when networking == 'opencontrail'}
+  tags:
+    - opencontrail
 
 # install kube master services
 - hosts: masters
@@ -53,3 +61,13 @@
     - node
   tags:
     - nodes
+
+# provision opencontrail once the services are operational
+- hosts:
+    - masters[0]
+    - nodes
+  sudo: yes
+  roles:
+    - { role: opencontrail-provision, when: networking == 'opencontrail' }
+  tags:
+    - opencontrail

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -37,6 +37,18 @@ insecure_registrys:
 # addresses do not need to be routable and must just be an unused block of space.
 kube_service_addresses: 10.254.0.0/16
 
+# Network implementation (flannel|opencontrail)
+networking: flannel
+
+# External network
+# opencontrail_public_subnet: 10.1.4.0/24
+
+# Underlay network
+# opencontrail_private_subnet: 192.168.1.0/24
+
+# Data interface
+# opencontrail_interface: eth1
+
 # Flannel internal network (optional). When flannel is used, it will assign IP
 # addresses from this range to individual pods.
 # This network must be unused in your network infrastructure!

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -65,6 +65,7 @@
   template: src=kube-addons.service.j2 dest=/etc/systemd/system/kube-addons.service
   notify:
     - reload and restart kube-addons
+  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15)
 
 - name: Enable and start kube addons
   service: name=kube-addons.service enabled=yes state=started

--- a/ansible/roles/master/defaults/main.yml
+++ b/ansible/roles/master/defaults/main.yml
@@ -1,0 +1,3 @@
+kube_master_insecure_port: 8080
+
+localBuildOutput: ../../_output/local

--- a/ansible/roles/master/handlers/main.yml
+++ b/ansible/roles/master/handlers/main.yml
@@ -22,3 +22,6 @@
 
 - name: restart iptables
   service: name=iptables state=restarted
+
+- name: restart kubelet
+  service: name=kubelet state=restarted

--- a/ansible/roles/master/tasks/localBuildInstall.yml
+++ b/ansible/roles/master/tasks/localBuildInstall.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy master binaries
   copy:
-    src: ../../kubernetes/_output/local/go/bin/{{ item }}
+    src: "{{ localBuildOutput }}/go/bin/{{ item }}"
     dest: /usr/bin/
     mode: 755
   with_items:
@@ -9,6 +9,7 @@
     - kube-scheduler
     - kube-controller-manager
     - kubectl
+    - kubelet
   notify: restart daemons
 
 - name: Copy master service files
@@ -20,6 +21,7 @@
     - kube-apiserver.service
     - kube-scheduler.service
     - kube-controller-manager.service
+    - kubelet.service
   notify: reload systemd
 
 - name: Copy systemd tmpfile for apiserver
@@ -28,3 +30,8 @@
     dest: /etc/tmpfiles.d/
     mode: 644
   notify: reload systemd
+
+- name: Create the /var/lib/kubelet working directory
+  file:
+    path: /var/lib/kubelet
+    state: directory

--- a/ansible/roles/master/tasks/main.yml
+++ b/ansible/roles/master/tasks/main.yml
@@ -70,6 +70,14 @@
 - name: write the kubecfg (auth) file for kubectl
   template: src=kubectl.kubeconfig.j2 dest={{ kube_config_dir }}/kubectl.kubeconfig
 
+- name: write the config files for kubelet
+  template: src=kubelet.j2 dest={{ kube_config_dir }}/kubelet
+  notify:
+    - restart kubelet
+
+- name: Enable kubelet
+  service: name=kubelet enabled=yes state=started
+
 - include: firewalld.yml
   when: has_firewalld
 

--- a/ansible/roles/master/templates/kubelet.j2
+++ b/ansible/roles/master/templates/kubelet.j2
@@ -1,0 +1,17 @@
+###
+# kubernetes kubelet (node) config
+
+# The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
+KUBELET_ADDRESS="--address=0.0.0.0"
+
+# The port for the info server to serve on
+# KUBELET_PORT="--port=10250"
+
+# You may leave this blank to use the actual hostname
+KUBELET_HOSTNAME="--hostname-override={{ inventory_hostname }}"
+
+# location of the api-server
+KUBELET_API_SERVER="--api-servers=http://localhost:{{ kube_master_insecure_port }}"
+
+# Add your own!
+KUBELET_ARGS="--register-node=false --config={{ kube_manifest_dir }}"

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -1,0 +1,1 @@
+localBuildOutput: ../../_output/local

--- a/ansible/roles/node/tasks/localBuildInstall.yml
+++ b/ansible/roles/node/tasks/localBuildInstall.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy node binaries
   copy:
-    src: ../../kubernetes/_output/local/go/bin/{{ item }}
+    src: "{{ localBuildOutput }}/go/bin/{{ item }}"
     dest: /usr/bin/
     mode: 755
   with_items:

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -64,6 +64,7 @@
 
 - name: Enable proxy
   service: name=kube-proxy enabled=yes state=started
+  when: networking != "opencontrail"
 
 - include: firewalld.yml
   when: has_firewalld

--- a/ansible/roles/node/templates/kubelet.j2
+++ b/ansible/roles/node/templates/kubelet.j2
@@ -13,9 +13,13 @@ KUBELET_HOSTNAME="--hostname-override={{ inventory_hostname }}"
 # location of the api-server
 KUBELET_API_SERVER="--api-servers=https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}"
 
-# Add your own!
-{% if dns_setup %}
-KUBELET_ARGS="--cluster-dns={{ dns_server }} --cluster-domain={{ dns_domain }} --kubeconfig={{ kube_config_dir}}/kubelet.kubeconfig --config={{ kube_manifest_dir }}"
-{% else %}
-KUBELET_ARGS="--kubeconfig={{ kube_config_dir }}/kubelet.kubeconfig --config={{ kube_manifest_dir }}"
-{% endif %}
+{% set kubelet_options = [] -%}
+{% if dns_setup -%}
+{{ kubelet_options.append('--cluster-dns=' + dns_server)|default('', true) -}}
+{{ kubelet_options.append('--cluster-domain=' + dns_domain)|default('', true) -}}
+{% endif -%}
+{% if networking == "opencontrail" -%}
+{{ kubelet_options.append('--network-plugin=opencontrail')|default('', true) -}}
+{% endif -%}
+
+KUBELET_ARGS="--kubeconfig={{ kube_config_dir }}/kubelet.kubeconfig --config={{ kube_manifest_dir }} {{ kubelet_options|join(' ') }}"

--- a/ansible/roles/opencontrail-provision/files/namespace.yml
+++ b/ansible/roles/opencontrail-provision/files/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opencontrail

--- a/ansible/roles/opencontrail-provision/tasks/main.yml
+++ b/ansible/roles/opencontrail-provision/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Pull config image
+  command: docker pull opencontrail/config:2.20
+  delegate_to: "{{ groups['masters'][0] }}"
+
+- name: controller provisioning
+  include: master.yml
+  when: inventory_hostname == groups['masters'][0]
+
+- name: node provisioning
+  include: nodes.yml
+  when: inventory_hostname in groups['nodes'] or inventory_hostname in groups['gateways']

--- a/ansible/roles/opencontrail-provision/tasks/master.yml
+++ b/ansible/roles/opencontrail-provision/tasks/master.yml
@@ -1,0 +1,29 @@
+---
+- name: Create temporary directory
+  command: mktemp -d
+  register: mktemp_result
+
+- name: Temporary directory var
+  set_fact:
+    host_tmp_dir: "{{ mktemp_result.stdout }}"
+
+- name: Namespace file
+  copy: src=namespace.yml dest={{ host_tmp_dir }}
+
+- name: Namespace status
+  command: kubectl get namespace opencontrail
+  ignore_errors: yes
+  register: namespace
+
+- name: Create namespace
+  command: kubectl create -f "{{ host_tmp_dir }}/namespace.yml"
+  when: namespace.rc != 0
+
+- name: Cleanup
+  file: path="{{ host_tmp_dir }}" state=absent
+
+- name: Metadata services
+  command: docker run opencontrail/config:2.20 /usr/share/contrail-utils/provision_linklocal.py --api_server_ip "{{ inventory_hostname }}" --api_server_port 8082 --linklocal_service_name kubernetes-ssl --linklocal_service_ip {{ kube_service_addresses | ipaddr('net') | ipaddr(1) | ipaddr('address')}} --linklocal_service_port 443 --ipfabric_service_ip "{{ hostvars[inventory_hostname]['ansible_' + opencontrail_interface]['ipv4']['address'] }}" --ipfabric_service_port 443 --oper add
+
+- name: Provision controller
+  command: docker run opencontrail/config:2.20 /usr/share/contrail-utils/provision_control.py --api_server_ip "{{ inventory_hostname }}" --api_server_port 8082 --host_name "{{ inventory_hostname }}" --host_ip "{{ hostvars[inventory_hostname]['ansible_' + opencontrail_interface]['ipv4']['address'] }}" --router_asn 64512 --oper add

--- a/ansible/roles/opencontrail-provision/tasks/nodes.yml
+++ b/ansible/roles/opencontrail-provision/tasks/nodes.yml
@@ -1,0 +1,4 @@
+---
+- name: Create virtual-router object
+  command: docker run opencontrail/config:2.20 /usr/share/contrail-utils/provision_vrouter.py --api_server_ip {{ groups['masters'][0] }} --host_name "{{ inventory_hostname }}{% if hostvars[inventory_hostname]['ansible_domain'] != "" %}.{{ hostvars[inventory_hostname]['ansible_domain'] }}{% endif %}" --host_ip "{{ hostvars[inventory_hostname]['ipaddr'] }}"
+  delegate_to: "{{ groups['masters'][0] }}"

--- a/ansible/roles/opencontrail/files/cassandra.manifest
+++ b/ansible/roles/opencontrail/files/cassandra.manifest
@@ -1,0 +1,40 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "opencontrail",
+        "name": "cassandra"
+    },
+    "spec":{
+	"containers":[{
+	    "name": "opencontrail-config-db",
+	    "image": "cassandra:2.2.0",
+	    "command": [
+		"/bin/sh",
+		"-c",
+		"sed -ri 's/^(start_rpc:) .*/\\1 true/' /etc/cassandra/cassandra.yaml && /docker-entrypoint.sh cassandra -f"
+	    ],
+	    "ports": [{
+		"name": "cassandra",
+		"containerPort": 9160,
+		"hostPort": 9160
+	    }],
+	    "env": [{
+		"name": "CASSANDRA_CLUSTER_NAME",
+		"value": "OpenContrail-config"
+	    }],
+	    "volumeMounts": [{
+		"name": "data",
+		"mountPath": "/var/lib/cassandra",
+		"readOnly": false
+	    }]
+	}],
+	"volumes": [
+	    {
+		"name": "data",
+		"hostPath": {"path": "/var/lib/cassandra"}
+	    }
+	]
+    }
+
+}

--- a/ansible/roles/opencontrail/files/contrail-api.manifest
+++ b/ansible/roles/opencontrail/files/contrail-api.manifest
@@ -1,0 +1,41 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "opencontrail",
+        "name": "contrail-api"
+    },
+    "spec":{
+	"hostNetwork": true,
+	"containers":[{
+	    "name": "contrail-api",
+	    "image": "opencontrail/config:2.20",
+	    "command": ["/usr/bin/contrail-api"],
+	    "ports": [{
+		"name": "contrail-api",
+		"containerPort": 8082,
+		"hostPort": 8082
+	    }],
+	    "volumeMounts": [
+		{
+		    "name": "config",
+		    "mountPath": "/etc/contrail"
+		},
+		{
+		    "name": "logs",
+		    "mountPath": "/var/log/contrail",
+		    "readOnly": false
+		}]
+	}],
+	"volumes": [
+	    {
+		"name": "config",
+		"hostPath": {"path": "/etc/contrail"}
+	    },
+	    {
+		"name": "logs",
+		"hostPath": {"path": "/var/log/contrail"}
+	    }
+	]
+    }
+}

--- a/ansible/roles/opencontrail/files/contrail-control.manifest
+++ b/ansible/roles/opencontrail/files/contrail-control.manifest
@@ -1,0 +1,51 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "opencontrail",
+        "name": "contrail-control"
+    },
+    "spec":{
+	"hostNetwork": true,
+	"containers":[{
+	    "name": "contrail-control",
+	    "image": "opencontrail/control:2.20",
+	    "command": ["/usr/bin/contrail-control"],
+	    "securityContext": {
+	    	"capabilities": {
+		    "add": ["NET_BIND_SERVICE"]
+		}
+	    },
+	    "ports": [{
+		"name": "bgp",
+		"containerPort": 179,
+		"hostPort": 179
+	    }, {
+		"name": "xmpp",
+		"containerPort": 5269,
+		"hostPort": 5269
+	    }, {
+		"name": "control-ui",
+		"containerPort": 8083,
+		"hostPort": 8083
+	    }],
+	    "volumeMounts": [
+		{
+		    "name": "config",
+		    "mountPath": "/etc/contrail"
+		},
+		{
+		    "name": "logs",
+		    "mountPath": "/var/log/contrail",
+		    "readOnly": false
+		}]
+	}],
+	"volumes": [{
+	    "name": "config",
+	    "hostPath": {"path": "/etc/contrail"}
+	},{
+	    "name": "logs",
+	    "hostPath": {"path": "/var/log/contrail"}
+	}]
+    }
+}

--- a/ansible/roles/opencontrail/files/contrail-schema.manifest
+++ b/ansible/roles/opencontrail/files/contrail-schema.manifest
@@ -1,0 +1,39 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "opencontrail",
+        "name": "contrail-schema"
+    },
+    "spec":{
+	"hostNetwork": true,
+	"containers":[{
+	    "name": "contrail-schema",
+	    "image": "opencontrail/config:2.20",
+	    "command": ["/usr/bin/contrail-schema"],
+	    "ports": [{
+	    "name": "schema-ui",
+		"containerPort": 8087,
+		"hostPort": 8087
+	    }],
+	    "volumeMounts": [{
+		"name": "config",
+		"mountPath": "/etc/contrail"
+	    }, {
+		"name": "logs",
+		"mountPath": "/var/log/contrail",
+		"readOnly": false
+	    }]
+	}],
+	"volumes": [
+	    {
+		"name": "config",
+		"hostPath": {"path": "/etc/contrail"}
+	    },
+	    {
+		"name": "logs",
+		"hostPath": {"path": "/var/log/contrail"}
+	    }
+	]
+    }
+}

--- a/ansible/roles/opencontrail/files/contrail-vrouter-agent.manifest
+++ b/ansible/roles/opencontrail/files/contrail-vrouter-agent.manifest
@@ -1,0 +1,51 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "opencontrail",
+        "name":"contrail-vrouter-agent"
+    },
+    "spec":{
+	"hostNetwork": true,
+	"containers":[{
+	    "name": "contrail-vrouter-agent",
+	    "image": "opencontrail/vrouter-agent:2.20",
+	    "command": ["/usr/bin/contrail-vrouter-agent"],
+	    "securityContext": {
+	        "privileged": true
+	    },
+	    "ports": [{
+		"name": "vrouter-api",
+		"containerPort": 9090,
+		"hostPort": 9090
+	    }, {
+		"name": "ipc",
+		"containerPort": 9091,
+		"hostPort":9091 
+	    }, {
+		"name": "control-ui",
+		"containerPort": 8085,
+		"hostPort": 8085
+	    }],
+	    "volumeMounts": [
+		{
+		    "name": "config",
+		    "mountPath": "/etc/contrail"
+		},
+		{
+		    "name": "logs",
+		    "mountPath": "/var/log/contrail",
+		    "readOnly": false
+		}
+              ]
+	}],
+	"volumes": [{
+	    "name": "config",
+	    "hostPath": {"path": "/etc/contrail"}
+	},{
+	    "name": "logs",
+	    "hostPath": {"path": "/var/log/contrail"}
+	}
+       ]
+    }
+}

--- a/ansible/roles/opencontrail/files/contrail-vrouter-agent.service
+++ b/ansible/roles/opencontrail/files/contrail-vrouter-agent.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=OpenContrail VRouter agent
+
+[Service]
+ExecStart=/usr/bin/docker run --privileged=true --net=host -v /etc/contrail:/etc/contrail -v /var/log/contrail:/var/log/contrail opencontrail/vrouter-agent:2.20 /usr/bin/contrail-vrouter-agent
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/opencontrail/files/contrail-vrouter-agent.upstart
+++ b/ansible/roles/opencontrail/files/contrail-vrouter-agent.upstart
@@ -1,0 +1,10 @@
+description "OpenContrail VRouter agent"
+
+start on started docker.io
+stop on runlevel [!2345]
+
+respawn
+
+script
+        /usr/bin/docker run --privileged=true --net=host -v /etc/contrail:/etc/contrail -v /var/log/contrail:/var/log/contrail opencontrail/vrouter-agent:2.20 /usr/bin/contrail-vrouter-agent
+end script

--- a/ansible/roles/opencontrail/files/ifdown-vhost
+++ b/ansible/roles/opencontrail/files/ifdown-vhost
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+. /etc/init.d/functions
+
+cd /etc/sysconfig/network-scripts
+. ./network-functions
+
+[ -f ../network ] && . ../network
+
+CONFIG=${1}
+
+need_config "${CONFIG}"
+
+source_config
+
+exec /etc/sysconfig/network-scripts/ifdown-post ${CONFIG} ${2}

--- a/ansible/roles/opencontrail/files/ifmap-server.manifest
+++ b/ansible/roles/opencontrail/files/ifmap-server.manifest
@@ -1,0 +1,33 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "opencontrail",
+        "name": "ifmap-server"
+    },
+    "spec":{
+	"hostNetwork": true,
+	"containers":[{
+	    "name": "ifmap-server",
+	    "image": "opencontrail/ifmap-server:2.20",
+	    "ports": [{
+		"name": "ifmap",
+		"containerPort": 8443,
+		"hostPort": 8443
+	    }],
+	    "volumeMounts": [
+		{
+		    "name": "logs",
+		    "mountPath": "/var/log/contrail",
+		    "readOnly": false
+		}]
+	}],
+	"volumes": [
+	    {
+		"name": "logs",
+		"hostPath": {"path": "/var/log/ifmap-server"}
+	    }
+	]
+    }
+
+}

--- a/ansible/roles/opencontrail/files/ifup-vhost
+++ b/ansible/roles/opencontrail/files/ifup-vhost
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+. /etc/init.d/functions
+
+cd /etc/sysconfig/network-scripts
+. ./network-functions
+
+[ -f ../network ] && . ../network
+
+CONFIG=${1}
+
+need_config "${CONFIG}"
+
+source_config
+
+if ! /sbin/modprobe vrouter >/dev/null 2>&1; then
+   net_log $"OpenContrail vrouter kernel module not available"
+   exit 1
+fi
+
+if [ -n "${MACADDR}" ]; then
+    hwaddr=${MACADDR}
+else
+    if [ -n "${PHYSDEV}" ]; then
+	hwaddr=$(cat /sys/class/net/${PHYSDEV}/address)
+    fi
+fi
+
+if [ ! -d /sys/class/net/${DEVICE} ]; then
+    ip link add ${DEVICE} type vhost
+
+    if [ -n "${hwaddr}" ]; then
+	ip link set ${DEVICE} address ${hwaddr}
+    fi
+
+    if [ -n "${PHYSDEV}" ]; then
+	vif --add ${PHYSDEV} --mac ${hwaddr} --vrf 0 --vhost-phys --type physical >/dev/null 2>&1
+	vif --add ${DEVICE} --mac ${hwaddr} --vrf 0 --type vhost --xconnect ${PHYSDEV} >/dev/null 2>&1
+    fi
+fi
+
+if [ -n "${IPADDR}" ]; then
+    ip addr add dev ${DEVICE} ${IPADDR}
+fi
+
+ip link set ${DEVICE} up
+
+exec /etc/sysconfig/network-scripts/ifup-post ${CONFIG} ${2}
+

--- a/ansible/roles/opencontrail/files/kube-network-manager.manifest
+++ b/ansible/roles/opencontrail/files/kube-network-manager.manifest
@@ -1,0 +1,23 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "opencontrail",
+        "name": "kube-network-manager"
+    },
+    "spec":{
+	"hostNetwork": true,
+	"containers":[{
+	    "name": "kube-network-manager",
+	    "image": "opencontrail/kube-network-manager",
+	    "volumeMounts": [{
+		    "name": "config",
+		    "mountPath": "/etc/kubernetes"
+	    }]
+	}],
+	"volumes": [{
+	    "name": "config",
+	    "hostPath": {"path": "/etc/kubernetes"}
+	}]
+    } 
+}

--- a/ansible/roles/opencontrail/files/rabbitmq.manifest
+++ b/ansible/roles/opencontrail/files/rabbitmq.manifest
@@ -1,0 +1,35 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "opencontrail",
+        "name": "rabbitmq"
+    },
+    "spec":{
+	"hostNetwork": true,
+	"containers":[{
+	    "name": "rabbitmq",
+	    "image": "rabbitmq:3.5.4",
+	    "ports": [{
+		"name": "rabbitmq",
+		"containerPort": 5672,
+		"hostPort": 5672
+	    }],
+	    "env": [{
+		"name": "RABBITMQ_NODENAME",
+		"value": "localhost"
+	    }],
+	    "volumeMounts": [{
+		"name": "logs",
+		"mountPath": "/var/log/rabbitmq"
+	    }]
+	}],
+	"volumes": [
+	    {
+		"name": "logs",
+		"hostPath": {"path": "/var/log/rabbitmq"}
+	    }
+	]
+    }
+
+}

--- a/ansible/roles/opencontrail/files/vrouter.conf
+++ b/ansible/roles/opencontrail/files/vrouter.conf
@@ -1,0 +1,1 @@
+options vrouter vr_flow_entries=65536 vr_bridge_entries=1024

--- a/ansible/roles/opencontrail/files/zookeeper.manifest
+++ b/ansible/roles/opencontrail/files/zookeeper.manifest
@@ -1,0 +1,44 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "namespace": "opencontrail",
+        "name": "zookeeper"
+    },
+    "spec":{
+	"hostNetwork": true,
+	"containers":[{
+	    "name": "zookeeper",
+	    "image": "mesoscloud/zookeeper:3.4.6",
+	    "ports": [{
+		"name": "zookeeper",
+		"containerPort": 2181,
+		"hostPort": 2181
+	    }],
+	    "env": [{
+		"name": "MYID",
+		"value": "1"
+	    }, {
+		"name": "SERVERS",
+		"value": "localhost"
+	    }],
+	    "volumeMounts": [{
+		"name": "logs",
+		"mountPath": "/var/log/zookeeper",
+		"readOnly": false
+	    }, {
+		"name": "data",
+		"mountPath": "/var/lib/zookeeper",
+		"readOnly": false
+	    }]
+	}],
+	"volumes": [{
+		"name": "logs",
+		"hostPath": {"path": "/var/log/zookeeper"}
+	}, {
+		"name": "data",
+		"hostPath": {"path": "/var/lib/zookeeper"}
+	}]
+    }
+
+}

--- a/ansible/roles/opencontrail/handlers/main.yml
+++ b/ansible/roles/opencontrail/handlers/main.yml
@@ -1,0 +1,40 @@
+---
+# The kubernetes role invokes restart daemons. It must be defined here
+# since the opencontrail playbook depends on that role to setup basic
+# variables such as the kubernetes configuration file directory.
+- name: restart daemons
+  command: /bin/true
+
+- name: Bounce physical interface
+  shell: "ifdown {{ opencontrail_interface }} && ifup {{ opencontrail_interface }}"
+  ignore_errors: True
+
+- name: Bounce vhost0 interface
+  shell: "ifdown vhost0 && ifup vhost0"
+  ignore_errors: True
+
+- name: reload systemd
+  command: systemctl --system daemon-reload
+
+- name: restart contrail-vrouter-agent
+  service: name=contrail-vrouter-agent state=restarted
+
+- name: restart contrail-control
+  shell: docker ps | awk '/opencontrail\/control/ {print $1;}'
+  register: control_node_id
+  notify:
+    - kill contrail-control
+
+- name: kill contrail-control
+  command: docker kill {{ control_node_id.stdout }}
+  when: control_node_id.rc == 0 and control_node_id.stdout != ""
+
+- name: restart kube-network-manager
+  shell: docker ps | awk '/opencontrail\/kube-network-manager/ {print $1;}'
+  register: network_manager_id
+  notify:
+    - kill kube-network-manager
+
+- name: kill kube-network-manager
+  command: docker kill {{ network_manager_id.stdout }}
+  when: network_manager_id.rc == 0 and network_manager_id.stdout != ""

--- a/ansible/roles/opencontrail/meta/main.yml
+++ b/ansible/roles/opencontrail/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - { role: common }
+  - { role: docker }
+  - { role: kubernetes }

--- a/ansible/roles/opencontrail/tasks/gateway-redhat.yml
+++ b/ansible/roles/opencontrail/tasks/gateway-redhat.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Interface configuration file
+  template: src=ifcfg-gateway.j2 dest=/etc/sysconfig/network-scripts/ifcfg-{{ item }}
+  with_items:
+    - gateway0
+    - gateway1
+
+- name: Static routes
+  template: src=route-{{ item }}.j2 dest=/etc/sysconfig/network-scripts/route-{{ item }}
+  with_items:
+    - gateway0
+    - gateway1
+
+- name: Activate gateway0
+  command: ifup gateway0
+
+- name: Activate gateway1
+  command: ifup gateway1

--- a/ansible/roles/opencontrail/tasks/gateway-ubuntu.yml
+++ b/ansible/roles/opencontrail/tasks/gateway-ubuntu.yml
@@ -1,0 +1,23 @@
+---
+- name: Interface configuration file
+  template: src=gateway.cfg.j2 dest=/etc/network/interfaces.d/{{ item }}.cfg
+  with_items:
+    - gateway0
+    - gateway1
+
+- name: Activate gateway0
+  command: ifup gateway0
+
+- name: Activate gateway1
+  command: ifup gateway1
+
+- name: Install upstart configuration file
+  copy:
+    src: contrail-vrouter-agent.upstart
+    dest: /etc/init/contrail-vrouter-agent.conf
+
+- name: Create bridge sysvinit via upstart-job
+  file:
+    src: /lib/init/upstart-job
+    dest: /etc/init.d/contrail-vrouter-agent
+    state: link

--- a/ansible/roles/opencontrail/tasks/gateways.yml
+++ b/ansible/roles/opencontrail/tasks/gateways.yml
@@ -1,0 +1,29 @@
+---
+- name: VRouter log directory
+  file: path="/var/log/contrail" state=directory
+
+- name: VRouter agent configuration
+  template: src=contrail-vrouter-agent.conf.gateway.j2 dest=/etc/contrail/contrail-vrouter-agent.conf
+  notify:
+    - restart contrail-vrouter-agent
+
+- name: Redhat-sytle interface configuration
+  include: gateway-redhat.yml
+  when: ansible_distribution == "Fedora"
+
+- name: Ubuntu interface configuration
+  include: gateway-ubuntu.yml
+  when: ansible_distribution == "Ubuntu"
+
+- name: Create vrouter agent service
+  copy: src=contrail-vrouter-agent.service dest=/etc/systemd/system
+  notify:
+    - reload systemd
+  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15)
+
+- name: Docker pull image
+  command: docker pull opencontrail/vrouter-agent:2.20
+
+- name: Start vrouter agent
+  service: name=contrail-vrouter-agent enabled=yes state=started
+

--- a/ansible/roles/opencontrail/tasks/kmod-artifacts.yml
+++ b/ansible/roles/opencontrail/tasks/kmod-artifacts.yml
@@ -1,0 +1,48 @@
+---
+- name: Set variables
+  set_fact:
+    build_dir: "/tmp/.ansible/build/{{ kmod_build_tag }}"
+    install_dir: "/tmp/.ansible/install/{{ kmod_build_tag }}"
+    artifact_tar: "/tmp/.ansible/opencontrail-vrouter-{{ kmod_build_tag }}.tgz"
+
+- name: Create install tree
+  file:
+    path: "{{ install_dir }}/usr/bin"
+    state: directory
+
+- name: Create install tree (kmod)
+  file:
+    path: "{{ install_dir }}/lib/modules/{{ ansible_kernel }}/kernel/drivers/net"
+    state: directory
+
+- name: Install utilities
+  command: install -m 755 "production/vrouter/utils/{{ item }}" "{{ install_dir }}/usr/bin"
+  args:
+    chdir: "{{ build_dir }}"
+    creates: "{{ install_dir }}/usr/bin/{{ item }}"
+  with_items:
+    - dropstats
+    - flow
+    - mirror
+    - mpls
+    - nh
+    - rt
+    - vif
+    - vrfstats
+    - vrouter
+    - vxlan
+
+- name: Install kmod
+  command: install kbuild/vrouter.ko "{{ install_dir }}/lib/modules/{{ ansible_kernel }}/kernel/drivers/net"
+  args:
+    chdir: "{{ build_dir }}"
+    creates: "{{ install_dir }}/lib/modules/{{ ansible_kernel }}/kernel/drivers/net/vrouter.ko"
+
+- name: Create tarball
+  command: tar zcf "{{ artifact_tar }}" .
+  args:
+    chdir: "{{ install_dir }}"
+    creates: "{{ artifact_tar }}"
+
+- name: Fetch tarball
+  fetch: src="{{ artifact_tar }}" dest="/tmp/.ansible/artifacts/" flat=yes

--- a/ansible/roles/opencontrail/tasks/kmod-build-fedora.yml
+++ b/ansible/roles/opencontrail/tasks/kmod-build-fedora.yml
@@ -1,0 +1,16 @@
+---
+- name: kmod Dockerfile
+  template:
+    src: Dockerfile.redhat.j2
+    dest: /tmp/.ansible/build/{{ kmod_build_tag }}/Dockerfile
+
+- name: Build docker container
+  command: docker build -t opencontrail/kmod_{{ kmod_build_tag }} {{ kmod_build_tag }}
+  args:
+    chdir: /tmp/.ansible/build
+
+- name: Build kernel module
+  command: docker run -v /tmp/.ansible/build/{{ kmod_build_tag }}:/src/vrouter/build{{ ':Z' if ansible_selinux is defined and ansible_selinux.status == 'enabled' else '' }} opencontrail/kmod_{{ kmod_build_tag }} /bin/bash -c "USER=nobody scons --optimization=production --kernel-dir=/usr/src/kernels/{{ ansible_kernel }} vrouter && cp vrouter/vrouter.ko build/kbuild"
+  args:
+      creates: /tmp/.ansible/build/{{ kmod_build_tag }}/kbuild/vrouter.ko
+

--- a/ansible/roles/opencontrail/tasks/kmod-build-ubuntu.yml
+++ b/ansible/roles/opencontrail/tasks/kmod-build-ubuntu.yml
@@ -1,0 +1,16 @@
+---
+- name: kmod Dockerfile
+  template:
+    src: Dockerfile.debian.j2
+    dest: /tmp/.ansible/build/{{ kmod_build_tag }}/Dockerfile
+
+- name: Build docker container
+  command: docker build -t opencontrail/kmod_{{ kmod_build_tag }} {{ kmod_build_tag }}
+  args:
+    chdir: /tmp/.ansible/build
+
+- name: Build kernel module
+  command: docker run -v /tmp/.ansible/build/{{ kmod_build_tag }}:/src/vrouter/build opencontrail/kmod_{{ kmod_build_tag }} /bin/bash -c "USER=nobody scons --optimization=production --kernel-dir=/lib/modules/{{ ansible_kernel }}/build vrouter && cp vrouter/vrouter.ko build/kbuild"
+  args:
+      creates: /tmp/.ansible/build/{{ kmod_build_tag }}/kbuild/vrouter.ko
+

--- a/ansible/roles/opencontrail/tasks/kmod.yml
+++ b/ansible/roles/opencontrail/tasks/kmod.yml
@@ -1,0 +1,15 @@
+---
+- name: build tag
+  set_fact:
+     kmod_build_tag: "{{ ansible_distribution | lower}}{{ansible_distribution_version}}-{{ansible_kernel}}"
+
+- name: Create directory
+  file: path=/tmp/.ansible/build/{{ kmod_build_tag }} state=directory
+
+- include: kmod-build-fedora.yml
+  when: ansible_distribution == "Fedora"
+
+- include: kmod-build-ubuntu.yml
+  when: ansible_distribution == "Ubuntu"
+
+- include: kmod-artifacts.yml

--- a/ansible/roles/opencontrail/tasks/main.yml
+++ b/ansible/roles/opencontrail/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Build kernel module
+  include: kmod.yml
+  when: inventory_hostname == groups['masters'][0]
+
+- name: Install vrouter
+  include: vrouter.yml
+  when: inventory_hostname in groups['nodes'] or inventory_hostname in groups['gateways']
+
+- name: Install compute nodes
+  include: nodes.yml
+  when: inventory_hostname in groups['nodes']
+
+- name: Install gateways
+  include: gateways.yml
+  when: inventory_hostname in groups['gateways']
+
+- name: Install master
+  include: masters.yml
+  when: inventory_hostname in groups['masters']

--- a/ansible/roles/opencontrail/tasks/masters-config.yml
+++ b/ansible/roles/opencontrail/tasks/masters-config.yml
@@ -1,0 +1,13 @@
+---
+- name: Install templates
+  copy: src="{{item}}" dest="{{ kube_manifest_dir }}"
+  with_items:
+    - contrail-api.manifest
+    - contrail-schema.manifest
+    - ifmap-server.manifest
+    - kube-network-manager.manifest
+
+- name: Network manager configuration
+  template: src=kube-network.conf.j2 dest={{ kube_config_dir }}/network.conf
+  notify:
+    - restart kube-network-manager

--- a/ansible/roles/opencontrail/tasks/masters-control.yml
+++ b/ansible/roles/opencontrail/tasks/masters-control.yml
@@ -1,0 +1,13 @@
+---
+- name: Ensure configuration directory exists
+  file: path="/etc/contrail" state=directory
+
+- name: Configure control-node
+  template: src=contrail-control.conf.j2 dest=/etc/contrail/contrail-control.conf
+  notify:
+    - restart contrail-control
+
+- name: Install control-node manifest
+  copy: src=contrail-control.manifest dest="{{ kube_manifest_dir }}"
+
+

--- a/ansible/roles/opencontrail/tasks/masters-services.yml
+++ b/ansible/roles/opencontrail/tasks/masters-services.yml
@@ -1,0 +1,9 @@
+---
+- name: Install templates
+  copy: src="{{item}}" dest="{{ kube_manifest_dir }}"
+  with_items:
+    - cassandra.manifest
+    - rabbitmq.manifest
+    - zookeeper.manifest
+
+    

--- a/ansible/roles/opencontrail/tasks/masters.yml
+++ b/ansible/roles/opencontrail/tasks/masters.yml
@@ -1,0 +1,13 @@
+---
+- name: Set selinux permissive to enable directory mounts
+  selinux: state=permissive policy={{ ansible_selinux.type }}
+  when: ansible_selinux is defined and ansible_selinux.status == "enabled"
+
+- name: Assures manifests dir exists
+  file: path={{ kube_manifest_dir }} state=directory
+
+- include: masters-services.yml
+
+- include: masters-config.yml
+
+- include: masters-control.yml

--- a/ansible/roles/opencontrail/tasks/nodes-redhat.yml
+++ b/ansible/roles/opencontrail/tasks/nodes-redhat.yml
@@ -1,0 +1,5 @@
+---
+- name: Static routes
+  template: src=node-route-redhat.j2 dest=/etc/sysconfig/network-scripts/route-vhost0
+  notify:
+    - Bounce vhost0 interface

--- a/ansible/roles/opencontrail/tasks/nodes.yml
+++ b/ansible/roles/opencontrail/tasks/nodes.yml
@@ -1,0 +1,64 @@
+---
+
+# note: ansible localhost requires python-netaddr to be installed
+
+- name: Redhat-style interface configuration
+  include: nodes-redhat.yml
+  when: ansible_distribution == "Fedora"
+
+- name: Agent configuration
+  template: src=contrail-vrouter-agent.conf.node.j2 dest=/etc/contrail/contrail-vrouter-agent.conf
+
+- name: Make sure manifest directory exists
+  file: path={{ kube_manifest_dir }} state=directory
+
+- name: Ensure log directory exists
+  file: path=/var/log/contrail state=directory
+
+- name: Execute agent
+  copy: src=contrail-vrouter-agent.manifest dest={{ kube_manifest_dir }}
+
+- name: Ensure python pip is installed
+  action: "{{ ansible_pkg_mgr }}"
+  args:
+    name: python-pip
+    state: latest
+
+- name: bridge-utils
+  action: "{{ ansible_pkg_mgr }}"
+  args:
+    name: bridge-utils
+    state: latest
+
+- name: ethtool
+  action: "{{ ansible_pkg_mgr }}"
+  args:
+    name: ethtool
+    state: latest
+
+- name: Install plugin
+  pip: name=opencontrail-kubelet
+
+- name: Create plugin directory
+  file:
+    path: /usr/libexec/kubernetes/kubelet-plugins/net/exec/opencontrail
+    state: directory
+
+- name: Default plugin path
+  set_fact:
+    opencontrail_plugin_path: "/usr/bin/opencontrail-kubelet-plugin"
+
+- name: Check for plugin in /usr/local/bin
+  stat: path="/usr/local/bin/opencontrail-kubelet-plugin"
+  register: usr_local_stat
+
+- name: Override plugin path
+  set_fact:
+    opencontrail_plugin_path: "/usr/local/bin/opencontrail-kubelet-plugin"
+  when: usr_local_stat.stat.exists
+
+- name: Create symlink for plugin
+  file:
+     src: "{{ opencontrail_plugin_path }}"
+     dest: /usr/libexec/kubernetes/kubelet-plugins/net/exec/opencontrail/opencontrail
+     state: link

--- a/ansible/roles/opencontrail/tasks/vrouter-redhat.yml
+++ b/ansible/roles/opencontrail/tasks/vrouter-redhat.yml
@@ -1,0 +1,20 @@
+---
+- name: Interface up/down scripts
+  copy: src={{ item }} dest=/etc/sysconfig/network-scripts mode=755
+  with_items:
+    - ifup-vhost
+    - ifdown-vhost
+
+- name: Interface configuration file (physical)
+  template: src=ifcfg-eth.j2 dest=/etc/sysconfig/network-scripts/ifcfg-{{ opencontrail_interface }}
+  notify:
+    - Bounce physical interface
+
+- name: Interface configuration file (vhost0)
+  template: src=ifcfg-vhost0.j2 dest=/etc/sysconfig/network-scripts/ifcfg-vhost0
+  notify:
+    - Bounce vhost0 interface
+
+- name: Enable vhost0 interface
+  command: ifup vhost0
+

--- a/ansible/roles/opencontrail/tasks/vrouter-ubuntu.yml
+++ b/ansible/roles/opencontrail/tasks/vrouter-ubuntu.yml
@@ -1,0 +1,14 @@
+---
+- name: Interface configuration file (physical)
+  template: src=interface.cfg.j2 dest=/etc/network/interfaces.d/{{ opencontrail_interface }}.cfg
+  notify:
+    - Bounce physical interface
+
+- name: Interface configuration file (vhost0)
+  template: src=vhost0.cfg.j2 dest=/etc/network/interfaces.d/vhost0.cfg
+  notify:
+    - Bounce vhost0 interface
+
+- name: Enable vhost0 interface
+  command: ifup vhost0
+

--- a/ansible/roles/opencontrail/tasks/vrouter.yml
+++ b/ansible/roles/opencontrail/tasks/vrouter.yml
@@ -1,0 +1,28 @@
+---
+- name: build tag
+  set_fact:
+     kmod_build_tag: "{{ ansible_distribution | lower}}{{ansible_distribution_version}}-{{ansible_kernel}}"
+
+- name: Unpack vrouter tarball
+  unarchive:
+    src: "/tmp/.ansible/artifacts/opencontrail-vrouter-{{ kmod_build_tag }}.tgz"
+    dest: /
+
+- name: Depmod
+  command: depmod
+
+# Reduce the vrouter table sizes in order to be able to execute on a 2G VM.
+- name: Reduce memory utilization of vrouter
+  copy: src=vrouter.conf dest=/etc/modprobe.d
+  when: ansible_memtotal_mb|int < 4096
+
+- name: Redhat-style interface configuration
+  include: vrouter-redhat.yml
+  when: ansible_distribution == "Fedora"
+
+- name: Ubuntu interface configuration
+  include: vrouter-ubuntu.yml
+  when: ansible_distribution == "Ubuntu"
+
+- name: Ensure configuration directory exists
+  file: path=/etc/contrail state=directory

--- a/ansible/roles/opencontrail/templates/Dockerfile.debian.j2
+++ b/ansible/roles/opencontrail/templates/Dockerfile.debian.j2
@@ -1,0 +1,12 @@
+FROM {{ ansible_distribution | lower }}:{{ ansible_distribution_version }}
+RUN apt-get update
+RUN {{ ansible_pkg_mgr }} install -y git make
+RUN {{ ansible_pkg_mgr }} install -y automake flex bison gcc g++ scons linux-headers-{{ ansible_kernel }} libboost-dev libxml2-dev
+RUN mkdir -p src/vrouter
+WORKDIR src/vrouter
+RUN git clone -b R2.20 https://github.com/Juniper/contrail-vrouter vrouter
+RUN mkdir tools
+RUN (cd tools && git clone https://github.com/Juniper/contrail-build build)
+RUN (cd tools && git clone -b R2.20 https://github.com/Juniper/contrail-sandesh sandesh)
+RUN cp tools/build/SConstruct .
+

--- a/ansible/roles/opencontrail/templates/Dockerfile.redhat.j2
+++ b/ansible/roles/opencontrail/templates/Dockerfile.redhat.j2
@@ -1,0 +1,11 @@
+FROM {{ ansible_distribution | lower }}:{{ ansible_distribution_major_version }}
+RUN {{ ansible_pkg_mgr }} install -y git make
+RUN {{ ansible_pkg_mgr }} install -y automake flex bison gcc gcc-c++ boost boost-devel scons kernel-devel-{{ ansible_kernel }} libxml2-devel python-lxml
+RUN mkdir -p src/vrouter
+WORKDIR src/vrouter
+RUN git clone -b R2.20 https://github.com/Juniper/contrail-vrouter vrouter
+RUN mkdir tools
+RUN (cd tools && git clone https://github.com/Juniper/contrail-build build)
+RUN (cd tools && git clone -b R2.20 https://github.com/Juniper/contrail-sandesh sandesh)
+RUN cp tools/build/SConstruct .
+

--- a/ansible/roles/opencontrail/templates/contrail-control.conf.j2
+++ b/ansible/roles/opencontrail/templates/contrail-control.conf.j2
@@ -1,0 +1,8 @@
+[DEFAULT]
+hostip={{ hostvars[inventory_hostname]['ansible_' + opencontrail_interface]['ipv4']['address'] }}
+hostname={{ ansible_hostname }}
+
+[IFMAP]
+server_url=https://localhost:8443
+user=control-node
+password=control-node

--- a/ansible/roles/opencontrail/templates/contrail-vrouter-agent.conf.gateway.j2
+++ b/ansible/roles/opencontrail/templates/contrail-vrouter-agent.conf.gateway.j2
@@ -1,0 +1,22 @@
+[CONTROL-NODE]
+server={%for host in groups['masters']%}{{ hostvars[host]['ansible_' + opencontrail_interface]['ipv4']['address'] }} {% endfor %}
+
+
+[VIRTUAL-HOST-INTERFACE]
+name=vhost0
+ip={{ hostvars[inventory_hostname]['ipaddr'] }}
+{% if opencontrail_gateway  %}
+gateway={{ opencontrail_gateway }}
+{% endif %}
+physical_interface={{ opencontrail_interface }}
+
+[GATEWAY-0]
+routing_instance=default-domain:default-project:Public:Public
+interface=gateway0
+ip_blocks={{ opencontrail_public_subnet }}
+
+[GATEWAY-1]
+routing_instance=default-domain:kube-system:service-default:service-default
+interface=gateway1
+ip_blocks={{ kube_service_addresses }}
+routes={{ opencontrail_private_subnet }}

--- a/ansible/roles/opencontrail/templates/contrail-vrouter-agent.conf.node.j2
+++ b/ansible/roles/opencontrail/templates/contrail-vrouter-agent.conf.node.j2
@@ -1,0 +1,14 @@
+[CONTROL-NODE]
+server={%for host in groups['masters']%}{{ hostvars[host]['ansible_' + opencontrail_interface]['ipv4']['address'] }} {% endfor %}
+
+
+[VIRTUAL-HOST-INTERFACE]
+name=vhost0
+
+ip={{ hostvars[inventory_hostname]['ipaddr'] }}
+
+{% if opencontrail_gateway  %}
+gateway={{ opencontrail_gateway }}
+{% endif %}
+
+physical_interface={{ opencontrail_interface }}

--- a/ansible/roles/opencontrail/templates/gateway.cfg.j2
+++ b/ansible/roles/opencontrail/templates/gateway.cfg.j2
@@ -1,0 +1,15 @@
+auto {{ item }}
+iface {{ item }} inet static
+    pre-up modprobe vrouter
+    pre-up ip link add name {{ item }} type vhost
+    pre-up ip link set {{ item }} address 00:00:5e:00:01:00
+{% if item == "gateway0" and opencontrail_public_subnet is defined %}
+    up ip route add {{ opencontrail_public_subnet }} dev gateway0
+{% endif %}
+{% if item == "gateway1" %}
+    up ip route add {{ kube_service_addresses }} dev gateway1
+{% endif %}
+    address 0.0.0.0
+    post-down vif --list | awk '/^vif.*OS: {{ item }}/ {split($1, arr, "\/"); print arr[2];}' | xargs vif --delete
+    post-down ip link delete {{ item }}
+

--- a/ansible/roles/opencontrail/templates/ifcfg-eth.j2
+++ b/ansible/roles/opencontrail/templates/ifcfg-eth.j2
@@ -1,0 +1,4 @@
+DEVICE={{ opencontrail_interface }}
+BOOTPROTO=none
+ONBOOT=yes
+IPADDR=0.0.0.0

--- a/ansible/roles/opencontrail/templates/ifcfg-gateway.j2
+++ b/ansible/roles/opencontrail/templates/ifcfg-gateway.j2
@@ -1,0 +1,3 @@
+DEVICE={{ item }}
+TYPE=vhost
+MACADDR=00:00:5e:00:01:00

--- a/ansible/roles/opencontrail/templates/ifcfg-vhost0.j2
+++ b/ansible/roles/opencontrail/templates/ifcfg-vhost0.j2
@@ -1,0 +1,5 @@
+DEVICE=vhost0
+BOOTPROTO=none
+DEVICETYPE=vhost
+IPADDR={{ hostvars[inventory_hostname]['ipaddr'] }}
+PHYSDEV={{ opencontrail_interface }}

--- a/ansible/roles/opencontrail/templates/interface.cfg.j2
+++ b/ansible/roles/opencontrail/templates/interface.cfg.j2
@@ -1,0 +1,5 @@
+auto {{ opencontrail_interface }}
+iface {{ opencontrail_interface }} inet static
+    address 0.0.0.0
+    up ip link set $IFACE up
+    down ip link set $IFACE down

--- a/ansible/roles/opencontrail/templates/kube-network.conf.j2
+++ b/ansible/roles/opencontrail/templates/kube-network.conf.j2
@@ -1,0 +1,5 @@
+[DEFAULT]
+service-cluster-ip-range = {{ kube_service_addresses }}
+
+[opencontrail]
+public-ip-range = {{ opencontrail_public_subnet }}

--- a/ansible/roles/opencontrail/templates/kube-network.conf.j2
+++ b/ansible/roles/opencontrail/templates/kube-network.conf.j2
@@ -3,3 +3,4 @@ service-cluster-ip-range = {{ kube_service_addresses }}
 
 [opencontrail]
 public-ip-range = {{ opencontrail_public_subnet }}
+cluster-service = kube-system/default

--- a/ansible/roles/opencontrail/templates/node-route-redhat.j2
+++ b/ansible/roles/opencontrail/templates/node-route-redhat.j2
@@ -1,0 +1,1 @@
+{{ kube_service_addresses }} via {{ hostvars[groups['gateways'][0]]['ipaddr'] | ipaddr('address') }}

--- a/ansible/roles/opencontrail/templates/route-gateway0.j2
+++ b/ansible/roles/opencontrail/templates/route-gateway0.j2
@@ -1,0 +1,1 @@
+{{ opencontrail_public_subnet }} dev gateway0

--- a/ansible/roles/opencontrail/templates/route-gateway1.j2
+++ b/ansible/roles/opencontrail/templates/route-gateway1.j2
@@ -1,0 +1,1 @@
+{{ kube_service_addresses }} dev gateway1

--- a/ansible/roles/opencontrail/templates/vhost0.cfg.j2
+++ b/ansible/roles/opencontrail/templates/vhost0.cfg.j2
@@ -1,0 +1,15 @@
+auto vhost0
+iface vhost0 inet static
+    pre-up modprobe vrouter
+    pre-up ip link add name vhost0 type vhost
+    pre-up ip link set vhost0 address $(cat /sys/class/net/{{ opencontrail_interface }}/address)
+    pre-up vif --add {{ opencontrail_interface }} --mac $(cat /sys/class/net/{{ opencontrail_interface }}/address) --vrf 0 --vhost-phys --type physical
+    pre-up vif --add vhost0 --mac $(cat /sys/class/net/{{ opencontrail_interface }}/address) --vrf 0 --type vhost --xconnect {{ opencontrail_interface }}
+    address {{ hostvars[inventory_hostname]['ipaddr'] | ipaddr('address') }}
+    netmask {{ hostvars[inventory_hostname]['ipaddr'] | ipaddr('netmask') }}
+{% if inventory_hostname in groups['nodes'] %}
+    up ip route add {{ kube_service_addresses }} via {{ hostvars[groups['gateways'][0]]['ipaddr'] | ipaddr('address') }}
+{% endif %}
+    post-down vif --list | awk '/^vif.*OS: vhost0/ {split($1, arr, "\/"); print arr[2];}' | xargs vif --delete
+    post-down vif --list | awk '/^vif.*OS: {{ opencontrail_interface }}/ {split($1, arr, "\/"); print arr[2];}' | xargs vif --delete
+    post-down ip link delete vhost0


### PR DESCRIPTION
This pull request adds support to provision OpenContrail via ansible. The support has been tested with Fedora 22.

The user is expected to define the following variables in group_vars/all.yml:

```
networking: opencontrail

opencontrail_public_subnet: <External subnet for LoadBalancer services>
opencontrail_private_subnet: <Internal subnet with connectivity to the kubelets>
opencontrail_gateway: <optional | gateway address on private_subnet>
opencontrail_interface: eth1
```

The provisioning assumes that the system has two interfaces: a management interface (e.g. on board 1G interface) and 1 data interface (e.g. 2x10G bond0 interface).

To configure the software gateway that provides connectivity between the external network and the private virtual networks a new type of host "gateway" is defined. Example inventory file:

```
[masters]
roque-kube-master

[etcd]
roque-kube-master

[nodes]
roque-node3 ipaddr=192.168.1.3/24
roque-node4 ipaddr=192.168.1.4/24

[gateways]
roque-gateway ipaddr=192.168.1.254/24
```
## Details
- OpenContrail uses kubelet to execute its userspace components. This implies running kubelet on the master, similarly to the approach taken by salt provisioning scripts which use kubelet to run the kubernetes api-server, etc.
- The OpenContrail kernel module is compiled on-demand for the target.
- OpenContrail control plane components are distributed as containers (via docker hub).
