### PR TITLE
ansible: Consistently handle `http_proxy` not being defined

### DIFF
--- a/ansible/roles/etcd/tasks/github-release.yml
+++ b/ansible/roles/etcd/tasks/github-release.yml
@@ -12,8 +12,8 @@
     dest: /tmp/.ansible/files
     validate_certs: False
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
 
 - name: Extract tar file
   unarchive:

--- a/ansible/roles/kubernetes-addons/tasks/cluster-logging.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-logging.yml
@@ -9,8 +9,8 @@
     force=yes
     validate_certs=False
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
   with_items:
     - es-controller.yaml
     - es-service.yaml

--- a/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
@@ -9,8 +9,8 @@
     force=yes
     validate_certs=False
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
   with_items:
     - grafana-service.yaml
     - heapster-controller.yaml

--- a/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
@@ -9,8 +9,8 @@
     force=yes
     validate_certs=False
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
   with_items:
     - kube-ui-rc.yaml
     - kube-ui-svc.yaml

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -18,8 +18,8 @@
     force=yes
     validate_certs=False
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
 
 - include: dns.yml
   when: dns_setup

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -23,8 +23,8 @@
     force=yes
     validate_certs=False
   environment:
-    http_proxy: "{{ http_proxy }}"
-    https_proxy: "{{ https_proxy }}"
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
   when: cluster_logging
 
 - name: Get the node token values


### PR DESCRIPTION
The better fix for this might be putting the variables in
`$role/defaults`, but this works.