### PR TITLE
Allow custom default algorithm in service-loadbalancer

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -35,3 +35,5 @@ use-kubernetes-cluster-service
 user-whitelist
 whitelist-override-label
 error-page
+balance-algorithm
+

--- a/service-loadbalancer/loadbalancer.json
+++ b/service-loadbalancer/loadbalancer.json
@@ -2,6 +2,5 @@
     "name": "haproxy",
     "reloadCmd": "./haproxy_reload",
     "config": "/etc/haproxy/haproxy.cfg",
-    "template": "template.cfg",
-    "algorithm": "roundrobin"
+    "template": "template.cfg"
 }


### PR DESCRIPTION
Allow to choose a different algorithm to the default `roundrobin` using labels in the service.

_Is possible to choose between:_
- roundrobin (default)
- leastconn
- first
- source

HAProxy provides other [algorithms](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-balance) but is required to use additional parameters (if someone wants support for those please open an issue or just a comment in this PR)

To change the default just set the value in the label serviceloadbalancer/lb.algorithm

```
kubectl annotate svc example-go serviceloadbalancer/lb.algorithm="leastconn"
```

**If the specified string it does not exists in the list it will use the default.**
