### PR TITLE
Ansible: add proxy to make_ca_cert

### DIFF
--- a/ansible/roles/kubernetes/files/make-ca-cert.sh
+++ b/ansible/roles/kubernetes/files/make-ca-cert.sh
@@ -18,6 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Export proxy to ensure commands like curl could work
+export ${HTTP_PROXY} ${HTTPS_PROXY} 
+
 # Caller should set in the ev:
 # MASTER_IP - this may be an ip or things like "_use_gce_external_ip_"
 # MASTER_NAME - DNS name for the master

--- a/ansible/roles/kubernetes/tasks/gen_certs.yml
+++ b/ansible/roles/kubernetes/tasks/gen_certs.yml
@@ -35,6 +35,8 @@
     SERVICE_CLUSTER_IP_RANGE: "{{ kube_service_addresses }}"
     CERT_DIR: "{{ kube_cert_dir }}"
     CERT_GROUP: "{{ kube_cert_group }}"
+    HTTP_PROXY: "{{ http_proxy }}"
+    HTTPS_PROXY: "{{ https_proxy }}"
 
 - name: Verify certificate permissions
   file:


### PR DESCRIPTION
Ensure curl works if the host is behind proxy.

Signed-off-by: Guohua Ouyang <gouyang@redhat.com>