### PR TITLE
Enable cross-namespace ingress in nginx-alpha ingress controller.

### DIFF
--- a/Ingress/controllers/nginx-alpha/controller.go
+++ b/Ingress/controllers/nginx-alpha/controller.go
@@ -49,7 +49,7 @@ http {
     server_name {{$rule.Host}};
 {{ range $path := $rule.HTTP.Paths }}
     location {{$path.Path}} {
-      proxy_pass http://{{$path.Backend.ServiceName}};
+      proxy_pass http://{{$path.Backend.ServiceName}}.{{$ing.Namespace}}.svc.cluster.local;
     }{{end}}
   }{{end}}{{end}}
 }`


### PR DESCRIPTION
This allows you to run one ingress controller rc and fan out to services in multiple namespaces.