### PR TITLE
Make http_proxy configuration work across both RedHat and Debian

### DIFF
--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -18,6 +18,14 @@
   tags:
     - etcd
 
+- hosts: all
+  sudo: yes
+  roles:
+    - common
+    - docker
+  tags:
+    - docker
+
 # install flannel
 - hosts:
     - etcd

--- a/ansible/roles/docker/tasks/apt-docker-install.yml
+++ b/ansible/roles/docker/tasks/apt-docker-install.yml
@@ -1,12 +1,14 @@
 ---
 - name: Install GPG key
-  command: apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+  command: apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 {% if http_proxy is defined -%}--keyserver-options http-proxy={{ http_proxy }} {% endif -%} --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 
 - name: Configure apt repository
   template: src="docker.list.j2" dest="/etc/apt/sources.list.d/docker.list"
+  register: add_apt_source_docker
 
-- name: Update respository information
+- name: Update repository information
   command: apt-get update
+  when: add_apt_source_docker.changed
 
 - name: Install docker engine
   action: "{{ ansible_pkg_mgr }}"

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -8,6 +8,24 @@
 - include: generic-install.yml
   when: ansible_distribution != "Debian" and ansible_distribution != "Ubuntu"
 
+#
+# systemd service configuration uses EnvironmentFile (docker and docker-network)
+# upstart service configuration sources docker_config_dir / docker
+#
+- set_fact:
+    docker_use_upstart: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 15
+
+- name: Local vars for systemd installs
+  set_fact:
+    docker_config_net: "{{ docker_config_dir }}/docker-network"
+    docker_env_export: ""
+
+- name: Local vars for upstart installs
+  set_fact:
+    docker_config_net: "{{ docker_config_dir }}/docker"
+    docker_env_export: "export "
+  when: docker_use_upstart
+
 - name: Verify docker config files exists
   file: path={{ docker_config_dir }}/{{ item }} state=touch
   changed_when: false
@@ -19,22 +37,22 @@
   lineinfile: dest={{ docker_config_dir }}/docker regexp=^OPTIONS= line=OPTIONS="'--selinux-enabled --log-level=warn'"
   notify:
     - restart docker
-  when: ansible_distribution != "Ubuntu"
+  when: docker_use_upstart
 
-- name: Install http_proxy into docker-network
-  lineinfile: dest={{ docker_config_dir }}/docker-network regexp=^HTTP_PROXY= line=HTTP_PROXY="{{ http_proxy }}"
+- name: Install http_proxy into docker(-network)
+  lineinfile: dest={{ docker_config_net }} regexp="^{{ docker_env_export }}http_proxy=" line="{{docker_env_export}}http_proxy={{ http_proxy }}"
   when: http_proxy is defined
   notify:
     - restart docker
 
-- name: Install https_proxy into docker-network
-  lineinfile: dest={{ docker_config_dir }}/docker-network regexp=^HTTPS_PROXY= line=HTTPS_PROXY="{{ https_proxy }}"
+- name: Install https_proxy into docker(-network)
+  lineinfile: dest={{ docker_config_net }} regexp="^{{ docker_env_export }}https_proxy=" line="{{ docker_env_export }}https_proxy={{ https_proxy }}"
   when: https_proxy is defined
   notify:
     - restart docker
 
-- name: Install no-proxy into docker-network
-  lineinfile: dest={{ docker_config_dir }}/docker-network regexp=^NO_PROXY= line=NO_PROXY="{{ no_proxy }}"
+- name: Install no-proxy into docker(-network)
+  lineinfile: dest={{ docker_config_net }} regexp="^{{ docker_env_export }}no_proxy=" line="{{ docker_env_export }}no_proxy={{ no_proxy }}"
   when: no_proxy is defined
   notify:
     - restart docker

--- a/ansible/roles/node/meta/main.yml
+++ b/ansible/roles/node/meta/main.yml
@@ -1,5 +1,4 @@
 ---
 dependencies:
     - { role: common }
-    - { role: docker }
     - { role: kubernetes }

--- a/ansible/roles/opencontrail/meta/main.yml
+++ b/ansible/roles/opencontrail/meta/main.yml
@@ -1,5 +1,4 @@
 ---
 dependencies:
   - { role: common }
-  - { role: docker }
   - { role: kubernetes }


### PR DESCRIPTION
The format for proxy variables is different across RedHat (existing) and Debian based systems (as tested with the apt repository provided by docker).
Make the docker install a separate play, rather than being a dependency so that it is easier to verify.