### PR TITLE
Update Google Internal E2E Status More Often

### DIFF
--- a/mungegithub/www/script.js
+++ b/mungegithub/www/script.js
@@ -66,6 +66,7 @@ function SQCntl(dataService, $interval) {
 
   function getE2E(builds) {
     var result = [];
+    var failedBuild = false;
     angular.forEach(builds, function(value, key) {
       var obj = {
         'name': key
@@ -78,15 +79,16 @@ function SQCntl(dataService, $interval) {
         // red X mark
         obj.state = '\u2716';
         obj.color = 'red';
-        self.failedBuild = true;
+        failedBuild = true;
       } else {
         obj.state = 'Error';
         obj.color = 'red';
         obj.msg = value;
-        self.failedBuild = true;
+        failedBuild = true;
       }
       result.push(obj);
     });
+    self.failedBuild = failedBuild;
     return result;
   }
 
@@ -133,7 +135,6 @@ function SQCntl(dataService, $interval) {
         result.push(numobj);
       }
     });
-    console.log(result);
     result.sort(compareSearchTerms);
     return result;
   }


### PR DESCRIPTION
Currently, the submit queue web page only updates the google internal e2e
when it is processing PRs. This means if no PRs gets to that point in the
submit queue logic we will never update the web page. But even if there
are PRs which get to that point, the loop is every 30 minutes so its a
long delay.

Also, the web interface showed 'red' if it failed but never would go
back green if the tests started passing. So fix the javascript there.