### PR TITLE
removes hostname that vagrant adds to the localhost line of /etc/hosts

### DIFF
--- a/ansible/vagrant/vagrant-ansible.yml
+++ b/ansible/vagrant/vagrant-ansible.yml
@@ -9,3 +9,11 @@
         state=present
       when: hostvars[item].ansible_default_ipv4.address is defined
       with_items: groups['all']
+    - name: "Remove hostname from localhost line"
+      replace:
+        dest=/etc/hosts
+        regexp="{{ item }} localhost?"
+        replace="localhost"
+      when: hostvars[item].ansible_default_ipv4.address is defined
+      with_items: groups['all']
+


### PR DESCRIPTION
When bringing up a cluster using ansible and vagrant, the Vagrantfile sets the hostnames of the VMs to kube-master, kube-node-1, etc. As part of this hostname-setting, vagrant adds the hostname for each VM to the localhost line in `/etc/hosts`.

When the ansible script for etcd runs, it sets `ETCD_LISTEN_CLIENT_URLS` to `http://kube-master:2379`, which, when kube-master is on the localhost line of `/etc/hosts`, acts like it's setting `ETCD_LISTEN_CLIENT_URLS` to localhost, and so the nodes can't talk to etcd.

The PR takes the `vagrant-ansible.yml` file that adds an entry for each of the vagrant VMs in the `/etc/hosts` of each VM, and extends it to remove the hostname from the localhost line.

It may be that I'm not seeing the importance of this vagrant behavior, but ansible/vagrant with the Vagrantfile as written doesn't work without making this change.