### PR TITLE
Clear the submit queue any time we hit a non-stable e2e

### DIFF
--- a/mungegithub/pulls/submit-queue.go
+++ b/mungegithub/pulls/submit-queue.go
@@ -153,7 +153,9 @@ func (sq *SubmitQueue) Initialize(config *github_util.Config) error {
 // EachLoop is called at the start of every munge loop
 func (sq *SubmitQueue) EachLoop(config *github_util.Config) error {
 	// We check stable just to get an update in case no PR tries.
-	sq.e2e.Stable()
+	if !sq.e2e.Stable() {
+		sq.flushGithubE2EQueue(e2eFailure)
+	}
 
 	sq.Lock()
 	defer sq.Unlock()
@@ -473,6 +475,7 @@ func (sq *SubmitQueue) doGithubE2EAndMerge(pr *github_api.PullRequest) {
 	}
 
 	if !sq.e2e.Stable() {
+		sq.flushGithubE2EQueue(e2eFailure)
 		sq.SetPRStatus(pr, e2eFailure)
 		return
 	}


### PR DESCRIPTION
We were clearning the submit queue when we found google internal e2e was
unstable during the 30 minute loop, but not when we found e2e failed
after a github build. Flush e2e any time we found an unstable build.