### PR TITLE
submit queue: Do not update 'status' if PR already in queue

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -431,13 +431,17 @@ func (sq *SubmitQueue) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	sq.SetMergeStatus(obj, ghE2EQueued, true)
+	added := false
 	sq.Lock()
-	sq.githubE2EWakeup <- true
 	if _, ok := sq.githubE2EQueue[*obj.Issue.Number]; !ok {
 		sq.githubE2EQueue[*obj.Issue.Number] = obj
+		sq.githubE2EWakeup <- true
+		added = true
 	}
 	sq.Unlock()
+	if added {
+		sq.SetMergeStatus(obj, ghE2EQueued, true)
+	}
 
 	return
 }

--- a/mungegithub/www/index.html
+++ b/mungegithub/www/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-  <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/0.11.2/angular-material.min.css" type="text/css">
+  <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0-rc1/angular-material.min.css" type="text/css">
   <link rel="stylesheet" href="md-data-table.min.css" type="text/css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=RobotoDraft:300,400,500,700,400italic" type="text/css">
   <link rel="stylesheet" href="style.css" type="text/css">
@@ -218,7 +218,7 @@
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular.min.js" type="text/javascript"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular-animate.min.js" type="text/javascript"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular-aria.min.js" type="text/javascript"></script>
-  <script src="https://ajax.googleapis.com/ajax/libs/angular_material/0.11.2/angular-material.min.js" type="text/javascript"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0-rc1/angular-material.min.js" type="text/javascript"></script>
   <script src="md-data-table.min.js" type="text/javascript"></script>
   <script src="toArrayFilter.js" type="text/javascript"></script>
   <script src="script.js" type="text/javascript"></script>

--- a/mungegithub/www/index.html
+++ b/mungegithub/www/index.html
@@ -70,7 +70,7 @@
               <section>
                 <md-subheader class="md-primary">CURRENTLY RUNNING</md-subheader>
                 <md-list layout-padding>
-                  <md-list-item ng-repeat="pr in cntl.e2erunning">
+                  <md-list-item ng-repeat="pr in cntl.e2erunning track by pr.Number">
                     <a class="md-avatar" ng-href="https://github.com/kubernetes/kubernetes/pulls/{{pr.Login}}">
                       <img ng-src="{{pr.AvatarURL}}" alt="{{pr.Login}}">
                     </a>
@@ -119,7 +119,7 @@
                 </md-toolbar>
               </md-content>
               <md-list>
-                <md-list-item class="md-3-line" ng-repeat="pr in cntl.historicPRs | loginOrPR:cntl.historicDisplayValue | orderBy: '-Time'">
+                <md-list-item class="md-3-line" ng-repeat="pr in cntl.historicPRs | loginOrPR:cntl.historicDisplayValue | orderBy: '-Time' track by pr.Time">
                   <a class="md-avatar" ng-href="https://github.com/kubernetes/kubernetes/pulls/{{pr.Login}}">
                     <img ng-src="{{pr.AvatarURL}}" alt="{{pr.Login}}">
                   </a>
@@ -198,7 +198,7 @@
                       </tr>
                     </thead>
                     <tbody>
-                      <tr ng-repeat="stat in cntl.botStats | toArray | orderBy: cntl.StatOrder" track by stat.$key>
+                      <tr ng-repeat="stat in cntl.botStats | toArray | orderBy: cntl.StatOrder track by stat.$key">
                         <td>{{stat.$key}}</td>
                         <td>{{stat.Count}}</td>
                         <td>{{stat.CachedCount}}</td>


### PR DESCRIPTION
If a PR is on the merge queue and the munger runs again, it will
(likely) determine that the PR needs to be added to the queue. The
problem is that we also put this determination in the history. So we log
every 10 minutes that a PR is being 'enqueued' even though it was always
on the queue. This makes the log less useful.
