### PR TITLE
Allow the user to specify the full path for local build install.

### DIFF
--- a/ansible/roles/master/defaults/main.yml
+++ b/ansible/roles/master/defaults/main.yml
@@ -1,3 +1,3 @@
 kube_master_insecure_port: 8080
 
-localBuildOutput: ../../_output/local
+localBuildOutput: ../../_output/local/go/bin

--- a/ansible/roles/master/tasks/localBuildInstall.yml
+++ b/ansible/roles/master/tasks/localBuildInstall.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy master binaries
   copy:
-    src: "{{ localBuildOutput }}/go/bin/{{ item }}"
+    src: "{{ localBuildOutput }}/{{ item }}"
     dest: /usr/bin/
     mode: 0755
   with_items:

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -1,1 +1,1 @@
-localBuildOutput: ../../_output/local
+localBuildOutput: ../../_output/local/go/bin

--- a/ansible/roles/node/tasks/localBuildInstall.yml
+++ b/ansible/roles/node/tasks/localBuildInstall.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy node binaries
   copy:
-    src: "{{ localBuildOutput }}/go/bin/{{ item }}"
+    src: "{{ localBuildOutput }}/{{ item }}"
     dest: /usr/bin/
     mode: 0755
   with_items:


### PR DESCRIPTION
Local build path will be different when using docker build; or when
downloading pre-built binaries from github. Let the user specify the
full path.