### PR TITLE
Submit Queue: remove labels which are not correct

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -414,22 +414,42 @@ func (obj *MungeObject) LastModifiedTime() *time.Time {
 	return lastModified
 }
 
-// LabelTime returns the last time the request label was added to an issue.
-// If the label was never added you will get the 0 time.
-func (obj *MungeObject) LabelTime(label string) *time.Time {
+// labelEvent returns the most recent event where the given label was added to an issue
+func (obj *MungeObject) labelEvent(label string) *github.IssueEvent {
 	var labelTime *time.Time
+	var out github.IssueEvent
 	events, err := obj.GetEvents()
 	if err != nil {
-		return labelTime
+		return &out
 	}
 	for _, event := range events {
 		if *event.Event == "labeled" && *event.Label.Name == label {
 			if labelTime == nil || event.CreatedAt.After(*labelTime) {
 				labelTime = event.CreatedAt
+				out = event
 			}
 		}
 	}
-	return labelTime
+	return &out
+}
+
+// LabelTime returns the last time the request label was added to an issue.
+// If the label was never added you will get the 0 time.
+func (obj *MungeObject) LabelTime(label string) *time.Time {
+	event := obj.labelEvent(label)
+	if event == nil {
+		return nil
+	}
+	return event.CreatedAt
+}
+
+// LabelCreator returns the login name of the user who (last) created the given label
+func (obj *MungeObject) LabelCreator(label string) string {
+	event := obj.labelEvent(label)
+	if event == nil {
+		return ""
+	}
+	return *event.Actor.Login
 }
 
 // HasLabel returns if the label `name` is in the array of `labels`
@@ -452,6 +472,16 @@ func (obj *MungeObject) HasLabels(names []string) bool {
 		}
 	}
 	return true
+}
+
+// LabelSet returns the name of all of he labels applied to the object as a
+// kubernetes string set.
+func (obj *MungeObject) LabelSet() sets.String {
+	out := sets.NewString()
+	for _, label := range obj.Issue.Labels {
+		out.Insert(*label.Name)
+	}
+	return out
 }
 
 // GetLabelsWithPrefix will return a slice of all label names in `labels` which

--- a/mungegithub/github/testing/github.go
+++ b/mungegithub/github/testing/github.go
@@ -93,6 +93,7 @@ func Issue(user string, number int, labels []string, isPR bool) *github.Issue {
 // It expresses what label the event should be about and what time
 // the event took place.
 type LabelTime struct {
+	User  string
 	Label string
 	Time  int64
 }
@@ -109,6 +110,9 @@ func Events(labels []LabelTime) []github.IssueEvent {
 				Name: stringPtr(l.Label),
 			},
 			CreatedAt: timePtr(time.Unix(l.Time, 0)),
+			Actor: &github.User{
+				Login: stringPtr(l.User),
+			},
 		}
 		eMap[i] = event
 	}

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -91,25 +91,25 @@ func DontRequireGithubE2EIssue() *github.Issue {
 
 func OldLGTMEvents() []github.IssueEvent {
 	return github_test.Events([]github_test.LabelTime{
-		{"lgtm", 6},
-		{"lgtm", 7},
-		{"lgtm", 8},
+		{"bob", "lgtm", 6},
+		{"bob", "lgtm", 7},
+		{"bob", "lgtm", 8},
 	})
 }
 
 func NewLGTMEvents() []github.IssueEvent {
 	return github_test.Events([]github_test.LabelTime{
-		{"lgtm", 10},
-		{"lgtm", 11},
-		{"lgtm", 12},
+		{"bob", "lgtm", 10},
+		{"bob", "lgtm", 11},
+		{"bob", "lgtm", 12},
 	})
 }
 
 func OverlappingLGTMEvents() []github.IssueEvent {
 	return github_test.Events([]github_test.LabelTime{
-		{"lgtm", 8},
-		{"lgtm", 9},
-		{"lgtm", 10},
+		{"bob", "lgtm", 8},
+		{"bob", "lgtm", 9},
+		{"bob", "lgtm", 10},
 	})
 }
 


### PR DESCRIPTION
If the bot added a label like 'kind/design' or 'kind/new-api' and the PR changes such that the label no longer is appropriate this will remove that label. If a kind/new-api label was added by something other than the bot, it will be left alone, even if the PR does not match the map.