### PR TITLE
kube-ui.yml references a hard coded proxy

### DIFF
--- a/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
@@ -9,8 +9,8 @@
     force=yes
     validate_certs=False
   environment:
-    http_proxy: http://squid.apac.redhat.com:3128
-    https_proxy: https://squid.apac.redhat.com:3128
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
   with_items:
     - kube-ui-rc.yaml
     - kube-ui-svc.yaml


### PR DESCRIPTION
The other tasks in this role have proxy environment variables passed through from ansible. This file has hard coded values for a proxy (Squid?) at RedHat. Should this be the case?