### PR TITLE
ansible/gen_certs: Fix regression when HTTP_PROXY is not set

### DIFF
--- a/ansible/roles/kubernetes/tasks/gen_certs.yml
+++ b/ansible/roles/kubernetes/tasks/gen_certs.yml
@@ -35,8 +35,8 @@
     SERVICE_CLUSTER_IP_RANGE: "{{ kube_service_addresses }}"
     CERT_DIR: "{{ kube_cert_dir }}"
     CERT_GROUP: "{{ kube_cert_group }}"
-    HTTP_PROXY: "{{ http_proxy }}"
-    HTTPS_PROXY: "{{ https_proxy }}"
+    HTTP_PROXY: "{{ http_proxy|default('') }}"
+    HTTPS_PROXY: "{{ https_proxy|default('') }}"
 
 - name: Verify certificate permissions
   file:


### PR DESCRIPTION
Regression from 46131210fc99fe84e121f24987f0c1669f277710 when
`http_proxy` is *not* defined.

Ansible tried to quote the undefined variable, and it ended up breaking like:

```
Could not resolve proxy: {# https_proxy #}; Name or service not known
```