### PR TITLE
Show container ip and port instead of service name in the backends

### DIFF
--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -105,7 +105,7 @@ backend {{$svc.Name}}
     balance roundrobin
     # TODO: Make the path used to access a service customizable.
     reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-    {{range $j, $ep := $svc.Ep}}server {{$svcName}}_{{$j}} {{$ep}}
+    {{range _, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
     {{end}}
 {{end}}
 
@@ -121,6 +121,6 @@ frontend {{$svc.Name}}
 backend {{$svc.Name}}
     balance roundrobin
     mode tcp
-    {{range $j, $ep := $svc.Ep}}server {{$svcName}}_{{$j}} {{$ep}}
+    {{range _, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
     {{end}}
 {{end}}


### PR DESCRIPTION
The reason for this change is show the ip address of the container running in the backend and help in case is required to know information about the container.

Instead of

```
backend example-go:8080
    option      httplog
    balance roundrobin
    server example-go:8080_0 10.2.21.11:8080
    server example-go:8080_1 10.2.21.8:8080
```

it use this

```
backend example-go:8080
    option      httplog
    balance roundrobin
    server 10.2.21.11:8080 10.2.21.11:8080
    server 10.2.21.8:8080 10.2.21.8:8080
```
