### PR TITLE
Add support for session affinity using service.spec.sessionAffinity or cookies

### DIFF
--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -166,6 +167,18 @@ type service struct {
 	// The name of the cookie is SERVERID
 	// This only can be used in http services
 	CookieStickySession bool
+}
+
+type serviceByName []service
+
+func (s serviceByName) Len() int {
+	return len(s)
+}
+func (s serviceByName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s serviceByName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
 }
 
 // loadBalancerConfig represents loadbalancer specific configuration. Eventually
@@ -417,6 +430,10 @@ func (lbc *loadBalancerController) getServices() (httpSvc []service, tcpSvc []se
 			glog.Infof("Found service: %+v", newSvc)
 		}
 	}
+
+	sort.Sort(serviceByName(httpSvc))
+	sort.Sort(serviceByName(tcpSvc))
+
 	return
 }
 

--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -390,11 +390,13 @@ func (lbc *loadBalancerController) getServices() (httpSvc []service, tcpSvc []se
 						break
 					}
 				}
+			} else {
+				newSvc.Algorithm = lbc.cfg.lbDefAlgorithm
 			}
 
 			// By default sticky session is disabled
 			newSvc.SessionAffinity = false
-			if s.Spec.SessionAffinity != api.ServiceAffinityNone {
+			if s.Spec.SessionAffinity != "" {
 				newSvc.SessionAffinity = true
 			}
 

--- a/service-loadbalancer/service_loadbalancer_test.go
+++ b/service-loadbalancer/service_loadbalancer_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"testing"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
@@ -150,7 +156,10 @@ func TestGetServices(t *testing.T) {
 		getEndpoints(svc1, endpointAddresses, endpointPorts),
 		getEndpoints(svc2, endpointAddresses, endpointPorts),
 	}
+
 	flb := newFakeLoadBalancerController(endpoints, []*api.Service{svc1, svc2})
+	cfg, _ := filepath.Abs("./test-samples/loadbalancer_test.json")
+	flb.cfg = parseCfg(cfg, "roundrobin")
 	flb.tcpServices = map[string]int{
 		svc1.Name: 20,
 	}
@@ -225,3 +234,196 @@ func TestNewStaticPageHandler(t *testing.T) {
 		t.Fatalf("Expected local file content with not valid URL")
 	}
 }
