### PR TITLE
Cluster tagging

### DIFF
--- a/Ingress/controllers/gce/backends.go
+++ b/Ingress/controllers/gce/backends.go
@@ -40,7 +40,13 @@ func portKey(port int64) string {
 }
 
 func beName(port int64) string {
-	return fmt.Sprintf("%v-%d", backendPrefix, port)
+	// TODO: Pipe the clusterName through, for now it saves code churn to just
+	// grab it globally, especially since we haven't decided how to handle
+	// namespace conflicts in the Ubernetes context.
+	if *clusterName == "" {
+		return fmt.Sprintf("%v-%d", backendPrefix, port)
+	}
+	return truncate(fmt.Sprintf("%v-%d%v%v", backendPrefix, port, clusterNameDelimiter, *clusterName))
 }
 
 // NewBackendPool returns a new backend pool.

--- a/Ingress/controllers/gce/cluster_manager.go
+++ b/Ingress/controllers/gce/cluster_manager.go
@@ -53,6 +53,9 @@ const (
 
 	// port 0 is used as a signal for port not found/no such port etc.
 	invalidPort = 0
+
+	// Names longer than this are truncated, because of GCE restrictions.
+	nameLenLimit = 62
 )
 
 // ClusterManager manages cluster resource pools.

--- a/Ingress/controllers/gce/controller_test.go
+++ b/Ingress/controllers/gce/controller_test.go
@@ -33,7 +33,7 @@ import (
 // newLoadBalancerController create a loadbalancer controller.
 func newLoadBalancerController(t *testing.T, cm *fakeClusterManager, masterUrl string) *loadBalancerController {
 	client := client.NewOrDie(&client.Config{Host: masterUrl, Version: testapi.Default.Version()})
-	lb, err := NewLoadBalancerController(client, cm.ClusterManager, 1*time.Second)
+	lb, err := NewLoadBalancerController(client, cm.ClusterManager, 1*time.Second, api.NamespaceAll)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/Ingress/controllers/gce/rc.yaml
+++ b/Ingress/controllers/gce/rc.yaml
@@ -24,18 +24,18 @@ metadata:
   name: l7-lb-controller
   labels:
     k8s-app: glbc
-    version: v0.5
+    version: v0.5.1
 spec:
   # There should never be more than 1 controller alive simultaneously.
   replicas: 1
   selector:
     k8s-app: glbc
-    version: v0.5
+    version: v0.5.1
   template:
     metadata:
       labels:
         k8s-app: glbc
-        version: v0.5
+        version: v0.5.1
         name: glbc
     spec:
       terminationGracePeriodSeconds: 600
@@ -61,7 +61,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      - image: gcr.io/google_containers/glbc:0.5
+      - image: gcr.io/google_containers/glbc:0.5.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/Ingress/controllers/gce/utils.go
+++ b/Ingress/controllers/gce/utils.go
@@ -359,3 +359,13 @@ func getNodePort(client *client.Client, ns, name string) (nodePort int64, err er
 	})
 	return
 }
+
+// truncate truncates the given key to a GCE length limit.
+func truncate(key string) string {
+	if len(key) > nameLenLimit {
+		// GCE requires names to end with an albhanumeric, but allows characters
+		// like '-', so make sure the trucated name ends legally.
+		return fmt.Sprintf("%v%v", key[:nameLenLimit], alphaNumericChar)
+	}
+	return key
+}

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -39,7 +39,7 @@ user-whitelist
 whitelist-override-label
 error-page
 balance-algorithm
-gce-cluster-name
+cluster-uid
 sync-period
 delete-all-on-quit
 health-check-path
@@ -48,3 +48,4 @@ etcd-prefix
 etcd-server
 healthz-port
 network-config
+watch-namespace


### PR DESCRIPTION
Tag all resources with user specified cluster name. Useful to match resources with the controller that created them in e2e tests.
