### PR TITLE
Add ansible playbook support for Ubuntu 14.04.

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Override docker config file directory for Debian
   set_fact:
     docker_config_dir: "/etc/default"
-  when: ansible_distribution == "Debian"
+  when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
 
 - name: Determine if has rpm
   stat: path=/usr/bin/rpm

--- a/ansible/roles/docker/handlers/main.yml
+++ b/ansible/roles/docker/handlers/main.yml
@@ -25,6 +25,7 @@
 - name: docker graph driver 
   command: findmnt -no FSTYPE -T /var/lib/docker
   register: docker_driver
+  ignore_errors: True
   changed_when: false
 
   # TODO: fail if no --selinux-enabled in 'OPTIONS'

--- a/ansible/roles/docker/tasks/apt-docker-install.yml
+++ b/ansible/roles/docker/tasks/apt-docker-install.yml
@@ -1,0 +1,15 @@
+---
+- name: Install GPG key
+  command: apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+- name: Configure apt repository
+  template: src="docker.list.j2" dest="/etc/apt/sources.list.d/docker.list"
+
+- name: Update respository information
+  command: apt-get update
+
+- name: Install docker engine
+  action: "{{ ansible_pkg_mgr }}"
+  args:
+    name: docker-engine
+    state: latest

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -2,8 +2,11 @@
 - include: debian-install.yml
   when: ansible_distribution == "Debian"
 
+- include: apt-docker-install.yml
+  when: ansible_distribution == "Ubuntu"
+
 - include: generic-install.yml
-  when: ansible_distribution != "Debian"
+  when: ansible_distribution != "Debian" and ansible_distribution != "Ubuntu"
 
 - name: Verify docker config files exists
   file: path={{ docker_config_dir }}/{{ item }} state=touch
@@ -16,6 +19,7 @@
   lineinfile: dest={{ docker_config_dir }}/docker regexp=^OPTIONS= line=OPTIONS="--selinux-enabled --log-level=warn"
   notify:
     - restart docker
+  when: ansible_distribution != "Ubuntu"
 
 - name: Install http_proxy into docker-network
   lineinfile: dest={{ docker_config_dir }}/docker-network regexp=^HTTP_PROXY= line=HTTP_PROXY="{{ http_proxy }}"

--- a/ansible/roles/docker/templates/docker.list.j2
+++ b/ansible/roles/docker/templates/docker.list.j2
@@ -1,0 +1,1 @@
+deb https://apt.dockerproject.org/repo {{ ansible_distribution | lower }}-{{ ansible_distribution_release }} main

--- a/ansible/roles/etcd/defaults/main.yaml
+++ b/ansible/roles/etcd/defaults/main.yaml
@@ -1,4 +1,7 @@
 ---
+# etcd_source_type: package | github-release
+etcd_source_type: package
+
 etcd_client_port: 2379
 etcd_peer_port: 2380
 etcd_peers_group: etcd

--- a/ansible/roles/etcd/files/etcd.upstart
+++ b/ansible/roles/etcd/files/etcd.upstart
@@ -1,0 +1,19 @@
+description "etcd 2.0"
+
+start on (net-device-up and local-filesystems and runlevel [2345])
+stop on runlevel [016]
+
+respawn
+respawn limit 10 5
+
+script
+    if [ -f "/etc/etcd/etcd.conf" ]; then
+	set -a
+        . /etc/etcd/etcd.conf
+	set +a
+    fi
+
+    mkdir -p /var/etcd
+    chdir /var/etcd
+    exec /usr/local/bin/etcd >>/var/log/etcd.log 2>&1
+end script

--- a/ansible/roles/etcd/tasks/github-release.yml
+++ b/ansible/roles/etcd/tasks/github-release.yml
@@ -1,0 +1,33 @@
+---
+- name: etcd version
+  set_fact:
+    etcd_version: "v2.2.0"
+
+- name: Create download dir
+  file: path="/tmp/.ansible/files" state=directory
+
+- name: Download tar file
+  get_url:
+    url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
+    dest: /tmp/.ansible/files
+
+- name: Extract tar file
+  unarchive:
+    src: "/tmp/.ansible/files/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
+    dest: /usr/local
+    copy: no
+
+- name: Create symlinks
+  file:
+    src: /usr/local/etcd-{{ etcd_version }}-linux-amd64/{{ item }}
+    dest: /usr/local/bin/{{ item }}
+    state: link
+  with_items:
+    - etcd
+    - etcdctl
+
+- name: Create upstart script
+  copy: src=etcd.upstart dest=/etc/init/etcd.conf
+
+- name: Create config directory
+  file: path="/etc/etcd" state=directory