+
+//	buildTestLoadBalancer build a common loadBalancerController to be used
+//	in the tests to verify the generated HAProxy configuration file
+func buildTestLoadBalancer(lbDefAlgorithm string) *loadBalancerController {
+	endpointAddresses := []api.EndpointAddress{
+		{IP: "1.2.3.4"},
+		{IP: "5.6.7.8"},
+	}
+	ports := []int{80, 443}
+	endpointPorts := []api.EndpointPort{
+		{Port: ports[0], Protocol: "TCP"},
+		{Port: ports[1], Protocol: "HTTP"},
+	}
+	servicePorts := []api.ServicePort{
+		{Port: 10, TargetPort: util.NewIntOrStringFromInt(ports[0])},
+		{Port: 20, TargetPort: util.NewIntOrStringFromInt(ports[1])},
+	}
+
+	svc1 := getService(servicePorts)
+	svc1.ObjectMeta.Name = "svc-1"
+	svc2 := getService(servicePorts)
+	svc2.ObjectMeta.Name = "svc-2"
+	endpoints := []*api.Endpoints{
+		getEndpoints(svc1, endpointAddresses, endpointPorts),
+		getEndpoints(svc2, endpointAddresses, endpointPorts),
+	}
+	flb := newFakeLoadBalancerController(endpoints, []*api.Service{svc1, svc2})
+	cfg, _ := filepath.Abs("./test-samples/loadbalancer_test.json")
+	// do not have the input parameters. We need to specify a default.
+	if lbDefAlgorithm == "" {
+		lbDefAlgorithm = "roundrobin"
+	}
+
+	flb.cfg = parseCfg(cfg, lbDefAlgorithm)
+	cfgFile, _ := filepath.Abs("test-"+strconv.FormatInt(time.Now().UnixNano(),10))
+	flb.cfg.Config = cfgFile
+	flb.tcpServices = map[string]int{
+		svc1.Name: 20,
+	}
+
+	return flb
+}
+
+// compareCfgFiles check that two files are equals
+func compareCfgFiles(t *testing.T, orig, template string) {
+	f1, err := ioutil.ReadFile(orig)
+	if err != nil {
+		t.Fatalf("Expected a file but an error was returned: %v", err)
+	}
+	f2, err := ioutil.ReadFile(template)
+	if err != nil {
+		t.Fatalf("Expected a file but an error was returned: %v", err)
+	}
+
+	if !bytes.Equal(f1, f2) {
+		t.Fatalf("Expected the file contents were equals")
+	}
+}
+
+type serviceByName []service
+
+func (s serviceByName) Len() int {
+	return len(s)
+}
+func (s serviceByName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s serviceByName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name && s[i].FrontendPort < s[j].FrontendPort
+}
+
+func TestDefaultAlgorithm(t *testing.T) {
+	flb := buildTestLoadBalancer("")
+	httpSvc, tcpSvc := flb.getServices()
+	sort.Sort(serviceByName(httpSvc))
+	if err := flb.cfg.write(
+		map[string][]service{
+			"http": httpSvc,
+			"tcp":  tcpSvc,
+		}, false); err != nil {
+		t.Fatalf("Expected a valid HAProxy cfg, but an error was returned: %v", err)
+	}
+	template, _ := filepath.Abs("./test-samples/TestDefaultAlgorithm.cfg")
+	compareCfgFiles(t, flb.cfg.Config, template)
+	os.Remove(flb.cfg.Config)
+}
+
+func TestDefaultCustomAlgorithm(t *testing.T) {
+	flb := buildTestLoadBalancer("leastconn")
+	httpSvc, tcpSvc := flb.getServices()
+	sort.Sort(serviceByName(httpSvc))
+	if err := flb.cfg.write(
+		map[string][]service{
+			"http": httpSvc,
+			"tcp":  tcpSvc,
+		}, false); err != nil {
+		t.Fatalf("Expected at least one tcp or http service")
+	}
+	template, _ := filepath.Abs("./test-samples/TestDefaultCustomAlgorithm.cfg")
+	compareCfgFiles(t, flb.cfg.Config, template)
+	os.Remove(flb.cfg.Config)
+}
+
+func TestSyslog(t *testing.T) {
+	flb := buildTestLoadBalancer("")
+	httpSvc, tcpSvc := flb.getServices()
+	sort.Sort(serviceByName(httpSvc))
+	flb.cfg.startSyslog = true
+	if err := flb.cfg.write(
+		map[string][]service{
+			"http": httpSvc,
+			"tcp":  tcpSvc,
+		}, false); err != nil {
+		t.Fatalf("Expected at least one tcp or http service")
+	}
+	template, _ := filepath.Abs("./test-samples/TestSyslog.cfg")
+	compareCfgFiles(t, flb.cfg.Config, template)
+	os.Remove(flb.cfg.Config)
+}
+
+func TestSvcCustomAlgorithm(t *testing.T) {
+	flb := buildTestLoadBalancer("")
+	httpSvc, tcpSvc := flb.getServices()
+	httpSvc[0].Algorithm = "leastconn"
+	sort.Sort(serviceByName(httpSvc))
+	if err := flb.cfg.write(
+		map[string][]service{
+			"http": httpSvc,
+			"tcp":  tcpSvc,
+		}, false); err != nil {
+		t.Fatalf("Expected at least one tcp or http service")
+	}
+	template, _ := filepath.Abs("./test-samples/TestSvcCustomAlgorithm.cfg")
+	compareCfgFiles(t, flb.cfg.Config, template)
+	os.Remove(flb.cfg.Config)
+}
+
+func TestCustomDefaultAndSvcAlgorithm(t *testing.T) {
+	flb := buildTestLoadBalancer("leastconn")
+	httpSvc, tcpSvc := flb.getServices()
+	httpSvc[0].Algorithm = "roundrobin"
+	sort.Sort(serviceByName(httpSvc))
+
+	if err := flb.cfg.write(
+		map[string][]service{
+			"http": httpSvc,
+			"tcp":  tcpSvc,
+		}, false); err != nil {
+		t.Fatalf("Expected at least one tcp or http service")
+	}
+	template, _ := filepath.Abs("./test-samples/TestCustomDefaultAndSvcAlgorithm.cfg")
+	compareCfgFiles(t, flb.cfg.Config, template)
+	os.Remove(flb.cfg.Config)
+}
+
+func TestServiceAffinity(t *testing.T) {
+	flb := buildTestLoadBalancer("")
+	httpSvc, tcpSvc := flb.getServices()
+	httpSvc[0].SessionAffinity = true
+	sort.Sort(serviceByName(httpSvc))
+
+	if err := flb.cfg.write(
+		map[string][]service{
+			"http": httpSvc,
+			"tcp":  tcpSvc,
+		}, false); err != nil {
+		t.Fatalf("Expected at least one tcp or http service")
+	}
+	template, _ := filepath.Abs("./test-samples/TestServiceAffinity.cfg")
+	compareCfgFiles(t, flb.cfg.Config, template)
+	os.Remove(flb.cfg.Config)
+}
+
+// func TestServiceAffinityWithCookies(t *testing.T) {
+// 	flb := buildTestLoadBalancer("")
+// 	httpSvc, tcpSvc := flb.getServices()
+
+// 	httpSvc[0].SessionAffinity = true
+// 	httpSvc[0].CookieStickySession = true
+
+// 	sort.Sort(serviceByName(httpSvc))
+
+// 	if err := flb.cfg.write(
+// 		map[string][]service{
+// 			"http": httpSvc,
+// 			"tcp":  tcpSvc,
+// 		}, false); err != nil {
+// 		t.Fatalf("Expected at least one tcp or http service")
+// 	}
+// 	template, _ := filepath.Abs("./test-samples/TestServiceAffinityWithCookies.cfg")
+// 	compareCfgFiles(t, flb.cfg.Config, template)
+// 	os.Remove(flb.cfg.Config)
+// }

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -109,8 +109,21 @@ backend {{$svc.Name}}
     balance roundrobin
     # TODO: Make the path used to access a service customizable.
     reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
