### PR TITLE
Default path to catch-all if unspecified.

### DIFF
--- a/Ingress/controllers/gce/loadbalancer.go
+++ b/Ingress/controllers/gce/loadbalancer.go
@@ -39,6 +39,9 @@ const (
 	// The host used if none is specified. It is a valid value for Host
 	// recognized by GCE.
 	defaultHost = "*"
+
+	// The path used if none is specified. It is a valid path recognized by GCE.
+	defaultPath = "/*"
 )
 
 // gceUrlMap is a nested map of hostname->path regex->backend

--- a/Ingress/controllers/gce/utils.go
+++ b/Ingress/controllers/gce/utils.go
@@ -163,7 +163,14 @@ func (t *gceTranslator) toUrlMap(ing *extensions.Ingress) (gceUrlMap, error) {
 				// So keep requeuing the l7 till all backends exist.
 				return gceUrlMap{}, err
 			}
-			pathToBackend[p.Path] = backend
+			// The Ingress spec defines empty path as catch-all, so if a user
+			// asks for a single host and multiple empty paths, all traffic is
+			// sent to one of the last backend in the rules list.
+			path := p.Path
+			if path == "" {
+				path = defaultPath
+			}
+			pathToBackend[path] = backend
 		}
 		// If multiple hostless rule sets are specified, last one wins
 		host := rule.Host


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/17348

Fairly simple code reivew, @ArtfulCoder feel free to re-assign or ask for clarification
See https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/extensions/types.go#L571 for path spec.