--- a/ansible/roles/etcd/tasks/main.yml
+++ b/ansible/roles/etcd/tasks/main.yml
@@ -6,7 +6,16 @@
         state: latest
   notify:
     - restart etcd
-  when: not is_atomic
+  when: not is_atomic and ansible_distribution != "Ubuntu"
+
+- name: Force etcd_source_type to github when packages are not available
+  set_fact:
+    etcd_source_type: "github-release"
+  when: ansible_distribution == "Ubuntu"
+
+- name: Install from github
+  include: github-release.yml
+  when: etcd_source_type == "github-release"
 
 - name: Write etcd config file
   template: src=etcd.conf.j2 dest=/etc/etcd/etcd.conf

--- a/ansible/roles/kubernetes-addons/tasks/generic-install.yml
+++ b/ansible/roles/kubernetes-addons/tasks/generic-install.yml
@@ -5,7 +5,7 @@
 - name: Overwrite pyyaml package name for non-Debian
   set_fact:
     pyyaml_name: PyYAML
-  when: ansible_distribution != "Debian"
+  when: ansible_distribution != "Debian" and ansible_distribution != "Ubuntu"
 
 - name: Install PyYAML for non-debian
   action: "{{ ansible_pkg_mgr }}"

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -66,5 +66,9 @@
   notify:
     - reload and restart kube-addons
 
+- name: Install kube-addons upstart configuration
+  template: src=kube-addons.upstart.j2 dest=/etc/init/kube-addons.conf
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15
+
 - name: Enable and start kube addons
-  service: name=kube-addons.service enabled=yes state=started
+  service: name=kube-addons enabled=yes state=started

--- a/ansible/roles/kubernetes-addons/templates/kube-addons.upstart.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-addons.upstart.j2
@@ -1,0 +1,10 @@
+description "Kubernetes Addon Object Manager"
+
+start on started kube-apiserver
+stop on runlevel [!2345]
+
+env TOKEN_DIR={{ kube_token_dir }}
+env KUBECTL_BIN=/usr/bin/kubectl
+env KUBERNETES_MASTER_NAME={{ groups['masters'][0] }}
+
+exec {{ kube_script_dir }}/kube-addons.sh

--- a/ansible/roles/master/handlers/main.yml
+++ b/ansible/roles/master/handlers/main.yml
@@ -3,6 +3,7 @@
   command: systemctl --system daemon-reload
   notify:
     - restart daemons
+  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15)
 
 - name: restart daemons
   command: /bin/true

--- a/ansible/roles/master/tasks/localBuildInstall.yml
+++ b/ansible/roles/master/tasks/localBuildInstall.yml
@@ -3,7 +3,7 @@
   copy:
     src: ../../_output/local/go/bin/{{ item }}
     dest: /usr/bin/
-    mode: 755
+    mode: 0755
   with_items:
     - kube-apiserver
     - kube-scheduler
@@ -15,16 +15,28 @@
   copy:
     src: ../init/systemd/{{ item }}
     dest: /etc/systemd/system/
-    mode: 644
+    mode: 0644
   with_items:
     - kube-apiserver.service
     - kube-scheduler.service
     - kube-controller-manager.service
   notify: reload systemd
 
+- name: Upstart service files
+  copy:
+    src: ../init/upstart/{{ item }}
+    dest: /etc/init/
+    mode: 0644
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15
+  with_items:
+    - kube-apiserver.conf
+    - kube-scheduler.conf
+    - kube-controller-manager.conf
+    - kubelet.conf
+
 - name: Copy systemd tmpfile for apiserver
   copy:
     src: ../init/systemd/tmpfiles.d/
     dest: /etc/tmpfiles.d/
-    mode: 644
+    mode: 0644
   notify: reload systemd

--- a/ansible/roles/node/handlers/main.yml
+++ b/ansible/roles/node/handlers/main.yml
@@ -3,6 +3,7 @@
   command: systemctl --system daemon-reload
   notify:
     - restart daemons
+  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15)
 
 - name: restart daemons
   command: /bin/true

--- a/ansible/roles/node/tasks/localBuildInstall.yml
+++ b/ansible/roles/node/tasks/localBuildInstall.yml
@@ -3,7 +3,7 @@
   copy:
     src: ../../_output/local/go/bin/{{ item }}
     dest: /usr/bin/
-    mode: 755
+    mode: 0755
   with_items:
     - kubelet
     - kube-proxy
@@ -15,11 +15,21 @@
   copy:
     src: ../init/systemd/{{ item }}
     dest: /etc/systemd/system/
-    mode: 644
+    mode: 0644
   with_items:
     - kube-proxy.service
     - kubelet.service
   notify: reload systemd