+{{if and $svc.SessionAffinity !$svc.CookieStickySession}}
+    # create a stickiness table using client IP address as key
+    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
+    stick-table type ip size 100k expire 30m
+    stick on src
     {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
     {{end}}
+{{end}}
+{{if and $svc.SessionAffinity $svc.CookieStickySession}}
+    # insert a cookie with name SERVERID to stick a client with a backend server
+    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
+    cookie SERVERID insert indirect nocache
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}}
+    {{end}}
+{{end}}
 {{end}}
 
 
@@ -125,6 +138,12 @@ frontend {{$svc.Name}}
 backend {{$svc.Name}}
     balance roundrobin
     mode tcp
+{{if $svc.SessionAffinity}}
+    # create a stickiness table using client IP address as key
+    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
+    stick-table type ip size 100k expire 30m
+    stick on src    
+{{end}}
     {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
     {{end}}
 {{end}}

--- a/service-loadbalancer/test-samples/TestCustomDefaultAndSvcAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestCustomDefaultAndSvcAlgorithm.cfg
@@ -6,11 +6,7 @@ global
     server-state-file global
     server-state-base /var/state/haproxy/
 
-{{ if eq .startSyslog "true" }}
-    # log using a syslog socket
-    log /var/run/haproxy.log.socket local0 info
-    log /var/run/haproxy.log.socket local0 notice
-{{ end }}
+
 
 defaults
     log global
@@ -86,17 +82,23 @@ frontend httpfrontend
     # in case of host header routing it will add a new acl and use an or
     # condition to determine the backend to be used
     # the style of if/else blocks is meant to preserves the format of the output config file
-{{range $i, $svc := .services.http}}
-    acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
-    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
-    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
-    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
-{{ end }}
-{{end}}
 
-{{range $i, $svc := .services.http}}
-{{ $svcName := $svc.Name }}
-backend {{$svc.Name}}
+    acl url_acl_svc-1:10 path_beg /svc-1:10
+    use_backend svc-1:10 if url_acl_svc-1:10
+
+
+    acl url_acl_svc-2:10 path_beg /svc-2:10
+    use_backend svc-2:10 if url_acl_svc-2:10
+
+
+    acl url_acl_svc-2:20 path_beg /svc-2:20
+    use_backend svc-2:20 if url_acl_svc-2:20
+
+
+
+
+
+backend svc-1:10
     option  httplog
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
@@ -106,44 +108,61 @@ backend {{$svc.Name}}
     errorfile 503 /etc/haproxy/errors/503.http
     errorfile 504 /etc/haproxy/errors/504.http
 
-    balance {{$svc.Algorithm}}
+    balance roundrobin
     # TODO: Make the path used to access a service customizable.
-    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
-{{if and $svc.SessionAffinity $svc.CookieStickySession}}
-    # insert a cookie with name SERVERID to stick a client with a backend server
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
-    cookie SERVERID insert indirect nocache
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}}
-    {{end}}
-{{end}}
-{{end}}
+    reqrep ^([^\ :]*)\ /svc-1:10[/]?(.*) \1\ /\2
 
 
 
