### PR TITLE
Ansible: add proxy to get_url

### DIFF
--- a/ansible/roles/etcd/tasks/github-release.yml
+++ b/ansible/roles/etcd/tasks/github-release.yml
@@ -10,6 +10,10 @@
   get_url:
     url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
     dest: /tmp/.ansible/files
+    validate_certs: False
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
 
 - name: Extract tar file
   unarchive:

--- a/ansible/roles/kubernetes-addons/tasks/cluster-logging.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-logging.yml
@@ -7,6 +7,10 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/fluentd-elasticsearch/{{ item }}
     dest="{{ kube_addons_dir }}/cluster-logging/"
     force=yes
+    validate_certs=False
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
   with_items:
     - es-controller.yaml
     - es-service.yaml

--- a/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
@@ -7,6 +7,10 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/cluster-monitoring/influxdb/{{ item }}
     dest="{{ kube_addons_dir }}/cluster-monitoring/"
     force=yes
+    validate_certs=False
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
   with_items:
     - grafana-service.yaml
     - heapster-controller.yaml

--- a/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
@@ -7,6 +7,10 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/kube-ui/{{ item }}
     dest="{{ kube_addons_dir }}/kube-ui/"
     force=yes
+    validate_certs=False
+  environment:
+    http_proxy: http://squid.apac.redhat.com:3128
+    https_proxy: https://squid.apac.redhat.com:3128
   with_items:
     - kube-ui-rc.yaml
     - kube-ui-svc.yaml

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -16,6 +16,10 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/saltbase/salt/kube-addons/namespace.yaml
     dest="{{ kube_config_dir }}/addons/"
     force=yes
+    validate_certs=False
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
 
 - include: dns.yml
   when: dns_setup

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -21,6 +21,10 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
     dest="{{ kube_manifest_dir }}"
     force=yes
+    validate_certs=False
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
   when: cluster_logging
 
 - name: Get the node token values


### PR DESCRIPTION
get_url is failed when the host is using proxy, need to add proxy support to get_url.

There is ansible issue that get_url does not work with HTTPS proxy, see issue [#10941](https://github.com/ansible/ansible/issues/10941) in ansible project. It works by specifying both the proxy variables in environment and validate_certs=False.

Signed-off-by: Guohua Ouyang gouyang@redhat.com
