### PR TITLE
Recheck long running e2e tests are stable before merge

### DIFF
--- a/mungegithub/pulls/submit-queue.go
+++ b/mungegithub/pulls/submit-queue.go
@@ -368,6 +368,11 @@ func (sq *SubmitQueue) doGithubE2EAndMerge(pr *github_api.PullRequest) {
 		return
 	}
 
+	if !sq.e2e.Stable() {
+		sq.SetPRStatus(pr, e2eFailure)
+		return
+	}
+
 	sq.githubConfig.MergePR(pr, "submit-queue")
 	sq.SetPRStatus(pr, merged)
 	return


### PR DESCRIPTION
Since we rerun the github e2e tests (the fast ones) async, the time
between the check for stability of the slow google internal e2e tests
and when we are ready to merge could be quite large. Recheck the state
of the slow e2e tests before we merge.