+
+- name: Copy node upstart files
+  copy:
+    src: ../init/upstart/{{ item }}
+    dest: /etc/init
+    mode: 0644
+  with_items:
+    - kubelet.conf
+    - kube-proxy.conf
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15
 
 - name: Create the /var/lib/kubelet working directory
   file:

--- a/init/upstart/README.md
+++ b/init/upstart/README.md
@@ -1,0 +1,2 @@
+Translation of the systemd configuration files into upstart scripts
+in order to support Ubuntu 14.04.

--- a/init/upstart/kube-apiserver.conf
+++ b/init/upstart/kube-apiserver.conf
@@ -1,0 +1,27 @@
+description "Kubernetes API Server"
+
+start on (started networking and started etcd)
+stop on runlevel [016]
+
+respawn
+setuid kube
+
+script
+	if [ -f /etc/kubernetes/config ]; then
+	   . /etc/kubernetes/config
+	fi
+	if [ -f /etc/kubernetes/apiserver ]; then
+	   . /etc/kubernetes/apiserver
+	fi
+	exec /usr/bin/kube-apiserver \
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBE_ETCD_SERVERS \
+	    $KUBE_API_ADDRESS \
+	    $KUBE_API_PORT \
+	    $KUBELET_PORT \
+	    $KUBE_ALLOW_PRIV \
+	    $KUBE_SERVICE_ADDRESSES \
+	    $KUBE_ADMISSION_CONTROL \
+	    $KUBE_API_ARGS
+end script

--- a/init/upstart/kube-controller-manager.conf
+++ b/init/upstart/kube-controller-manager.conf
@@ -1,0 +1,21 @@
+description "Kubernetes Controller Manager"
+
+start on (started kube-apiserver)
+stop on runlevel [016]
+
+respawn
+setuid kube
+
+script
+	if [ -f /etc/kubernetes/config ]; then
+	   . /etc/kubernetes/config
+	fi
+	if [ -f /etc/kubernetes/controller-manager ]; then
+	   . /etc/kubernetes/controller-manager
+	fi
+	exec /usr/bin/kube-controller-manager \
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBE_MASTER \
+	    $KUBE_CONTROLLER_MANAGER_ARGS
+end script

--- a/init/upstart/kube-proxy.conf
+++ b/init/upstart/kube-proxy.conf
@@ -1,0 +1,23 @@
+description "Kubernetes Kube-Proxy Server"
+
+start on (filesystem and net-device-up IFACE!=lo)
+stop on runlevel [016]
+
+respawn
+
+limit nofile 65536 65536
+
+script
+    if [ -f /etc/kubernetes/config ]; then
+        . /etc/kubernetes/config
+    fi
+    if [ -f /etc/kubernetes/proxy ]; then
+        . /etc/kubernetes/proxy
+    fi
+
+    exec /usr/bin/kube-proxy \
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBE_MASTER \
+	    $KUBE_PROXY_ARGS
+end script

--- a/init/upstart/kube-scheduler.conf
+++ b/init/upstart/kube-scheduler.conf
@@ -1,0 +1,21 @@
+description "Kubernetes Scheduler Plugin"
+
+start on (started kube-apiserver)
+stop on runlevel [016]
+
+respawn
+setuid kube
+
+script
+	if [ -f /etc/kubernetes/config ]; then
+	   . /etc/kubernetes/config
+	fi
+	if [ -f /etc/kubernetes/scheduler ]; then
+	   . /etc/kubernetes/scheduler
+	fi
+	exec /usr/bin/kube-scheduler \
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBE_MASTER \
+	    $KUBE_SCHEDULER_ARGS
+end script

--- a/init/upstart/kubelet.conf
+++ b/init/upstart/kubelet.conf
@@ -1,0 +1,24 @@
+description "Kubernetes Kubelet Server"
+
+start on (started docker)
+stop on runlevel [016]
+
+respawn
+
+script
+	if [ -f /etc/kubernetes/config ]; then
+	   . /etc/kubernetes/config
+	fi
+	if [ -f /etc/kubernetes/kubelet ]; then
+	   . /etc/kubernetes/kubelet
+	fi
+	exec /usr/bin/kubelet \
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBELET_API_SERVER \
+	    $KUBELET_ADDRESS \
+	    $KUBELET_PORT \
+	    $KUBELET_HOSTNAME \
+	    $KUBE_ALLOW_PRIV \
+	    $KUBELET_ARGS
+end script


### PR DESCRIPTION
- Uses etcd from github release since it isn't available upstream.
- Upstream docker.io package is too old; override with apt repository from projectdocker.org.
- Use upstart for services since 14.04 doesn't yet support systemd.
- Ansible copy mode requires 0 prefix to be interpreted as octal. The issue seems to affect Ubuntu nodes but not Fedora.
  https://github.com/ansible/ansible-modules-core/issues/1798
