### PR TITLE
Use the more generic name "jenkins/google" for Jenkins commit status

### DIFF
--- a/mungegithub/pulls/ok-to-test.go
+++ b/mungegithub/pulls/ok-to-test.go
@@ -49,7 +49,7 @@ func (OkToTestMunger) MungePullRequest(config *github_util.Config, pr *github.Pu
 	if !github_util.HasLabel(issue.Labels, "lgtm") {
 		return
 	}
-	status, err := config.GetStatus(pr, []string{"Jenkins GCE e2e"})
+	status, err := config.GetStatus(pr, []string{"jenkins/google"})
 	if err != nil {
 		glog.Errorf("unexpected error getting status: %v", err)
 		return

--- a/mungegithub/pulls/submit-queue.go
+++ b/mungegithub/pulls/submit-queue.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	needsOKToMergeLabel = "needs-ok-to-merge"
-	gceE2EContext       = "Jenkins GCE e2e"
+	needsOKToMergeLabel      = "needs-ok-to-merge"
+	defaultJenkinsE2EContext = "jenkins/google"
 )
 
 var (
@@ -170,7 +170,7 @@ func (sq *SubmitQueue) AddFlags(cmd *cobra.Command, config *github_util.Config) 
 	cmd.Flags().StringSliceVar(&sq.RequiredStatusContexts, "required-contexts", []string{"cla/google", "Shippable", "continuous-integration/travis-ci/pr"}, "Comma separate list of status contexts required for a PR to be considered ok to merge")
 	cmd.Flags().StringVar(&sq.Address, "address", ":8080", "The address to listen on for HTTP Status")
 	cmd.Flags().StringVar(&sq.DontRequireE2ELabel, "dont-require-e2e-label", "e2e-not-required", "If non-empty, a PR with this label will be merged automatically without looking at e2e results")
-	cmd.Flags().StringVar(&sq.E2EStatusContext, "e2e-status-context", "Jenkins GCE e2e", "The name of the github status context for the e2e PR Builder")
+	cmd.Flags().StringVar(&sq.E2EStatusContext, "e2e-status-context", defaultJenkinsE2EContext, "The name of the github status context for the e2e PR Builder")
 	cmd.Flags().StringVar(&sq.WWWRoot, "www", "www", "Path to static web files to serve from the webserver")
 	sq.addWhitelistCommand(cmd, config)
 }
@@ -466,8 +466,8 @@ func (sq *SubmitQueue) doGithubE2EAndMerge(pr *github_api.PullRequest) {
 	}
 
 	// Check if the thing we care about is success
-	if ok := sq.githubConfig.IsStatusSuccess(pr, []string{gceE2EContext}); !ok {
-		glog.Infof("Status after build is not 'success', skipping PR %d", *pr.Number)
+	if ok := sq.githubConfig.IsStatusSuccess(pr, []string{sq.E2EStatusContext}); !ok {
+		glog.Infof("Status after build for %q is not 'success', skipping PR %d", sq.E2EStatusContext, *pr.Number)
 		sq.SetPRStatus(pr, ghE2EFailed)
 		return
 	}

--- a/mungegithub/pulls/submit-queue_test.go
+++ b/mungegithub/pulls/submit-queue_test.go
@@ -179,7 +179,7 @@ func fakeRunGithubE2ESuccess(ciStatus *github.CombinedStatus, shouldPass bool) {
 	ciStatus.State = stringPtr("pending")
 	for id := range ciStatus.Statuses {
 		status := &ciStatus.Statuses[id]
-		if *status.Context == gceE2EContext {
+		if *status.Context == defaultJenkinsE2EContext {
 			status.State = stringPtr("pending")
 			break
 		}
@@ -190,7 +190,7 @@ func fakeRunGithubE2ESuccess(ciStatus *github.CombinedStatus, shouldPass bool) {
 	found := false
 	for id := range ciStatus.Statuses {
 		status := &ciStatus.Statuses[id]
-		if *status.Context == gceE2EContext {
+		if *status.Context == defaultJenkinsE2EContext {
 			if shouldPass {
 				status.State = stringPtr("success")
 			} else {
@@ -202,7 +202,7 @@ func fakeRunGithubE2ESuccess(ciStatus *github.CombinedStatus, shouldPass bool) {
 	}
 	if !found {
 		e2eStatus := github.RepoStatus{
-			Context: stringPtr(gceE2EContext),
+			Context: stringPtr(defaultJenkinsE2EContext),
 			State:   stringPtr("success"),
 		}
 		ciStatus.Statuses = append(ciStatus.Statuses, e2eStatus)
@@ -392,7 +392,7 @@ func claStatus(status github.CombinedStatus) github.CombinedStatus {
 
 func successGithubStatus(status github.CombinedStatus) github.CombinedStatus {
 	s := github.RepoStatus{
-		Context: stringPtr(gceE2EContext),
+		Context: stringPtr(defaultJenkinsE2EContext),
 		State:   stringPtr("success"),
 	}
 	status.Statuses = append(status.Statuses, s)
@@ -401,7 +401,7 @@ func successGithubStatus(status github.CombinedStatus) github.CombinedStatus {
 
 func failGithubStatus(status github.CombinedStatus) github.CombinedStatus {
 	s := github.RepoStatus{
-		Context: stringPtr(gceE2EContext),
+		Context: stringPtr(defaultJenkinsE2EContext),
 		State:   stringPtr("failure"),
 	}
 	status.Statuses = append(status.Statuses, s)
@@ -656,6 +656,7 @@ func TestMungePullRequest(t *testing.T) {
 		sq.EachLoop(config)
 		sq.userWhitelist.Insert("k8s-merge-robot")
 		sq.DontRequireE2ELabel = "e2e-not-required"
+		sq.E2EStatusContext = defaultJenkinsE2EContext
 
 		sq.MungePullRequest(config, test.pr, test.issue, test.commits, test.events)
 		if test.shouldWaitForE2E {


### PR DESCRIPTION
The Google-run PR Jenkins is now starting to run verification checks
and unit/integration tests in addition to the e2e tests, so we should
make the name more generic.

This also sets precedent for other folks (like RedHat) who are
interested in setting up PR Jenkins bots.

@kubernetes/goog-testing @kubernetes/rh-cluster-infra @brendandburns 