-{{range $i, $svc := .services.tcp}}
-{{ $svcName := $svc.Name }}
-frontend {{$svc.Name}}
-    bind *:{{$svc.FrontendPort}}
+
+backend svc-2:10
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance leastconn
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:10[/]?(.*) \1\ /\2
+
+
+
+
+backend svc-2:20
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance leastconn
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:20[/]?(.*) \1\ /\2
+
+
+
+
+
+
+
+
+frontend svc-1:20
+    bind *:20
     mode tcp
-    default_backend {{$svc.Name}}
+    default_backend svc-1:20
 
-backend {{$svc.Name}}
-    balance {{$svc.Algorithm}}
+backend svc-1:20
+    balance leastconn
     mode tcp
-{{if $svc.SessionAffinity}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src    
-{{end}}
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
+
+    server 1.2.3.4:443 1.2.3.4:443
+    server 5.6.7.8:443 5.6.7.8:443
+    
+

--- a/service-loadbalancer/test-samples/TestDefaultAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestDefaultAlgorithm.cfg
@@ -6,11 +6,7 @@ global
     server-state-file global
     server-state-base /var/state/haproxy/
 
-{{ if eq .startSyslog "true" }}
-    # log using a syslog socket
-    log /var/run/haproxy.log.socket local0 info
-    log /var/run/haproxy.log.socket local0 notice
-{{ end }}
+
 
 defaults
     log global
@@ -86,17 +82,23 @@ frontend httpfrontend
     # in case of host header routing it will add a new acl and use an or
     # condition to determine the backend to be used
     # the style of if/else blocks is meant to preserves the format of the output config file
-{{range $i, $svc := .services.http}}
-    acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
-    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
-    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
-    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
-{{ end }}
-{{end}}
 
-{{range $i, $svc := .services.http}}
-{{ $svcName := $svc.Name }}
-backend {{$svc.Name}}
+    acl url_acl_svc-1:10 path_beg /svc-1:10
+    use_backend svc-1:10 if url_acl_svc-1:10
+
+
+    acl url_acl_svc-2:10 path_beg /svc-2:10
+    use_backend svc-2:10 if url_acl_svc-2:10
+
+
+    acl url_acl_svc-2:20 path_beg /svc-2:20
+    use_backend svc-2:20 if url_acl_svc-2:20
+
+
+
+
+
+backend svc-1:10
     option  httplog
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
@@ -106,44 +108,61 @@ backend {{$svc.Name}}
     errorfile 503 /etc/haproxy/errors/503.http
     errorfile 504 /etc/haproxy/errors/504.http
 
-    balance {{$svc.Algorithm}}
+    balance roundrobin
     # TODO: Make the path used to access a service customizable.
-    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
-{{if and $svc.SessionAffinity $svc.CookieStickySession}}
-    # insert a cookie with name SERVERID to stick a client with a backend server
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
-    cookie SERVERID insert indirect nocache
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}}
-    {{end}}
-{{end}}
-{{end}}
+    reqrep ^([^\ :]*)\ /svc-1:10[/]?(.*) \1\ /\2
 
 
 
-{{range $i, $svc := .services.tcp}}
-{{ $svcName := $svc.Name }}
-frontend {{$svc.Name}}
-    bind *:{{$svc.FrontendPort}}
+
+backend svc-2:10
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:10[/]?(.*) \1\ /\2
+
+
+
+
+backend svc-2:20
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:20[/]?(.*) \1\ /\2
+
+
+
+
+
+
+
+
+frontend svc-1:20
+    bind *:20
     mode tcp
-    default_backend {{$svc.Name}}
+    default_backend svc-1:20
 
