### PR TITLE
Add default.conf for nginx-alpha ingress controller

### DIFF
--- a/Ingress/controllers/nginx-alpha/default.conf
+++ b/Ingress/controllers/nginx-alpha/default.conf
@@ -1,0 +1,4 @@
+# A very simple nginx configuration file that forces nginx to start as a daemon.
+events {}
+http {}
+daemon on;


### PR DESCRIPTION
`default.conf` was previously missing and build (e.g. `make container`) fails without it.