### PR TITLE
ignore errors for nodes without a running firewalld

### DIFF
--- a/ansible/roles/node/tasks/firewalld.yml
+++ b/ansible/roles/node/tasks/firewalld.yml
@@ -1,14 +1,18 @@
 ---
 - name: Open firewalld port for the kubelet
   firewalld: port=10250/tcp permanent=false state=enabled
+  ignore_errors: yes
 
 - name: Save firewalld port for the kubelet
   firewalld: port=10250/tcp permanent=true state=enabled
+  ignore_errors: yes
 
 - name: Open redirected service traffic
   command: /bin/firewall-cmd --direct --add-rule ipv4 filter INPUT 1
            -i docker0 -j ACCEPT -m comment --comment "kube-proxy redirects"
+  ignore_errors: yes
 
 - name: Save redirected service traffic
   command: /bin/firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT 1
            -i docker0 -j ACCEPT -m comment --comment "kube-proxy redirects"
+  ignore_errors: yes


### PR DESCRIPTION
If firewalld is installed on a fedora or centos system, the ansible scripts attempt to configure it, whether it's running or not. Most of the tasks for configuring firewalld are set to ignore errors, which allows the provisioning to continue on hosts that have firewalld installed, but where firewalld is not running. This PR adds that same `ignore_errors: yes` to the node firewalld tasks.

cc @eparis 