-backend {{$svc.Name}}
-    balance {{$svc.Algorithm}}
+backend svc-1:20
+    balance roundrobin
     mode tcp
-{{if $svc.SessionAffinity}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src    
-{{end}}
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
+
+    server 1.2.3.4:443 1.2.3.4:443
+    server 5.6.7.8:443 5.6.7.8:443
+    
+

--- a/service-loadbalancer/test-samples/TestDefaultCustomAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestDefaultCustomAlgorithm.cfg
@@ -6,11 +6,7 @@ global
     server-state-file global
     server-state-base /var/state/haproxy/
 
-{{ if eq .startSyslog "true" }}
-    # log using a syslog socket
-    log /var/run/haproxy.log.socket local0 info
-    log /var/run/haproxy.log.socket local0 notice
-{{ end }}
+
 
 defaults
     log global
@@ -86,17 +82,23 @@ frontend httpfrontend
     # in case of host header routing it will add a new acl and use an or
     # condition to determine the backend to be used
     # the style of if/else blocks is meant to preserves the format of the output config file
-{{range $i, $svc := .services.http}}
-    acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
-    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
-    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
-    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
-{{ end }}
-{{end}}
 
-{{range $i, $svc := .services.http}}
-{{ $svcName := $svc.Name }}
-backend {{$svc.Name}}
+    acl url_acl_svc-1:10 path_beg /svc-1:10
+    use_backend svc-1:10 if url_acl_svc-1:10
+
+
+    acl url_acl_svc-2:10 path_beg /svc-2:10
+    use_backend svc-2:10 if url_acl_svc-2:10
+
+
+    acl url_acl_svc-2:20 path_beg /svc-2:20
+    use_backend svc-2:20 if url_acl_svc-2:20
+
+
+
+
+
+backend svc-1:10
     option  httplog
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
@@ -106,44 +108,61 @@ backend {{$svc.Name}}
     errorfile 503 /etc/haproxy/errors/503.http
     errorfile 504 /etc/haproxy/errors/504.http
 
-    balance {{$svc.Algorithm}}
+    balance leastconn
     # TODO: Make the path used to access a service customizable.
-    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
-{{if and $svc.SessionAffinity $svc.CookieStickySession}}
-    # insert a cookie with name SERVERID to stick a client with a backend server
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
-    cookie SERVERID insert indirect nocache
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}}
-    {{end}}
-{{end}}
-{{end}}
+    reqrep ^([^\ :]*)\ /svc-1:10[/]?(.*) \1\ /\2
 
 
 
-{{range $i, $svc := .services.tcp}}
-{{ $svcName := $svc.Name }}
-frontend {{$svc.Name}}
-    bind *:{{$svc.FrontendPort}}
+
+backend svc-2:10
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance leastconn
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:10[/]?(.*) \1\ /\2
+
+
+
+
+backend svc-2:20
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance leastconn
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:20[/]?(.*) \1\ /\2
+
+
+
+
+
+
+
+
+frontend svc-1:20
+    bind *:20
     mode tcp
-    default_backend {{$svc.Name}}
+    default_backend svc-1:20
 
-backend {{$svc.Name}}
-    balance {{$svc.Algorithm}}
+backend svc-1:20
+    balance leastconn
     mode tcp
