### PR TITLE
SubmitQueue: Set as 'Status' in github for every PR

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -668,7 +668,7 @@ func (obj *MungeObject) SetStatus(state, url, description, context string) error
 	config := obj.config
 	status := &github.RepoStatus{
 		State:       &state,
-		URL:         &url,
+		TargetURL:   &url,
 		Description: &description,
 		Context:     &context,
 	}

--- a/mungegithub/mungers/ok-to-test.go
+++ b/mungegithub/mungers/ok-to-test.go
@@ -52,12 +52,8 @@ func (OkToTestMunger) Munge(obj *github.MungeObject) {
 	if !obj.HasLabel("lgtm") {
 		return
 	}
-	status, err := obj.GetStatus([]string{"Jenkins GCE e2e"})
-	if err != nil {
-		glog.Errorf("unexpected error getting status: %v", err)
-		return
-	}
-	if status == "incomplete" {
+	state := obj.GetStatusState([]string{"Jenkins GCE e2e"})
+	if state == "incomplete" {
 		glog.V(2).Infof("status is incomplete, adding ok to test")
 		msg := `@k8s-bot ok to test
 

--- a/mungegithub/mungers/ping_ci.go
+++ b/mungegithub/mungers/ping_ci.go
@@ -63,16 +63,12 @@ func (PingCIMunger) Munge(obj *github.MungeObject) {
 		glog.V(2).Infof("Skipping %d - not mergeable", *obj.Issue.Number)
 		return
 	}
-	if status, err := obj.GetStatus([]string{jenkinsCIContext, travisContext}); err == nil && status != "incomplete" {
+	if state := obj.GetStatusState([]string{jenkinsCIContext, travisContext}); state != "incomplete" {
 		glog.V(2).Info("Have %s status - skipping ping CI", jenkinsCIContext)
 		return
 	}
-	status, err := obj.GetStatus([]string{shippableContext, travisContext})
-	if err != nil {
-		glog.Errorf("unexpected error getting status: %v", err)
-		return
-	}
-	if status == "incomplete" {
+	state := obj.GetStatusState([]string{shippableContext, travisContext})
+	if state == "incomplete" {
 		msg := "Continuous integration appears to have missed, closing and re-opening to trigger it"
 		obj.WriteComment(msg)
 

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -355,7 +355,7 @@ func (sq *SubmitQueue) requiredStatusContexts(obj *github.MungeObject) []string 
 	contexts := sq.RequiredStatusContexts
 
 	// If the pr has a jenkins ci status, require it, otherwise require shippable
-	if status, err := obj.GetStatus([]string{jenkinsCIContext}); err == nil && status != "incomplete" {
+	if state := obj.GetStatusState([]string{jenkinsCIContext}); state != "incomplete" {
 		contexts = append(contexts, jenkinsCIContext)
 	} else {
 		contexts = append(contexts, shippableContext)


### PR DESCRIPTION
As written this will change almost every PR on
https://github.com/kubernetes/kubernetes/pulls to show a yellow dot
instead of a green check (red X will stay red X). That may be a major
issue for some viewers of that page.

At the bottom of github we have statuses for CI, cla, etc. This adds a
status, to all PRs for the submit queue. It will add the same message as
seen below a PR at http://submit-queue.k8s.io in the github UI. These
messages are (hopefully) the correct next step for someone trying to get
their PR merged.

The 'details' link will link back to the submit-queue web page for the
given PR. The PR tab of the web page will not hae any additional useful
information, although the history tab might, if the PR every got greens
across the board.