### PR TITLE
Ansible: Add quotation marks to docker options

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -13,7 +13,7 @@
     - docker-network
 
 - name: Turn down docker logging
-  lineinfile: dest={{ docker_config_dir }}/docker regexp=^OPTIONS= line=OPTIONS="--selinux-enabled --log-level=warn"
+  lineinfile: dest={{ docker_config_dir }}/docker regexp=^OPTIONS= line=OPTIONS="'--selinux-enabled --log-level=warn'"
   notify:
     - restart docker
 
@@ -36,7 +36,7 @@
     - restart docker
 
 - name: Add any insecure registrys to docker config
-  lineinfile: dest={{ docker_config_dir }}/docker regexp=^INSECURE_REGISTRY= line=INSECURE_REGISTRY='{% for reg in insecure_registrys %}--insecure-registry="{{ reg }}" {% endfor %}'
+  lineinfile: dest={{ docker_config_dir }}/docker regexp=^INSECURE_REGISTRY= line=INSECURE_REGISTRY="'{% for reg in insecure_registrys %}--insecure-registry={{ reg }} {% endfor %}'"
   when: insecure_registrys is defined and insecure_registrys > 0
   notify:
     - restart docker


### PR DESCRIPTION
Notice that docker-logrotate is sourcing /etc/sysconfig/docker, it
throws an error without quotation marks.

Signed-off-by: Guohua Ouyang <gouyang@redhat.com>