-{{if $svc.SessionAffinity}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src    
-{{end}}
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
+
+    server 1.2.3.4:443 1.2.3.4:443
+    server 5.6.7.8:443 5.6.7.8:443
+    
+

--- a/service-loadbalancer/test-samples/TestServiceAffinity.cfg
+++ b/service-loadbalancer/test-samples/TestServiceAffinity.cfg
@@ -6,11 +6,7 @@ global
     server-state-file global
     server-state-base /var/state/haproxy/
 
-{{ if eq .startSyslog "true" }}
-    # log using a syslog socket
-    log /var/run/haproxy.log.socket local0 info
-    log /var/run/haproxy.log.socket local0 notice
-{{ end }}
+
 
 defaults
     log global
@@ -86,17 +82,23 @@ frontend httpfrontend
     # in case of host header routing it will add a new acl and use an or
     # condition to determine the backend to be used
     # the style of if/else blocks is meant to preserves the format of the output config file
-{{range $i, $svc := .services.http}}
-    acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
-    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
-    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
-    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
-{{ end }}
-{{end}}
 
-{{range $i, $svc := .services.http}}
-{{ $svcName := $svc.Name }}
-backend {{$svc.Name}}
+    acl url_acl_svc-1:10 path_beg /svc-1:10
+    use_backend svc-1:10 if url_acl_svc-1:10
+
+
+    acl url_acl_svc-2:10 path_beg /svc-2:10
+    use_backend svc-2:10 if url_acl_svc-2:10
+
+
+    acl url_acl_svc-2:20 path_beg /svc-2:20
+    use_backend svc-2:20 if url_acl_svc-2:20
+
+
+
+
+
+backend svc-1:10
     option  httplog
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
@@ -106,44 +108,69 @@ backend {{$svc.Name}}
     errorfile 503 /etc/haproxy/errors/503.http
     errorfile 504 /etc/haproxy/errors/504.http
 
-    balance {{$svc.Algorithm}}
+    balance roundrobin
     # TODO: Make the path used to access a service customizable.
-    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
+    reqrep ^([^\ :]*)\ /svc-1:10[/]?(.*) \1\ /\2
+
     # create a stickiness table using client IP address as key
     # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
     stick-table type ip size 100k expire 30m
     stick on src
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
-{{if and $svc.SessionAffinity $svc.CookieStickySession}}
-    # insert a cookie with name SERVERID to stick a client with a backend server
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
-    cookie SERVERID insert indirect nocache
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}}
-    {{end}}
-{{end}}
-{{end}}
+    server 1.2.3.4:80 1.2.3.4:80
+    server 5.6.7.8:80 5.6.7.8:80
+    
 
 
 
-{{range $i, $svc := .services.tcp}}
-{{ $svcName := $svc.Name }}
-frontend {{$svc.Name}}
-    bind *:{{$svc.FrontendPort}}
+
+backend svc-2:10
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:10[/]?(.*) \1\ /\2
+
+
+
+
+backend svc-2:20
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:20[/]?(.*) \1\ /\2
+
+
+
+
+
+
+
+
+frontend svc-1:20
+    bind *:20
     mode tcp
-    default_backend {{$svc.Name}}
+    default_backend svc-1:20
 
-backend {{$svc.Name}}
-    balance {{$svc.Algorithm}}
+backend svc-1:20
+    balance roundrobin
     mode tcp
-{{if $svc.SessionAffinity}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src    
-{{end}}
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
+
+    server 1.2.3.4:443 1.2.3.4:443
+    server 5.6.7.8:443 5.6.7.8:443
+    
+

--- a/service-loadbalancer/test-samples/TestServiceAffinityWithCookies.cfg
+++ b/service-loadbalancer/test-samples/TestServiceAffinityWithCookies.cfg
@@ -6,11 +6,7 @@ global
     server-state-file global
     server-state-base /var/state/haproxy/
 
-{{ if eq .startSyslog "true" }}
-    # log using a syslog socket
-    log /var/run/haproxy.log.socket local0 info
-    log /var/run/haproxy.log.socket local0 notice
-{{ end }}
+
 
 defaults
     log global
@@ -86,17 +82,23 @@ frontend httpfrontend
     # in case of host header routing it will add a new acl and use an or
     # condition to determine the backend to be used
     # the style of if/else blocks is meant to preserves the format of the output config file
-{{range $i, $svc := .services.http}}
-    acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
-    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
-    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
-    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
-{{ end }}
-{{end}}
 
-{{range $i, $svc := .services.http}}
-{{ $svcName := $svc.Name }}
-backend {{$svc.Name}}
+    acl url_acl_svc-1:10 path_beg /svc-1:10
+    use_backend svc-1:10 if url_acl_svc-1:10
+
+
+    acl url_acl_svc-2:10 path_beg /svc-2:10
+    use_backend svc-2:10 if url_acl_svc-2:10
+
+
+    acl url_acl_svc-2:20 path_beg /svc-2:20
+    use_backend svc-2:20 if url_acl_svc-2:20
+
+
+
+
+
+backend svc-1:10
     option  httplog
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
@@ -106,44 +108,68 @@ backend {{$svc.Name}}
     errorfile 503 /etc/haproxy/errors/503.http
     errorfile 504 /etc/haproxy/errors/504.http
 
-    balance {{$svc.Algorithm}}
+    balance roundrobin
     # TODO: Make the path used to access a service customizable.
-    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
-{{if and $svc.SessionAffinity $svc.CookieStickySession}}
+    reqrep ^([^\ :]*)\ /svc-1:10[/]?(.*) \1\ /\2
+
+
     # insert a cookie with name SERVERID to stick a client with a backend server
     # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
     cookie SERVERID insert indirect nocache
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}}
-    {{end}}
-{{end}}
-{{end}}
+    server 1.2.3.4:80 1.2.3.4:80 cookie s0
+    server 5.6.7.8:80 5.6.7.8:80 cookie s1
+    
 
 
 
