### PR TITLE
Add acl to route traffic using Host header using metadata from service

### DIFF
--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -47,6 +47,7 @@ const (
 	reloadQPS    = 10.0
 	resyncPeriod = 10 * time.Second
 	healthzPort  = 8081
+	lbHostKey    = "serviceloadbalancer/lb.host"
 )
 
 var (
@@ -272,7 +273,7 @@ func (lbc *loadBalancerController) getServices() (httpSvc []service, tcpSvc []se
 				Name: getServiceNameForLBRule(&s, servicePort.Port),
 				Ep:   ep,
 			}
-			if val, ok := s.Labels["lbHost"]; ok {
+			if val, ok := s.Labels[lbHostKey]; ok {
 				newSvc.Host = val
 			}
 			if port, ok := lbc.tcpServices[sName]; ok && port == servicePort.Port {

--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -124,6 +124,10 @@ type service struct {
 	// for this service. For http, it's always :80, for each tcp service it
 	// is the service port of any service matching a name in the tcpServices set.
 	FrontendPort int
+
+	// Host if not empty it will add a new haproxy acl to route traffic using the
+	// host header inside the http request. It only applies to http traffic.
+	Host string
 }
 
 // loadBalancerConfig represents loadbalancer specific configuration. Eventually
@@ -267,6 +271,9 @@ func (lbc *loadBalancerController) getServices() (httpSvc []service, tcpSvc []se
 			newSvc := service{
 				Name: getServiceNameForLBRule(&s, servicePort.Port),
 				Ep:   ep,
+			}
+			if val, ok := s.Labels["lbHost"]; ok {
+				newSvc.Host = val
 			}
 			if port, ok := lbc.tcpServices[sName]; ok && port == servicePort.Port {
 				newSvc.FrontendPort = servicePort.Port

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -73,10 +73,10 @@ frontend httpfrontend
 {{range $i, $svc := .services.http}}
     acl url_{{$svc.Name}} path_beg /{{$svc.Name}}
     use_backend {{$svc.Name}} if url_{{$svc.Name}}
-    {{ if $svc.Host }}
+{{ if $svc.Host }}
     acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
     use_backend {{$svc.Name}} if host_acl_{{$svc.Name}}
-    {{ end }}
+{{ end }}
 {{end}}
 
 {{range $i, $svc := .services.http}}

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -70,11 +70,14 @@ frontend httpfrontend
     # inherit default mode, needs changing for tcp
     # forward everything meant for /foo to the foo backend
     # default_backend foo
+    # in case of host header routing it will add a new acl and use an or
+    # condition to determine the backend to be used
 {{range $i, $svc := .services.http}}
     acl url_{{$svc.Name}} path_beg /{{$svc.Name}}
-    use_backend {{$svc.Name}} if url_{{$svc.Name}}
 {{ if $svc.Host }}
     acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
+    use_backend {{$svc.Name}} if url_{{$svc.Name}} or host_acl_{{$svc.Name}}
+{{ else }}
     use_backend {{$svc.Name}} if host_acl_{{$svc.Name}}
 {{ end }}
 {{end}}

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -73,6 +73,10 @@ frontend httpfrontend
 {{range $i, $svc := .services.http}}
     acl url_{{$svc.Name}} path_beg /{{$svc.Name}}
     use_backend {{$svc.Name}} if url_{{$svc.Name}}
+    {{ if $svc.Host }}
+    acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
+    use_backend {{$svc.Name}} if host_acl_{{$svc.Name}}
+    {{ end }}
 {{end}}
 
 {{range $i, $svc := .services.http}}


### PR DESCRIPTION
Example:

```
aledbf$ kubectl get services
NAME           LABELS                                    SELECTOR           IP(S)        PORT(S)
example-go     run=example-go                            run=example-go     10.3.0.36    8080/TCP
kubernetes     component=apiserver,provider=kubernetes   <none>             10.3.0.1     443/TCP
```



```
aledbf$ kubectl label services --overwrite --selector="run=example-go" lbHost="www.k8s.io"
```

```
aledbf$ kubectl get services
NAME           LABELS                                    SELECTOR           IP(S)        PORT(S)
example-go     lbHost=www.k8s.io,run=example-go          run=example-go     10.3.0.36    8080/TCP
kubernetes     component=apiserver,provider=kubernetes   <none>             10.3.0.1     443/TCP
```
