### PR TITLE
Add the always_run flag to commands that 'register' status.

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -3,6 +3,7 @@
   stat: path=/run/ostree-booted
   register: s
   changed_when: false
+  always_run: yes
 
 - name: Init the is_atomic fact
   set_fact:
@@ -26,6 +27,7 @@
   stat: path=/usr/bin/rpm
   register: s
   changed_when: false
+  always_run: yes
 
 - name: Init the has_rpm fact
   set_fact:

--- a/ansible/roles/common/tasks/rpm.yml
+++ b/ansible/roles/common/tasks/rpm.yml
@@ -4,6 +4,7 @@
   register: s
   changed_when: false
   failed_when: false
+  always_run: yes
 
 - name: Set the has_firewalld fact
   set_fact:
@@ -15,6 +16,7 @@
   register: s
   changed_when: false
   failed_when: false
+  always_run: yes
 
 - name: Set the has_iptables fact
   set_fact:

--- a/ansible/roles/pre-ansible/tasks/main.yml
+++ b/ansible/roles/pre-ansible/tasks/main.yml
@@ -2,10 +2,12 @@
 - name: Get os_version from /etc/os-release
   raw: "grep '^VERSION_ID=' /etc/os-release | sed s'/VERSION_ID=//'"
   register: os_version
+  always_run: yes
 
 - name: Get distro name from /etc/os-release
   raw: "grep '^NAME=' /etc/os-release | sed s'/NAME=//'"
   register: distro
+  always_run: yes
 
 - include: fedora-dnf.yml
   when: os_version.stdout|int >= 22 and 'Fedora' in distro.stdout


### PR DESCRIPTION
It is useful to be able to run the playbook with the option "--check" in order to validate different scenarios without making changes to the running system. That requires the pre-ansible and common tasks to succeed when "--check" is enabled. "always_run" on tasks that produce status is required for this to work.