-{{range $i, $svc := .services.tcp}}
-{{ $svcName := $svc.Name }}
-frontend {{$svc.Name}}
-    bind *:{{$svc.FrontendPort}}
+backend svc-2:10
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:10[/]?(.*) \1\ /\2
+
+
+
+
+backend svc-2:20
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:20[/]?(.*) \1\ /\2
+
+
+
+
+
+
+
+
+frontend svc-1:20
+    bind *:20
     mode tcp
-    default_backend {{$svc.Name}}
+    default_backend svc-1:20
 
-backend {{$svc.Name}}
-    balance {{$svc.Algorithm}}
+backend svc-1:20
+    balance roundrobin
     mode tcp
-{{if $svc.SessionAffinity}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src    
-{{end}}
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
+
+    server 1.2.3.4:443 1.2.3.4:443
+    server 5.6.7.8:443 5.6.7.8:443
+    
+

--- a/service-loadbalancer/test-samples/TestSvcCustomAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestSvcCustomAlgorithm.cfg
@@ -6,11 +6,7 @@ global
     server-state-file global
     server-state-base /var/state/haproxy/
 
-{{ if eq .startSyslog "true" }}
-    # log using a syslog socket
-    log /var/run/haproxy.log.socket local0 info
-    log /var/run/haproxy.log.socket local0 notice
-{{ end }}
+
 
 defaults
     log global
@@ -86,17 +82,23 @@ frontend httpfrontend
     # in case of host header routing it will add a new acl and use an or
     # condition to determine the backend to be used
     # the style of if/else blocks is meant to preserves the format of the output config file
-{{range $i, $svc := .services.http}}
-    acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
-    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
-    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
-    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
-{{ end }}
-{{end}}
 
-{{range $i, $svc := .services.http}}
-{{ $svcName := $svc.Name }}
-backend {{$svc.Name}}
+    acl url_acl_svc-1:10 path_beg /svc-1:10
+    use_backend svc-1:10 if url_acl_svc-1:10
+
+
+    acl url_acl_svc-2:10 path_beg /svc-2:10
+    use_backend svc-2:10 if url_acl_svc-2:10
+
+
+    acl url_acl_svc-2:20 path_beg /svc-2:20
+    use_backend svc-2:20 if url_acl_svc-2:20
+
+
+
+
+
+backend svc-1:10
     option  httplog
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
@@ -106,44 +108,61 @@ backend {{$svc.Name}}
     errorfile 503 /etc/haproxy/errors/503.http
     errorfile 504 /etc/haproxy/errors/504.http
 
-    balance {{$svc.Algorithm}}
+    balance leastconn
     # TODO: Make the path used to access a service customizable.
-    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
-{{if and $svc.SessionAffinity $svc.CookieStickySession}}
-    # insert a cookie with name SERVERID to stick a client with a backend server
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
-    cookie SERVERID insert indirect nocache
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}}
-    {{end}}
-{{end}}
-{{end}}
+    reqrep ^([^\ :]*)\ /svc-1:10[/]?(.*) \1\ /\2
 
 
 
-{{range $i, $svc := .services.tcp}}
-{{ $svcName := $svc.Name }}
-frontend {{$svc.Name}}
-    bind *:{{$svc.FrontendPort}}
+
+backend svc-2:10
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:10[/]?(.*) \1\ /\2
+
+
+
+
+backend svc-2:20
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:20[/]?(.*) \1\ /\2
+
+
+
+
+
+
+
+
+frontend svc-1:20
+    bind *:20
     mode tcp
-    default_backend {{$svc.Name}}
+    default_backend svc-1:20
 
