### PR TITLE
ansible: make apiserver port easy to configure

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -31,6 +31,9 @@ insecure_registrys:
 #http_proxy: "http://proxy.example.com:3128"
 #https_proxy: "http://proxy.example.com:3128"
 
+# The port that the Kubernetes apiserver component listens on.
+kube_master_api_port: 443
+
 # Kubernetes internal network for services.
 # Kubernetes services will get fake IP addresses from this range.
 # This range must not conflict with anything in your infrastructure. These


### PR DESCRIPTION
Atomic host cannot listen to port 443 currently, so it should be able to configure the api port.

Signed-off-by: Guohua Ouyang gouyang@redhat.com
