### PR TITLE
Add syslog server to servicelb image to get haproxy logs

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -158,6 +158,10 @@
 			"Rev": "821cda7e48749cacf7cad2c6ed01e96457ca7e9d"
 		},
 		{
+			"ImportPath": "github.com/ziutek/syslog",
+			"Rev": "0e395dffb67b1423a648cba4031fc13b4d866b6b"
+		},
+		{
 			"ImportPath": "golang.org/x/crypto/ssh",
 			"Rev": "c84e1f8e3a7e322d497cd16c0e8a13c7e127baf3"
 		},

--- a/Godeps/_workspace/src/github.com/ziutek/syslog/LICENSE
+++ b/Godeps/_workspace/src/github.com/ziutek/syslog/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2012, Michal Derkacz
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Godeps/_workspace/src/github.com/ziutek/syslog/README.md
+++ b/Godeps/_workspace/src/github.com/ziutek/syslog/README.md
@@ -1,0 +1,9 @@
+Using this library you can easy implement your own syslog server that:
+
+1. Can listen on multiple UDP ports and unix domain sockets.
+
+2. Can pass parsed syslog messages to your own handlers so your code can analyze
+and respond for them.
+
+See [documentation](http://gopkgdoc.appspot.com/pkg/github.com/ziutek/syslog)
+and [example server](https://github.com/ziutek/syslog/blob/master/example_server/main.go).

--- a/Godeps/_workspace/src/github.com/ziutek/syslog/example_server/main.go
+++ b/Godeps/_workspace/src/github.com/ziutek/syslog/example_server/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"github.com/ziutek/syslog"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+type handler struct {
+	// To simplify implementation of our handler we embed helper
+	// syslog.BaseHandler struct.
+	*syslog.BaseHandler
+}
+
+// Simple fiter for named/bind messages which can be used with BaseHandler
+func filter(m *syslog.Message) bool {
+	return m.Tag == "named" || m.Tag == "bind"
+}
+
+func newHandler() *handler {
+	h := handler{syslog.NewBaseHandler(5, filter, false)}
+	go h.mainLoop() // BaseHandler needs some gorutine that reads from its queue
+	return &h
+}
+
+// mainLoop reads from BaseHandler queue using h.Get and logs messages to stdout
+func (h *handler) mainLoop() {
+	for {
+		m := h.Get()
+		if m == nil {
+			break
+		}
+		fmt.Println(m)
+	}
+	fmt.Println("Exit handler")
+	h.End()
+}
+
+func main() {
+	// Create a server with one handler and run one listen gorutine
+	s := syslog.NewServer()
+	s.AddHandler(newHandler())
+	s.Listen("0.0.0.0:1514")
+
+	// Wait for terminating signal
+	sc := make(chan os.Signal, 2)
+	signal.Notify(sc, syscall.SIGTERM, syscall.SIGINT)
+	<-sc
+
+	// Shutdown the server
+	fmt.Println("Shutdown the server...")
+	s.Shutdown()
+	fmt.Println("Server is down")
+}

--- a/Godeps/_workspace/src/github.com/ziutek/syslog/filehandler.go
+++ b/Godeps/_workspace/src/github.com/ziutek/syslog/filehandler.go
@@ -1,0 +1,94 @@
+package syslog
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// FileHandler implements Handler interface in the way to save messages into a
+// text file. It properly handles logrotate HUP signal (closes a file and tries
+// to open/create new one).
+type FileHandler struct {
+	bh       *BaseHandler
+	filename string
+	f        *os.File
+	l        Logger
+}
+
+// NewFileHandler accepts all arguments expected by NewBaseHandler plus
+// filename which is the path to the log file.
+func NewFileHandler(filename string, qlen int, filter func(*Message) bool,
+	ft bool) *FileHandler {
+
+	h := &FileHandler{
+		bh:       NewBaseHandler(qlen, filter, ft),
+		filename: filename,
+		l:        log.New(os.Stderr, "", log.LstdFlags),
+	}
+	go h.mainLoop()
+	return h
+}
+
+// SetLogger changes an internal logger used to log I/O errors. By default I/O
+// errors are written to os.Stderr using log.Logger.
+func (h *FileHandler) SetLogger(l Logger) {
+	h.l = l
+}
+
+func (h *FileHandler) mainLoop() {
+	defer h.bh.End()
+
+	mq := h.bh.Queue()
+	sq := make(chan os.Signal, 1)
+	signal.Notify(sq, syscall.SIGHUP)
+
+	for {
+		select {
+		case <-sq: // SIGHUP probably from logrotate
+			h.checkErr(h.f.Close())
+			h.f = nil
+		case m, ok := <-mq: // message to save
+			if !ok {
+				if h.f != nil {
+					h.checkErr(h.f.Close())
+				}
+				return
+			}
+			h.saveMessage(m)
+		}
+	}
+}
+
+func (h *FileHandler) saveMessage(m *Message) {
+	var err error
+	if h.f == nil {
+		h.f, err = os.OpenFile(
+			h.filename,
+			os.O_WRONLY|os.O_APPEND|os.O_CREATE,
+			0620,
+		)
+		if h.checkErr(err) {
+			return
+		}
+	}
+	_, err = h.f.WriteString(m.String() + "\n")
+	h.checkErr(err)
+}
+
+func (h *FileHandler) checkErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if h.l == nil {
+		log.Print(h.filename, ": ", err)
+	} else {
+		h.l.Print(h.filename, ": ", err)
+	}
+	return true
+}
+
+func (h *FileHandler) Handle(m *Message) *Message {
+	return h.bh.Handle(m)
+}

--- a/Godeps/_workspace/src/github.com/ziutek/syslog/handler.go
+++ b/Godeps/_workspace/src/github.com/ziutek/syslog/handler.go
@@ -1,0 +1,81 @@
+package syslog
+
+// Handler handles syslog messages
+type Handler interface {
+	// Handle should return Message (mayby modified) for future processing by
+	// other handlers or return nil. If Handle is called with nil message it
+	// should complete all remaining work and properly shutdown before return.
+	Handle(*Message) *Message
+}
+
+// BaseHandler is desigend for simplify the creation of real handlers. It
+// implements Handler interface using nonblocking queuing of messages and
+// simple message filtering.
+type BaseHandler struct {
+	queue  chan *Message
+	end    chan struct{}
+	filter func(*Message) bool
+	ft     bool
+}
+
+// NewBaseHandler creates BaseHandler using specified filter. If filter is nil
+// or if it returns true messages are passed to BaseHandler internal queue
+// (of qlen length). If filter returns false or ft is true messages are returned
+// to server for future processing by other handlers.
+func NewBaseHandler(qlen int, filter func(*Message) bool, ft bool) *BaseHandler {
+	return &BaseHandler{
+		queue:  make(chan *Message, qlen),
+		end:    make(chan struct{}),
+		filter: filter,
+		ft:     ft,
+	}
+}
+
+// Handle inserts m in an internal queue. It immediately returns even if
+// queue is full. If m == nil it closes queue and waits for End method call
+// before return.
+func (h *BaseHandler) Handle(m *Message) *Message {
+	if m == nil {
+		close(h.queue) // signal that ther is no more messages for processing
+		<-h.end        // wait for handler shutdown
+		return nil
+	}
+	if h.filter != nil && !h.filter(m) {
+		// m doesn't match the filter
+		return m
+	}
+	// Try queue m
+	select {
+	case h.queue <- m:
+	default:
+	}
+	if h.ft {
+		return m
+	}
+	return nil
+}
+
+// Get returns first message from internal queue. It waits for message if queue
+// is empty. It returns nil if there is no more messages to process and handler
+// should shutdown.
+func (h *BaseHandler) Get() *Message {
+	m, ok := <-h.queue
+	if ok {
+		return m
+	}
+	return nil
+}
+
+// Queue returns BaseHandler internal queue as read-only channel. You can use
+// it directly, especially if your handler need to select from multiple channels
+// or have to work without blocking. You need to check if this channel is closed by
+// sender and properly shutdown in this case.
+func (h *BaseHandler) Queue() <-chan *Message {
+	return h.queue
+}
+
+// End signals the server that handler properly shutdown. You need to call End
+// only if Get has returned nil before.
+func (h *BaseHandler) End() {
+	close(h.end)
+}

--- a/Godeps/_workspace/src/github.com/ziutek/syslog/internallog.go
+++ b/Godeps/_workspace/src/github.com/ziutek/syslog/internallog.go
@@ -1,0 +1,15 @@
+package syslog
+
+// Logger is an interface for package internal (non fatal) logging
+type Logger interface {
+	Print(...interface{})
+	Printf(format string, v ...interface{})
+	Println(...interface{})
+}
+
+// FatalLogger is an interface for logging package internal fatal errors
+type FatalLogger interface {
+	Fatal(...interface{})
+	Fatalf(format string, v ...interface{})
+	Fatalln(...interface{})
+}

--- a/Godeps/_workspace/src/github.com/ziutek/syslog/message.go
+++ b/Godeps/_workspace/src/github.com/ziutek/syslog/message.go
@@ -1,0 +1,58 @@
+package syslog
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+type Message struct {
+	Time   time.Time
+	Source net.Addr
+	Facility
+	Severity
+	Timestamp time.Time // optional
+	Hostname  string    // optional
+	Tag       string // message tag as defined in RFC 3164
+	Content   string // message content as defined in RFC 3164
+	Tag1      string // alternate message tag (white rune as separator)
+	Content1  string // alternate message content (white rune as separator)
+}
+
+// NetSrc only network part of Source as string (IP for UDP or Name for UDS)
+func (m *Message) NetSrc() string {
+	switch a := m.Source.(type) {
+	case *net.UDPAddr:
+		return a.IP.String()
+	case *net.UnixAddr:
+		return a.Name
+	case *net.TCPAddr:
+		return a.IP.String()
+	}
+	// Unknown type
+	return m.Source.String()
+}
+
+func (m *Message) String() string {
+	timeLayout := "2006-01-02 15:04:05"
+	timestampLayout := "01-02 15:04:05"
+	var h []string
+	if !m.Timestamp.IsZero() {
+		h = append(h, m.Timestamp.Format(timestampLayout))
+	}
+	if m.Hostname != "" {
+		h = append(h, m.Hostname)
+	}
+	var header string
+	if len(h) > 0 {
+		header += " " + strings.Join(h, " ")
+	}
+	return fmt.Sprintf(
+		"%s %s <%s,%s>%s %s%s",
+		m.Time.Format(timeLayout), m.Source,
+		m.Facility, m.Severity,
+		header,
+		m.Tag, m.Content,
+	)
+}

--- a/Godeps/_workspace/src/github.com/ziutek/syslog/priority.go
+++ b/Godeps/_workspace/src/github.com/ziutek/syslog/priority.go
@@ -1,0 +1,95 @@
+package syslog
+
+type Facility byte
+
+const (
+	Kern Facility = iota
+	User
+	Mail
+	Daemon
+	Auth
+	Syslog
+	Lpr
+	News
+	Uucp
+	Cron
+	Authpriv
+	System0
+	System1
+	System2
+	System3
+	System4
+	Local0
+	Local1
+	Local2
+	Local3
+	Local4
+	Local5
+	Local6
+	Local7
+)
+
+var facToStr = [...]string{
+	"kern",
+	"user",
+	"mail",
+	"daemon",
+	"auth",
+	"syslog",
+	"lpr",
+	"news",
+	"uucp",
+	"cron",
+	"authpriv",
+	"system0",
+	"system1",
+	"system2",
+	"system3",
+	"system4",
+	"local0",
+	"local1",
+	"local2",
+	"local3",
+	"local4",
+	"local5",
+	"local6",
+	"local7",
+}
+
+func (f Facility) String() string {
+	if f > Local7 {
+		return "unknown"
+	}
+	return facToStr[f]
+}
+
+type Severity byte
+
+const (
+	Emerg Severity = iota
+	Alert
+	Crit
+	Err
+	Warning
+	Notice
+	Info
+	Debug
+)
+
+var sevToStr = [...]string{
+	"emerg",
+	"alert",
+	"crit",
+	"err",
+	"waining",
+	"notice",
+	"info",
+	"debug",
+}
+
+func (s Severity) String() string {
+	if s > Debug {
+		return "unknown"
+	}
+	return sevToStr[s]
+}

--- a/Godeps/_workspace/src/github.com/ziutek/syslog/server.go
+++ b/Godeps/_workspace/src/github.com/ziutek/syslog/server.go
@@ -1,0 +1,173 @@
+// Syslog server library. It is based on RFC 3164 so it doesn't parse properly
+// packets with new header format (described in RFC 5424).
+package syslog
+
+import (
+	"bytes"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+type Server struct {
+	conns    []net.PacketConn
+	handlers []Handler
+	shutdown bool
+	l        FatalLogger
+}
+
+//  NewServer creates idle server
+func NewServer() *Server {
+	return &Server{l: log.New(os.Stderr, "", log.LstdFlags)}
+}
+
+// SetLogger sets logger for server errors. A running server is rather quiet and
+// logs only fatal errors using FatalLogger interface. By default standard Go
+// logger is used so errors are writen to stderr and after that whole
+// application is halted. Using SetLogger you can change this behavior (log
+// erross elsewhere and don't halt whole application).
+func (s *Server) SetLogger(l FatalLogger) {
+	s.l = l
+}
+
+// AddHandler adds h to internal ordered list of handlers
+func (s *Server) AddHandler(h Handler) {
+	s.handlers = append(s.handlers, h)
+}
+
+// Listen starts gorutine that receives syslog messages on specified address.
+// addr can be a path (for unix domain sockets) or host:port (for UDP).
+func (s *Server) Listen(addr string) error {
+	var c net.PacketConn
+	if strings.IndexRune(addr, ':') != -1 {
+		a, err := net.ResolveUDPAddr("udp", addr)
+		if err != nil {
+			return err
+		}
+		c, err = net.ListenUDP("udp", a)
+		if err != nil {
+			return err
+		}
+	} else {
+		a, err := net.ResolveUnixAddr("unixgram", addr)
+		if err != nil {
+			return err
+		}
+		c, err = net.ListenUnixgram("unixgram", a)
+		if err != nil {
+			return err
+		}
+	}
+	s.conns = append(s.conns, c)
+	go s.receiver(c)
+	return nil
+}
+
+// Shutdown stops server.
+func (s *Server) Shutdown() {
+	s.shutdown = true
+	for _, c := range s.conns {
+		err := c.Close()
+		if err != nil {
+			s.l.Fatalln(err)
+		}
+	}
+	s.passToHandlers(nil)
+	s.conns = nil
+	s.handlers = nil
+}
+
+func isNotAlnum(r rune) bool {
+	return !(unicode.IsLetter(r) || unicode.IsNumber(r))
+}
+
+func isNulCrLf(r rune) bool {
+	return r == 0 || r == '\r' || r == '\n'
+}
+
+func (s *Server) passToHandlers(m *Message) {
+	for _, h := range s.handlers {
+		m = h.Handle(m)
+		if m == nil {
+			break
+		}
+	}
+}
+
+func (s *Server) receiver(c net.PacketConn) {
+	//q := (chan<- Message)(s.q)
+	buf := make([]byte, 1024)
+	for {
+		n, addr, err := c.ReadFrom(buf)
+		if err != nil {
+			if !s.shutdown {
+				s.l.Fatalln("Read error:", err)
+			}
+			return
+		}
+		pkt := buf[:n]
+
+		m := new(Message)
+		m.Source = addr
+		m.Time = time.Now()
+
+		// Parse priority (if exists)
+		prio := 13 // default priority
+		hasPrio := false
+		if pkt[0] == '<' {
+			n = 1 + bytes.IndexByte(pkt[1:], '>')
+			if n > 1 && n < 5 {
+				p, err := strconv.Atoi(string(pkt[1:n]))
+				if err == nil && p >= 0 {
+					hasPrio = true
+					prio = p
+					pkt = pkt[n+1:]
+				}
+			}
+		}
+		m.Severity = Severity(prio & 0x07)
+		m.Facility = Facility(prio >> 3)
+
+		// Parse header (if exists)
+		if hasPrio && len(pkt) >= 16 && pkt[15] == ' ' {
+			// Get timestamp
+			layout := "Jan _2 15:04:05"
+			ts, err := time.Parse(layout, string(pkt[:15]))
+			if err == nil && !ts.IsZero() {
+				// Get hostname
+				n = 16 + bytes.IndexByte(pkt[16:], ' ')
+				if n != 15 {
+					m.Timestamp = ts
+					m.Hostname = string(pkt[16:n])
+					pkt = pkt[n+1:]
+				}
+			}
+			// TODO: check for version an new format of header as
+			// described in RFC 5424.
+		}
+
+		// Parse msg part
+		msg := string(bytes.TrimRightFunc(pkt, isNulCrLf))
+		n = strings.IndexFunc(msg, isNotAlnum)
+		if n != -1 {
+			m.Tag = msg[:n]
+			m.Content = msg[n:]
+		} else {
+			m.Content = msg
+		}
+		msg = strings.TrimFunc(msg, unicode.IsSpace)
+		n = strings.IndexFunc(msg, unicode.IsSpace)
+		if n != -1 {
+			m.Tag1 = msg[:n]
+			m.Content1 = strings.TrimLeftFunc(msg[n+1:], unicode.IsSpace)
+		} else {
+			m.Content1 = msg
+		}
+
+		s.passToHandlers(m)
+	}
+}

--- a/service-loadbalancer/Dockerfile
+++ b/service-loadbalancer/Dockerfile
@@ -16,8 +16,12 @@
 FROM alpine:3.2
 MAINTAINER Prashanth B <beeps@google.com>
 
-RUN apk add -U haproxy bash && \
+RUN apk add -U haproxy bash curl && \
   rm -rf /var/cache/apk/*
+
+RUN mkdir /etc/haproxy/errors 
+RUN for ERROR_CODE in 400 403 408 500 502 503 504;do curl -sSL -o /etc/haproxy/errors/$ERROR_CODE.http \
+	https://raw.githubusercontent.com/haproxy/haproxy-1.5/master/examples/errorfiles/$ERROR_CODE.http;done
 
 ADD haproxy.cfg /etc/haproxy/haproxy.cfg
 ADD service_loadbalancer service_loadbalancer

--- a/service-loadbalancer/Makefile
+++ b/service-loadbalancer/Makefile
@@ -5,7 +5,7 @@ TAG = 0.0
 PREFIX = gcr.io/google_containers/servicelb
 
 server: service_loadbalancer.go
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o service_loadbalancer ./service_loadbalancer.go
+	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o service_loadbalancer ./service_loadbalancer.go ./loadbalancer_log.go
 
 container: server
 	docker build -t $(PREFIX):$(TAG) .

--- a/service-loadbalancer/README.md
+++ b/service-loadbalancer/README.md
@@ -286,6 +286,8 @@ Europe
   5. run the service_loadbalancer with --dry
 - Check http://<node_ip>:1936 for the stats page. It requires the password used in the template file.
 - Try talking to haproxy on the stats socket directly on the container using kubectl exec, eg: echo “show info” | socat unix-connect:/tmp/haproxy stdio
+- Run the service_loadbalancer with the flag --syslog to append the haproxy log as part of the pod stdout. Use kubectl logs to check the 
+status of the services or stats about the traffic
 
 ### Wishlist:
 

--- a/service-loadbalancer/haproxy.cfg
+++ b/service-loadbalancer/haproxy.cfg
@@ -9,9 +9,9 @@ defaults
 	mode	http
 	option	httplog
 	option	dontlognull
-    contimeout 5000
-    clitimeout 50000
-    srvtimeout 50000
+    timeout connect 5000
+    timeout client 50000
+    timeout server 50000
 	errorfile 400 /etc/haproxy/errors/400.http
 	errorfile 403 /etc/haproxy/errors/403.http
 	errorfile 408 /etc/haproxy/errors/408.http

--- a/service-loadbalancer/haproxy.cfg
+++ b/service-loadbalancer/haproxy.cfg
@@ -20,5 +20,13 @@ defaults
 	errorfile 503 /etc/haproxy/errors/503.http
 	errorfile 504 /etc/haproxy/errors/504.http
 
+# haproxy stats, required hostport and firewall rules for :1936
+listen stats :1936
+    mode http
+    stats enable
+    stats hide-version
+    stats realm Haproxy\ Statistics
+    stats uri /
+
 frontend localnodes
     bind *:80

--- a/service-loadbalancer/loadbalancer_log.go
+++ b/service-loadbalancer/loadbalancer_log.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/ziutek/syslog"
+)
+
+type handler struct {
+	*syslog.BaseHandler
+}
+
+type syslogServer struct {
+	*syslog.Server
+}
+
+// newSyslogServer start a syslog server using a unix socket to listen for connections
+func newSyslogServer(path string) (*syslogServer, error) {
+	glog.Infof("Starting syslog server for haproxy using %v as socket", path)
+	// remove the socket file if exists
+	os.Remove(path)
+
+	server := &syslogServer{syslog.NewServer()}
+	server.AddHandler(newHandler())
+	err := server.Listen(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return server, nil
+}
+
+func newHandler() *handler {
+	h := handler{syslog.NewBaseHandler(1000, nil, false)}
+	go h.mainLoop()
+	return &h
+}
+
+func (h *handler) mainLoop() {
+	for {
+		message := h.Get()
+		if message == nil {
+			break
+		}
+
+		fmt.Printf("servicelb [%s] %s%s\n", strings.ToUpper(message.Severity.String()), message.Tag, message.Content)
+	}
+
+	h.End()
+}

--- a/service-loadbalancer/loadbalancer_log_test.go
+++ b/service-loadbalancer/loadbalancer_log_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+func TestSyslogSocket(t *testing.T) {
+	server, err := newSyslogServer("test-syslog.socket")
+	if err != nil {
+		t.Fatalf("Unexpected error, received %+v, expected a valid syslog socket server", err)
+	}
+
+	server.Shutdown()
+}

--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -106,6 +106,9 @@ var (
 	httpPort  = flags.Int("http-port", 80, `Port to expose http services.`)
 	statsPort = flags.Int("stats-port", 1936, `Port for loadbalancer stats,
 		Used in the loadbalancer liveness probe.`)
+
+	startSyslog = flags.Bool("syslog", false, `if set, it will start a syslog server
+		that will forward haproxy logs to stdout.`)
 )
 
 // service encapsulates a single backend entry in the load balancer config.
@@ -431,9 +434,11 @@ func main() {
 	var kubeClient *unversioned.Client
 	var err error
 
-	_, err = newSyslogServer("/var/run/haproxy.log.socket")
-	if err != nil {
-		glog.Fatalf("Failed to start syslog server: %v", err)
+	if *startSyslog {
+		_, err = newSyslogServer("/var/run/haproxy.log.socket")
+		if err != nil {
+			glog.Fatalf("Failed to start syslog server: %v", err)
+		}
 	}
 
 	clientConfig := kubectl_util.DefaultClientConfig(flags)

--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -133,7 +133,7 @@ type loadBalancerConfig struct {
 	Config      string `json:"config" description:"path to loadbalancers configuration file."`
 	Template    string `json:"template" description:"template for the load balancer config."`
 	Algorithm   string `json:"algorithm" description:"loadbalancing algorithm."`
-	startSyslog bool
+	startSyslog bool   `description:"indicates if the load balancer uses syslog."`
 }
 
 // write writes the configuration file, will write to stdout if dryRun == true

--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -430,6 +430,12 @@ func main() {
 
 	var kubeClient *unversioned.Client
 	var err error
+
+	_, err = newSyslogServer("/var/run/haproxy.log.socket")
+	if err != nil {
+		glog.Fatalf("Failed to start syslog server: %v", err)
+	}
+
 	clientConfig := kubectl_util.DefaultClientConfig(flags)
 	if *cluster {
 		if kubeClient, err = unversioned.NewInCluster(); err != nil {

--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -475,6 +475,7 @@ func main() {
 	if *dry {
 		dryRun(lbc)
 	} else {
+		lbc.cfg.reload()
 		util.Until(lbc.worker, time.Second, util.NeverStop)
 	}
 }

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -4,9 +4,9 @@ global
     daemon
     stats socket /tmp/haproxy
 
-    # log using a syslog socket
+    {{ if eq .startSyslog "true" }}# log using a syslog socket
     log /var/run/haproxy.log.socket local0 info
-    log /var/run/haproxy.log.socket local0 notice
+    log /var/run/haproxy.log.socket local0 notice{{ end }}
 
 defaults
     log	global
@@ -31,12 +31,12 @@ frontend httpfrontend
     # inherit default mode, needs changing for tcp
     # forward everything meant for /foo to the foo backend
     # default_backend foo
-{{range $i, $svc := .httpServices}}
+{{range $i, $svc := .services.http}}
     acl url_{{$svc.Name}} path_beg /{{$svc.Name}}
     use_backend {{$svc.Name}} if url_{{$svc.Name}}
 {{end}}
 
-{{range $i, $svc := .httpServices}}
+{{range $i, $svc := .services.http}}
 {{ $svcName := $svc.Name }}
 backend {{$svc.Name}}
     mode	http
@@ -58,7 +58,7 @@ backend {{$svc.Name}}
 
 
 
-{{range $i, $svc := .tcpServices}}
+{{range $i, $svc := .services.tcp}}
 {{ $svcName := $svc.Name }}
 frontend {{$svc.Name}}
     bind *:{{$svc.FrontendPort}}

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -4,9 +4,11 @@ global
     daemon
     stats socket /tmp/haproxy
 
-    {{ if eq .startSyslog "true" }}# log using a syslog socket
+{{ if eq .startSyslog "true" }}
+    # log using a syslog socket
     log /var/run/haproxy.log.socket local0 info
-    log /var/run/haproxy.log.socket local0 notice{{ end }}
+    log /var/run/haproxy.log.socket local0 notice
+{{ end }}
 
 defaults
     log	global

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -4,6 +4,10 @@ global
     daemon
     stats socket /tmp/haproxy
 
+    # log using a syslog socket
+    log /var/run/haproxy.log.socket local0 info
+    log /var/run/haproxy.log.socket local0 notice
+
 defaults
     log	global
     option	dontlognull


### PR DESCRIPTION
Is not possible to use a file or device like `/dev/log`, but is possible to use a syslog server.
This allows the redirection of `haproxy` logs to stdout starting a local syslog server that just prints the content of the messages

```
Sep 15 17:45:57 backend-4 sh[25987]: servicelb [INFO] 172.17.144.1:58858 [15/Sep/2015:17:45:54.182] www app-demo/172.17.144.3:5000 3557/0/0/2/3559 200 139 - - ---- 2/2/0/1/0 0/0 "HEAD /v3/health-check HTTP/1.1"
```
