### PR TITLE
First draft of 'shame' report.

### DIFF
--- a/mungegithub/mungegithub.go
+++ b/mungegithub/mungegithub.go
@@ -24,6 +24,7 @@ import (
 
 	github_util "k8s.io/contrib/mungegithub/github"
 	"k8s.io/contrib/mungegithub/mungers"
+	"k8s.io/contrib/mungegithub/reports"
 	"k8s.io/kubernetes/pkg/util"
 
 	"github.com/golang/glog"
@@ -36,15 +37,17 @@ var (
 
 type mungeConfig struct {
 	github_util.Config
-	MinIssueNumber int
-	PRMungersList  []string
-	Once           bool
-	Period         time.Duration
+	MinIssueNumber   int
+	PRMungersList    []string
+	IssueReportsList []string
+	Once             bool
+	Period           time.Duration
 }
 
 func addMungeFlags(config *mungeConfig, cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&config.Once, "once", false, "If true, run one loop and exit")
 	cmd.Flags().StringSliceVar(&config.PRMungersList, "pr-mungers", []string{"blunderbuss", "lgtm-after-commit", "needs-rebase", "ok-to-test", "path-label", "ping-ci", "size", "stale-unit-test", "submit-queue"}, "A list of pull request mungers to run")
+	cmd.Flags().StringSliceVar(&config.IssueReportsList, "issue-reports", []string{}, "A list of issue reports to run. If set, will run the reports and exit.")
 	cmd.Flags().DurationVar(&config.Period, "period", 10*time.Minute, "The period for running mungers")
 }
 
@@ -83,6 +86,9 @@ func main() {
 			if err := config.PreExecute(); err != nil {
 				return err
 			}
+			if len(config.IssueReportsList) > 0 {
+				return reports.RunReports(&config.Config, config.IssueReportsList...)
+			}
 			if len(config.PRMungersList) == 0 {
 				glog.Fatalf("must include at least one --pr-mungers")
 			}
@@ -100,6 +106,11 @@ func main() {
 	allMungers := mungers.GetAllMungers()
 	for _, m := range allMungers {
 		m.AddFlags(root, &config.Config)
+	}
+
+	allReports := reports.GetAllReports()
+	for _, r := range allReports {
+		r.AddFlags(root, &config.Config)
 	}
 
 	if err := root.Execute(); err != nil {

--- a/mungegithub/reports/reports.go
+++ b/mungegithub/reports/reports.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reports
+
+import (
+	"fmt"
+
+	"k8s.io/contrib/mungegithub/github"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+// Report is the interface which all reports must implement to register
+type Report interface {
+	// Take action on a specific github issue:
+	Report(config *github.Config) error
+	AddFlags(cmd *cobra.Command, config *github.Config)
+	Name() string
+}
+
+var reportMap = map[string]Report{}
+var reports = []Report{}
+
+// GetAllReports returns a slice of all registered reports. This list is
+// completely independant of the reports selected at runtime in --pr-reports.
+// This is all possible reports.
+func GetAllReports() []Report {
+	out := []Report{}
+	for _, report := range reportMap {
+		out = append(out, report)
+	}
+	return out
+}
+
+// GetActiveReports returns a slice of all reports which both registered and
+// were requested by the user
+func GetActiveReports() []Report {
+	return reports
+}
+
+// RegisterReport should be called in `init()` by each report to make itself
+// available by name
+func RegisterReport(report Report) error {
+	if _, found := reportMap[report.Name()]; found {
+		return fmt.Errorf("a report with that name (%s) already exists", report.Name())
+	}
+	reportMap[report.Name()] = report
+	glog.Infof("Registered %#v at %s", report, report.Name())
+	return nil
+}
+
+// RegisterReportOrDie will call RegisterReport but will be fatal on error
+func RegisterReportOrDie(report Report) {
+	if err := RegisterReport(report); err != nil {
+		glog.Fatalf("Failed to register report: %s", err)
+	}
+}
+
+// RunReports runs the specified reports.
+func RunReports(cfg *github.Config, runReports ...string) error {
+	for _, name := range runReports {
+		report, ok := reportMap[name]
+		if !ok {
+			return fmt.Errorf("%v: not a valid report", name)
+		}
+		if err := report.Report(cfg); err != nil {
+			return fmt.Errorf("Error running %v: %v", report.Name(), err)
+		}
+	}
+	return nil
+}

--- a/mungegithub/reports/shame.go
+++ b/mungegithub/reports/shame.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reports
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	githubhelper "k8s.io/contrib/mungegithub/github"
+
+	"github.com/google/go-github/github"
+	"github.com/spf13/cobra"
+)
+
+// ShameReport lists flaky tests and writes group+individual email to nag people to fix them.
+type ShameReport struct {
+	Command string
+	From    string
+	Cc      string
+}
+
+func init() {
+	RegisterReportOrDie(&ShameReport{})
+}
+
+// Name is the name usable in --issue-reports
+func (s *ShameReport) Name() string { return "shame" }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (s *ShameReport) AddFlags(cmd *cobra.Command, config *githubhelper.Config) {
+	cmd.Flags().StringVar(&s.Command, "shame-report-cmd", "tee -a shame.txt", "command to execute, passing the report as stdin")
+	cmd.Flags().StringVar(&s.From, "shame-from", "", "From: header for shame report")
+	cmd.Flags().StringVar(&s.Cc, "shame-cc", "", "Cc: header for shame report")
+}
+
+type reportData struct {
+	loginToEmail     map[string]string
+	loginToIssues    map[string][]issueReportData
+	totalTests       int
+	lowPriorityTests int
+}
+
+type issueReportData struct {
+	number   int
+	age      time.Duration
+	priority string
+	title    string
+}
+
+func (self issueReportData) String() string {
+	days := self.age.Hours() / 24
+	return fmt.Sprintf("  [%v] %v: %q (%.2v days)", self.priority, self.number, self.title, days)
+}
+
+func gatherData(cfg *githubhelper.Config) (*reportData, error) {
+	issues, err := cfg.ListAllIssues(&github.IssueListByRepoOptions{
+		State:  "open",
+		Sort:   "created",
+		Labels: []string{"kind/flake"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r := reportData{
+		loginToEmail:  map[string]string{},
+		loginToIssues: map[string][]issueReportData{},
+	}
+	for _, issue := range issues {
+		assignee := "UNASSIGNED"
+		if issue.Assignee != nil && issue.Assignee.Login != nil {
+			assignee = *issue.Assignee.Login
+			if _, ok := r.loginToEmail[assignee]; !ok {
+				if u, err := cfg.GetUser(assignee); err == nil {
+					if u.Email != nil {
+						r.loginToEmail[assignee] = *u.Email
+					} else {
+						// Don't keep looking this up
+						r.loginToEmail[assignee] = ""
+					}
+				}
+			}
+		}
+		age := time.Duration(0)
+		if issue.CreatedAt != nil {
+			age = time.Now().Sub(*issue.CreatedAt)
+		}
+		priority := "??"
+		priorityLabels := githubhelper.GetLabelsWithPrefix(issue.Labels, "priority/")
+		if len(priorityLabels) == 1 {
+			priority = strings.TrimPrefix(priorityLabels[0], "priority/")
+		}
+		if priority == "P2" || priority == "P3" {
+			r.lowPriorityTests++
+			continue
+		}
+		reportData := issueReportData{
+			priority: priority,
+			number:   *issue.Number,
+			title:    *issue.Title,
+			age:      age,
+		}
+		r.loginToIssues[assignee] = append(r.loginToIssues[assignee], reportData)
+		if priority == "??" {
+			const unprioritized = "UNPRIORITIZED"
+			r.loginToIssues[unprioritized] = append(r.loginToIssues[unprioritized], reportData)
+		}
+		r.totalTests++
+	}
+	return &r, nil
+}
+
+func (s *ShameReport) runCmd(r io.Reader) error {
+	args := strings.Split(s.Command, " ")
+	bin := args[0]
+	args = args[1:]
+	cmd := exec.Command(bin, args...)
+	cmd.Stdin = r
+	return cmd.Run()
+}
+
+// Report is the workhorse that actually makes the report.
+func (s *ShameReport) Report(cfg *githubhelper.Config) error {
+	r, err := gatherData(cfg)
+	if err != nil {
+		return err
+	}
+
+	individuals, err := s.groupReport(r)
+	if err != nil {
+		return err
+	}
+	for user := range individuals {
+		if err := s.individualReport(user, r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *ShameReport) groupReport(r *reportData) (map[string]bool, error) {
+	needsIndividualEmail := map[string]bool{}
+	// Gather report body
+	chunks := []string{}
+	for assignee, issues := range r.loginToIssues {
+		strs := []string{}
+		// Exclude issues less than three days old if we can
+		// individually email the owner.
+		for _, data := range issues {
+			if data.age < 3*24*time.Hour && mayEmail(r.loginToEmail[assignee]) {
+				continue
+			}
+			strs = append(strs, data.String())
+		}
+		if len(strs) == 0 {
+			needsIndividualEmail[assignee] = true
+			continue
+		}
+		sort.Strings(strs)
+		chunks = append(chunks, fmt.Sprintf("%v:\n%v", assignee, strings.Join(strs, "\n")))
+	}
+	sort.Strings(chunks)
+
+	// Gather addresses
+	to := []string{}
+	missingAddresses := []string{}
+	for u, e := range r.loginToEmail {
+		if mayEmail(e) {
+			to = append(to, e)
+		} else {
+			missingAddresses = append(missingAddresses, u)
+		}
+	}
+	sort.Strings(to)
+	sort.Strings(missingAddresses)
+
+	dest := &bytes.Buffer{}
+
+	// Write the report
+	if s.From != "" {
+		fmt.Fprintf(dest, "From: %v\n", s.From)
+	}
+	if s.Cc != "" {
+		fmt.Fprintf(dest, "Cc: %v\n", s.Cc)
+	}
+	fmt.Fprintf(dest, "To: %v\n", strings.Join(to, ","))
+	fmt.Fprintf(dest, "Subject: Kubernetes flaky Test Report: %v flaky tests\n", r.totalTests)
+	fmt.Fprintf(dest, `
+If you are in the To: line of this email, you have flaky tests to fix! Flaky
+tests, even if they flake only a small percentage of the time, cause the merge
+queue to become very long, which causes everyone on the team pain and
+suffering.  Please either fix the tests assigned to you or find them an owner
+who will fix them.
+
+There were %v P2/P3 issues which are not reported here.
+
+Full report:
+`, r.lowPriorityTests)
+	fmt.Fprintf(dest, "%s\n", strings.Join(chunks, "\n\n"))
+	if len(missingAddresses) > 0 {
+		fmt.Fprintf(dest, `
+These users couldn't be added to the To: line, as we have no address for them:
+
+%v
+
+Individuals with an accessible email and no assignments older than 3 days will
+be left off the group email, so please make your email address public in github!
+
+Note: non-google users are not emailed by this system.
+
+`, strings.Join(missingAddresses, ", "))
+	}
+
+	return needsIndividualEmail, s.runCmd(dest)
+}
+
+func (s *ShameReport) individualReport(user string, r *reportData) error {
+	// Gather report body
+	issues := r.loginToIssues[user]
+	strs := []string{}
+	for _, data := range issues {
+		strs = append(strs, data.String())
+	}
+	sort.Strings(strs)
+	chunk := fmt.Sprintf("%v:\n%v\n", user, strings.Join(strs, "\n"))
+
+	to := []string{}
+	email := r.loginToEmail[user]
+	if mayEmail(email) {
+		to = append(to, email)
+	}
+	sort.Strings(to)
+
+	dest := &bytes.Buffer{}
+
+	// Write the report
+	if s.From != "" {
+		fmt.Fprintf(dest, "From: %v\n", s.From)
+	}
+	// No Cc on individual emails!
+	fmt.Fprintf(dest, "To: %v\n", strings.Join(to, ","))
+	fmt.Fprint(dest, "Bcc: dbsmith@google.com\n") // so I know it works
+	fmt.Fprintf(dest, "Subject: Kubernetes flaky Test Report: %v flaky tests\n", r.totalTests)
+	fmt.Fprintf(dest, `
+Hi %v,
+
+This is a note to let you know that you have flaky tests assigned to you.
+Owners of tests broken for less than 3 days are left off the group email!
+
+Full report:
+`, user)
+	fmt.Fprint(dest, chunk)
+
+	return s.runCmd(dest)
+}
+
+func mayEmail(email string) bool { return strings.HasSuffix(email, "@google.com") }


### PR DESCRIPTION
This report is intended to be sent as an email. The purpose is to shame people into fixing the flaky tests they own.

Still a bit of a WIP.

Run with the command `$ ./mungegithub --token-file=$HOME/lavalamp-github-token --issue-reports=shame`

It outputs:

```
To: dawnchen@google.com,karl@mesosphere.com,madhusudancs@gmail.com,pmorie@redhat.com,quinton@google.com,vishnuk@google.com
Missing addresses for: ArtfulCoder, bprashanth, brendandburns, davidopp, fgrzadkowski, gmarek, ixdy, jdef, mikedanese, piosz, wojtek-t
Subject: Kubernetes flaky Test Report: 38 flaky tests

If you are in the To: line of this email, you have flaky tests to fix! Flaky
tests, even if they flake only a small percentage of the time, cause the merge
queue to become very long, which causes everyone on the team pain and
suffering.  Please either fix the tests assigned to you or find them an owner
who will fix them.

There were 11 P2/P3 issues which are not reported here.

Full report:
ArtfulCoder:
  [P0] 13818: "flaky/broken e2e: Services should be able to change the type and nodeport settings of a service" (71 days)

UNASSIGNED:
  [P1] 10300: "Lack of visibility/attention to shippable/travis flakes may be hiding real bugs" (1.5e+02 days)
  [P1] 12765: "Flakey Test: Monitoring - should verify monitoring pods and all cluster nodes are available on influxdb using heapster. " (98 days)
  [P1] 13515: "GKE upgrade e2e tests leaking target pools, forwarding rules, and firewall rules" (79 days)
  [P1] 14370: "Document how to write good tests" (59 days)
  [P1] 14691: "oidc.TestOIDCDiscoverySecureConnection Flaky" (53 days)
  [P1] 15381: "Services should work after restarting apiserver flake" (42 days)
  [P1] 16308: "PD E2E Tests could leak PDs in some failure scenarios" (25 days)
  [P1] 17018: "Flaky: k8s.io/kubernetes/pkg/controller/framework_test.TestUpdate" (11 days)
  [P1] 9121: "Flaky test: TestUpgradeResponse" (1.7e+02 days)

UNPRIORITIZED:
  [??] 14931: "cni.TestCNIPlugin flake" (50 days)
  [??] 15412: "[mesos/docker] Flakey Smoke Test - TLS handshake timeout" (42 days)
  [??] 15413: "[mesos/docker] Flakey Smoke Test - provided IP is already allocated" (42 days)
  [??] 15872: "Flaky: Kubectl client Guestbook application should create and stop a working application" (32 days)
  [??] 17181: "exec.TestSelectPlugin is flaky" (8 days)
  [??] 17256: "Flaky Service test in per-PR jenkins" (7 days)
  [??] 17332: "unit test TestGenericScheduler is flaky" (4.1 days)

bprashanth:
  [P0] 17518: "Flaky test: Kubernetes e2e suite.GCE L7 LoadBalancer Controller should create GCE L7 loadbalancers and verify Ingress" (1.1 days)

davidopp:
  [P1] 14421: "runSchedulerNoPhantomPodsTest integration flake" (58 days)

dchen1107:
  [P0] 15498: "e2e: Reboot each node by triggering kernel panic and ensure they function upon restart flaky" (39 days)

fgrzadkowski:
  [P1] 14695: "flaky e2e: Network when a minion node becomes unreachable [replication controller] recreates pods scheduled on the unreachable minion node AND allows scheduling of pods on a minion after it rejoins the cluster" (53 days)
  [P1] 14836: "Visibility into gce-reboot failures is poor" (51 days)

gmarek:
  [P0] 15139: "\"SchedulerPredicates validates MaxPods\" e2e test is flaky" (46 days)

ixdy:
  [P0] 16828: "kubernetes-soak-continuous-e2e-gce-1.1 broken on SchedulerPredicates tests" (16 days)

jdef:
  [P1] 11821: "Flaky: TestDQ_always_pop_earliest_deadline_multi" (1.2e+02 days)
  [P1] 11857: "Flaky: TestDQ_always_pop_earliest_deadline" (1.2e+02 days)

madhusudancs:
  [P0] 17521: "Flake: NodeOutOfDisk runs out of disk space" (1.1 days)

mikedanese:
  [P0] 16385: "e2e flake: failed to initialize within 300 seconds" (24 days)
  [P0] 17583: "Flake: Services should work after restarting kube-proxy" (0.091 days)
  [P1] 13764: "pkg/probe/http fails with Go 1.5 or 1.4" (72 days)
  [P1] 14072: "flaky e2e: Daemon set should launch a daemon pod on every node of the cluster" (65 days)
  [P1] 16623: "e2e flake: Daemon set should run and stop complex daemon" (21 days)

piosz:
  [P0] 17584: "Flake: Horizontal pod autoscaling [Autoscaling Suite] should scale from 1 pod to 3 pods and from 3 to 5 (via deployment, with scale resource: CPU)" (0.09 days)
  [P1] 15496: "Initial Resources should set initial resources based on historical data flaky" (39 days)

pmorie:
  [P1] 13690: "soak test failure: Downward API fails to provide pod IP as an env variable after a while" (73 days)

quinton-hoole:
  [P1] 13062: "Label and move slow e2e tests into a separate test job" (91 days)
  [P1] 13828: "Multiple e2e tests fail with \"Namespace x is active\"" (71 days)

wojtek-t:
  [P1] 14899: "TestMaxInFlight is flaky" (50 days)
```
