### PR TITLE
for ansible/vagrant/pkgManager install w/ CentOS 7, get pkgs from extras repo

### DIFF
--- a/ansible/roles/common/files/virt7-docker-common-candidate.repo
+++ b/ansible/roles/common/files/virt7-docker-common-candidate.repo
@@ -1,5 +1,0 @@
-[virt7-docker-common-candidate]
-name=virt7-docker-common-candidate
-baseurl=http://cbs.centos.org/repos/virt7-docker-common-candidate/x86_64/os/
-enabled=0
-gpgcheck=0

--- a/ansible/roles/common/files/virt7-testing.repo
+++ b/ansible/roles/common/files/virt7-testing.repo
@@ -1,5 +1,0 @@
-[virt7-testing]
-name=virt7-testing
-baseurl=http://cbs.centos.org/repos/virt7-testing/x86_64/os/
-enabled=0
-gpgcheck=0

--- a/ansible/roles/common/tasks/centos.yml
+++ b/ansible/roles/common/tasks/centos.yml
@@ -1,6 +1,0 @@
----
-- name: CentOS | Install Testing centos7 repo
-  copy: src=virt7-testing.repo dest=/etc/yum.repos.d/virt7-testing.repo
-
-- name: CentOS | Install docker-common-candidate centos7 repo
-  copy: src=virt7-docker-common-candidate.repo dest=/etc/yum.repos.d/virt7-docker-common-candidate.repo

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -48,8 +48,5 @@
 - include: rpm.yml
   when: has_rpm
 
-- include: centos.yml
-  when: ansible_distribution == "CentOS"
-
 - include: fedora-install.yml
   when: not is_atomic and ansible_distribution == "Fedora"

--- a/ansible/roles/master/tasks/pkgMgrInstallers/centos-install.yml
+++ b/ansible/roles/master/tasks/pkgMgrInstallers/centos-install.yml
@@ -3,6 +3,5 @@
   yum:
     pkg=kubernetes-master
     state=latest
-    enablerepo=virt7-docker-common-candidate
   notify:
     - restart daemons

--- a/ansible/roles/node/tasks/pkgMgrInstallers/centos-install.yml
+++ b/ansible/roles/node/tasks/pkgMgrInstallers/centos-install.yml
@@ -3,6 +3,5 @@
   yum:
     pkg=kubernetes-node
     state=latest
-    enablerepo=virt7-docker-common-candidate
   notify:
     - restart daemons


### PR DESCRIPTION
Currently, when running the ansible/vagrant scripts to bring up a cluster based on packages from the CentOS 7 repositories, we're installing kubernetes and docker from the [CentOS Build System](https://wiki.centos.org/HowTos/CommunityBuildSystem), rather than from the centos extras repository (which is enabled by default in CentOS). This PR would change that, pulling the packages from the extras repo.

The docker and kubernetes packages from the extras repo are updated about every six weeks, following updates to RHEL Atomic Host, so they're reasonably up-to-date. The CBS packages tend to be fairly bleeding-edge, with changes that might not match user expectations of CentOS. For instance, the current kubenetes-client package provided by the CBS repo includes a `kubectl` that's symlinked to the `openshift` executable.

There may be a reason why the packages from extras weren't acceptable in the past -- this repo didn't include kube 1.0 until August, for instance, but I think extras is the right source for our packages at this point. 

@eparis, does this sound reasonable to you?