### PR TITLE
Blunderbuss: don't panic if less than 4 lines changed

### DIFF
--- a/mungegithub/pulls/blunderbuss.go
+++ b/mungegithub/pulls/blunderbuss.go
@@ -103,13 +103,13 @@ func (b *BlunderbussMunger) MungePullRequest(config *config.MungeConfig, pr *git
 		}
 		for _, file := range commit.Files {
 			fileWeight := int64(1)
-			if file.Changes != nil {
+			if file.Changes != nil && *file.Changes != 0 {
 				fileWeight = int64(*file.Changes)
 			}
 			// Judge file size on a log scale-- effectively this
 			// makes three buckets, we shouldn't have many 10k+
 			// line changes.
-			fileWeight = int64(math.Log10(float64(fileWeight)) + .5)
+			fileWeight = int64(math.Log10(float64(fileWeight))) + 1
 			fileOwners := b.config.FindOwners(*file.Filename)
 			if len(fileOwners) == 0 {
 				glog.Warningf("Couldn't find an owner for: %s", *file.Filename)


### PR DESCRIPTION
Basically the code does:
```
    log := math.Log10($NUM_LINES_CHANGED)
    logPlus := log + .5
    fileWeight := int64(logPlus)
```
So lets assume that $NUM_LINES_CHANGED == 3.
```
    log        == 0.4771212547196624
    logPlus    == 0.9771212547196624
    fileWeight == 0
```
This means that further on weightSum (and other things) will be calculated by
a multiple by fileWeight and thus will get the value of 0. Both

`100.0*float64(potentialOwners[cur])/float64(weightSum)`
  and
`selection := rand.Int63n(weightSum)`

Will cause a panic if weightSum == 0

I solve this by adding 1 to the fileWeight after it is truncated to
int64. So we can never get a value of 0.

