### PR TITLE
Recheck mergeability if github error about branch changed on merge

### DIFF
--- a/submit-queue/e2e.go
+++ b/submit-queue/e2e.go
@@ -129,7 +129,7 @@ func (e *e2eTester) runE2ETests(pr *github_api.PullRequest, issue *github_api.Is
 	// if there is a 'e2e-not-required' label, just merge it.
 	if len(e.Config.DontRequireE2ELabel) > 0 && github_util.HasLabel(issue.Labels, e.Config.DontRequireE2ELabel) {
 		e.msg("Merging %d since %s is set", *pr.Number, e.Config.DontRequireE2ELabel)
-		return e.Config.MergePR(*pr.Number, "submit-queue")
+		return e.Config.MergePR(pr, "submit-queue")
 	}
 
 	body := "@k8s-bot test this [submit-queue is verifying that this PR is safe to merge]"
@@ -147,7 +147,7 @@ func (e *e2eTester) runE2ETests(pr *github_api.PullRequest, issue *github_api.Is
 		e.msg("Status after build is not 'success', skipping PR %d", *pr.Number)
 		return nil
 	}
-	return e.Config.MergePR(*pr.Number, "submit-queue")
+	return e.Config.MergePR(pr, "submit-queue")
 }
 
 func (e *e2eTester) ServeHTTP(res http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
We found in the logs:
 Base branch was modified. Review and try the merge again.
On some PRs that were not merged. Although the github API does not
describe this error we are assuming it is because github has not
calculated the mergeability of the PR in question. Thus the workaround
is to check mergeability and then try to merge again.
