### PR TITLE
Fix travis flakes/failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: go
 
 matrix:
   include:
-    - go: 1.4
-    - go: 1.5
+    - go: 1.4.3
+    - go: 1.5.1
 
 install:
   - mkdir -p $HOME/gopath/src/k8s.io


### PR DESCRIPTION
We do a number of things here:
- do not re-use issue numbers
- update golang versions
- break the sleep loop when the test is over
- look for the 'reason' in the history as well as the end result
- add names to the test cases to make figuring out which case failed easier