### PR TITLE
Group all backends for a single service

### DIFF
--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -80,13 +80,12 @@ frontend httpfrontend
     # default_backend foo
     # in case of host header routing it will add a new acl and use an or
     # condition to determine the backend to be used
+    # the style of if/else blocks is meant to preserves the format of the output config file
 {{range $i, $svc := .services.http}}
     acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
-{{ if $svc.Host }}
-    acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
+    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
     use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
-{{ else }}
-    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
+    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
 {{ end }}
 {{end}}
 
@@ -105,7 +104,7 @@ backend {{$svc.Name}}
     balance roundrobin
     # TODO: Make the path used to access a service customizable.
     reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-    {{range _, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
     {{end}}
 {{end}}
 
@@ -121,6 +120,6 @@ frontend {{$svc.Name}}
 backend {{$svc.Name}}
     balance roundrobin
     mode tcp
-    {{range _, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
     {{end}}
 {{end}}


### PR DESCRIPTION
This improves the readability of the configuration file:

```
    acl url_acl_example-go:8080 path_beg /example-go:8080
    use_backend example-go:8080 if url_acl_example-go:8080

    acl url_acl_example-go-2:8080 path_beg /example-go-2:8080
    acl host_acl_example-go-2:8080 hdr(host) www.google.cl
    use_backend example-go-2:8080 if url_acl_example-go-2:8080 or host_acl_example-go-2:8080
```