-backend {{$svc.Name}}
-    balance {{$svc.Algorithm}}
+backend svc-1:20
+    balance roundrobin
     mode tcp
-{{if $svc.SessionAffinity}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src    
-{{end}}
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
+
+    server 1.2.3.4:443 1.2.3.4:443
+    server 5.6.7.8:443 5.6.7.8:443
+    
+

--- a/service-loadbalancer/test-samples/TestSyslog.cfg
+++ b/service-loadbalancer/test-samples/TestSyslog.cfg
@@ -6,11 +6,11 @@ global
     server-state-file global
     server-state-base /var/state/haproxy/
 
-{{ if eq .startSyslog "true" }}
+
     # log using a syslog socket
     log /var/run/haproxy.log.socket local0 info
     log /var/run/haproxy.log.socket local0 notice
-{{ end }}
+
 
 defaults
     log global
@@ -86,17 +86,23 @@ frontend httpfrontend
     # in case of host header routing it will add a new acl and use an or
     # condition to determine the backend to be used
     # the style of if/else blocks is meant to preserves the format of the output config file
-{{range $i, $svc := .services.http}}
-    acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
-    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
-    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
-    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
-{{ end }}
-{{end}}
 
-{{range $i, $svc := .services.http}}
-{{ $svcName := $svc.Name }}
-backend {{$svc.Name}}
+    acl url_acl_svc-1:10 path_beg /svc-1:10
+    use_backend svc-1:10 if url_acl_svc-1:10
+
+
+    acl url_acl_svc-2:10 path_beg /svc-2:10
+    use_backend svc-2:10 if url_acl_svc-2:10
+
+
+    acl url_acl_svc-2:20 path_beg /svc-2:20
+    use_backend svc-2:20 if url_acl_svc-2:20
+
+
+
+
+
+backend svc-1:10
     option  httplog
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
@@ -106,44 +112,61 @@ backend {{$svc.Name}}
     errorfile 503 /etc/haproxy/errors/503.http
     errorfile 504 /etc/haproxy/errors/504.http
 
-    balance {{$svc.Algorithm}}
+    balance roundrobin
     # TODO: Make the path used to access a service customizable.
-    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
-{{if and $svc.SessionAffinity $svc.CookieStickySession}}
-    # insert a cookie with name SERVERID to stick a client with a backend server
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
-    cookie SERVERID insert indirect nocache
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}}
-    {{end}}
-{{end}}
-{{end}}
+    reqrep ^([^\ :]*)\ /svc-1:10[/]?(.*) \1\ /\2
 
 
 
-{{range $i, $svc := .services.tcp}}
-{{ $svcName := $svc.Name }}
-frontend {{$svc.Name}}
-    bind *:{{$svc.FrontendPort}}
+
+backend svc-2:10
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:10[/]?(.*) \1\ /\2
+
+
+
+
+backend svc-2:20
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+    # TODO: Make the path used to access a service customizable.
+    reqrep ^([^\ :]*)\ /svc-2:20[/]?(.*) \1\ /\2
+
+
+
+
+
+
+
+
+frontend svc-1:20
+    bind *:20
     mode tcp
-    default_backend {{$svc.Name}}
+    default_backend svc-1:20
 
-backend {{$svc.Name}}
-    balance {{$svc.Algorithm}}
+backend svc-1:20
+    balance roundrobin
     mode tcp
-{{if $svc.SessionAffinity}}
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src    
-{{end}}
-    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
-    {{end}}
-{{end}}
+
+    server 1.2.3.4:443 1.2.3.4:443
+    server 5.6.7.8:443 5.6.7.8:443
+    
+

--- a/service-loadbalancer/test-samples/loadbalancer_test.json
+++ b/service-loadbalancer/test-samples/loadbalancer_test.json
@@ -1,0 +1,6 @@
+{
+    "name": "haproxy",
+    "reloadCmd": "./haproxy_reload",
+    "config": "haproxy_test.cfg",
+    "template": "template.cfg"
+}


### PR DESCRIPTION
Use the attribute `sessionAffinity` from the service spec to enable the use a stickiness table in haproxy
http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table

Example: 
- stick-table
  `sessionAffinity=ClientIP`
- cookies
  `sessionAffinity=ClientIP` and annotation `serviceloadbalancer/lb.cookie-sticky-session=true`
