### PR TITLE
Add ansible network-service-install tag instead of flannel

### DIFF
--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -35,7 +35,7 @@
   roles:
     - { role: flannel, when: networking == 'flannel' }
   tags:
-    - flannel
+    - network-service-install
 
 # install opencontrail
 - hosts: all


### PR DESCRIPTION
As additional network layers are added to the ansible playbook, it would be good to have a general tag to install and eventually configure the network layer so that a group variable can drive the networking choice and configuration, but the tag will ensure that one of the items is installed.