### PR TITLE
Handle paging when getting commits

### DIFF
--- a/mungegithub/github/github_test.go
+++ b/mungegithub/github/github_test.go
@@ -205,7 +205,7 @@ func TestForEachIssueDo(t *testing.T) {
 			if r.URL.Query().Get("sort") != "created" {
 				t.Errorf("Unexpected sort: %s", r.URL.Query().Get("sort"))
 			}
-			if r.URL.Query().Get("per_page") != "20" {
+			if r.URL.Query().Get("per_page") != "100" {
 				t.Errorf("Unexpected per_page: %s", r.URL.Query().Get("per_page"))
 			}
 			w.Header().Add("Link",

--- a/mungegithub/mungers/lgtm_after_commit.go
+++ b/mungegithub/mungers/lgtm_after_commit.go
@@ -62,6 +62,7 @@ func (LGTMAfterCommitMunger) Munge(obj *github.MungeObject) {
 	}
 
 	if lastModified.After(*lgtmTime) {
+		glog.Infof("PR: %d lgtm:%s  lastModified:%s", *obj.Issue.Number, lgtmTime.String(), lastModified.String())
 		lgtmRemovedBody := "PR changed after LGTM, removing LGTM."
 		if err := obj.WriteComment(lgtmRemovedBody); err != nil {
 			return

--- a/mungegithub/rc.yaml
+++ b/mungegithub/rc.yaml
@@ -8,7 +8,7 @@ metadata:
   name: mungegithub-2015-10-26-2a7f8fd
   namespace: default
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     app: mungegithub
     track: alpha


### PR DESCRIPTION
The change after LGTM hook has been trigger incorrectly. See:

https://github.com/kubernetes/kubernetes/pull/13146
https://github.com/kubernetes/kubernetes/pull/15994

This handles paging on commits (which we shouldn't have more than 100
commits, but that is a code path this munger uses) and adds a touch more
debug info.
