### PR TITLE
Submit Queue: Retest PRs every 48 hours

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -756,6 +756,18 @@ func (obj *MungeObject) IsStatusSuccess(requiredContexts []string) bool {
 	return false
 }
 
+// GetStatusTime returns when the status was set
+func (obj *MungeObject) GetStatusTime(context string) *time.Time {
+	status := obj.GetStatus(context)
+	if status == nil {
+		return nil
+	}
+	if status.UpdatedAt != nil {
+		return status.UpdatedAt
+	}
+	return status.CreatedAt
+}
+
 // Sleep for the given amount of time and then write to the channel
 func timeout(sleepTime time.Duration, c chan bool) {
 	time.Sleep(sleepTime)

--- a/mungegithub/github/testing/github.go
+++ b/mungegithub/github/testing/github.go
@@ -185,8 +185,10 @@ func updateStatusState(status *github.CombinedStatus) *github.CombinedStatus {
 func fillMap(sMap map[int]github.RepoStatus, contexts []string, state string) {
 	for _, context := range contexts {
 		s := github.RepoStatus{
-			Context: stringPtr(context),
-			State:   stringPtr(state),
+			Context:   stringPtr(context),
+			State:     stringPtr(state),
+			UpdatedAt: timePtr(time.Unix(0, 0)),
+			CreatedAt: timePtr(time.Unix(0, 0)),
 		}
 		sMap[len(sMap)] = s
 	}

--- a/mungegithub/mungegithub.go
+++ b/mungegithub/mungegithub.go
@@ -44,7 +44,7 @@ type mungeConfig struct {
 
 func addMungeFlags(config *mungeConfig, cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&config.Once, "once", false, "If true, run one loop and exit")
-	cmd.Flags().StringSliceVar(&config.PRMungersList, "pr-mungers", []string{"blunderbuss", "lgtm-after-commit", "needs-rebase", "ok-to-test", "path-label", "ping-ci", "size", "submit-queue"}, "A list of pull request mungers to run")
+	cmd.Flags().StringSliceVar(&config.PRMungersList, "pr-mungers", []string{"blunderbuss", "lgtm-after-commit", "needs-rebase", "ok-to-test", "path-label", "ping-ci", "size", "stale-unit-test", "submit-queue"}, "A list of pull request mungers to run")
 	cmd.Flags().DurationVar(&config.Period, "period", 10*time.Minute, "The period for running mungers")
 }
 
@@ -86,7 +86,10 @@ func main() {
 			if len(config.PRMungersList) == 0 {
 				glog.Fatalf("must include at least one --pr-mungers")
 			}
-			mungers.InitializeMungers(config.PRMungersList, &config.Config)
+			err := mungers.InitializeMungers(config.PRMungersList, &config.Config)
+			if err != nil {
+				glog.Fatalf("unable to initialize requested mungers: %v", err)
+			}
 			return doMungers(config)
 		},
 	}

--- a/mungegithub/mungers/stale-unit-test.go
+++ b/mungegithub/mungers/stale-unit-test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/contrib/mungegithub/github"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+const (
+	staleHours = 48
+)
+
+// StaleUnitTestMunger will remove the LGTM flag from an PR which has been
+// updated since the reviewer added LGTM
+type StaleUnitTestMunger struct{}
+
+func init() {
+	RegisterMungerOrDie(StaleUnitTestMunger{})
+}
+
+// Name is the name usable in --pr-mungers
+func (StaleUnitTestMunger) Name() string { return "stale-unit-test" }
+
+// Initialize will initialize the munger
+func (StaleUnitTestMunger) Initialize(config *github.Config) error { return nil }
+
+// EachLoop is called at the start of every munge loop
+func (StaleUnitTestMunger) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (StaleUnitTestMunger) AddFlags(cmd *cobra.Command, config *github.Config) {}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (StaleUnitTestMunger) Munge(obj *github.MungeObject) {
+	requiredContexts := []string{jenkinsCIContext, gceE2EContext}
+
+	if !obj.IsPR() {
+		return
+	}
+
+	if !obj.HasLabels([]string{"lgtm"}) {
+		return
+	}
+
+	if mergeable, err := obj.IsMergeable(); !mergeable || err != nil {
+		return
+	}
+
+	if !obj.IsStatusSuccess(requiredContexts) {
+		return
+	}
+
+	for _, context := range requiredContexts {
+		statusTime := obj.GetStatusTime(context)
+		if statusTime == nil {
+			glog.Errorf("%d: unable to determine time %q context was set", *obj.Issue.Number, context)
+			return
+		}
+		if time.Since(*statusTime) > staleHours*time.Hour {
+			msgFormat := `@k8s-bot test this
+
+Tests are more than %d hours old. Re-running tests.`
+			msg := fmt.Sprintf(msgFormat, staleHours)
+			obj.WriteComment(msg)
+			err := obj.WaitForPending(requiredContexts)
+			if err != nil {
+				glog.Errorf("Failed waiting for PR to start testing: %v", err)
+			}
+			return
+		}
+	}
+}

--- a/mungegithub/mungers/stale-unit-test_test.go
+++ b/mungegithub/mungers/stale-unit-test_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	github_util "k8s.io/contrib/mungegithub/github"
+	github_test "k8s.io/contrib/mungegithub/github/testing"
+
+	"github.com/golang/glog"
+	"github.com/google/go-github/github"
+)
+
+var (
+	_ = fmt.Printf
+	_ = glog.Errorf
+)
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+func NowStatus() *github.CombinedStatus {
+	status := github_test.Status("mysha", []string{claContext, shippableContext, travisContext, jenkinsCIContext, gceE2EContext}, nil, nil, nil)
+	for i := range status.Statuses {
+		s := &status.Statuses[i]
+		s.CreatedAt = timePtr(time.Now())
+		s.UpdatedAt = timePtr(time.Now())
+	}
+	return status
+}
+
+func TestOldUnitTestMunge(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	tests := []struct {
+		name     string
+		tested   bool
+		ciStatus *github.CombinedStatus
+	}{
+		{
+			name:     "Test0",
+			tested:   true,
+			ciStatus: SuccessStatus(), // Ran at time.Unix(0,0)
+		},
+		{
+			name:     "Test1",
+			tested:   false,
+			ciStatus: NowStatus(), // Ran at time.Unix(0,0)
+		},
+	}
+	for testNum, test := range tests {
+		issueNum := testNum + 1
+		tested := false
+
+		issue := NoOKToMergeIssue()
+		issue.Number = intPtr(issueNum)
+		pr := ValidPR()
+		pr.Number = intPtr(issueNum)
+		client, server, mux := github_test.InitServer(t, issue, pr, nil, nil, test.ciStatus)
+
+		path := fmt.Sprintf("/repos/o/r/issues/%d/comments", issueNum)
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "POST" {
+				t.Errorf("Unexpected method: %s", r.Method)
+			}
+
+			type comment struct {
+				Body string `json:"body"`
+			}
+			c := new(comment)
+			json.NewDecoder(r.Body).Decode(c)
+			msg := c.Body
+			if strings.HasPrefix(msg, "@k8s-bot test this") {
+				tested = true
+				test.ciStatus.State = stringPtr("pending")
+				for id := range test.ciStatus.Statuses {
+					status := &test.ciStatus.Statuses[id]
+					if *status.Context == gceE2EContext || *status.Context == jenkinsCIContext {
+						status.State = stringPtr("pending")
+						break
+					}
+				}
+
+			}
+			w.WriteHeader(http.StatusOK)
+			data, err := json.Marshal(github.IssueComment{})
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			w.Write(data)
+		})
+
+		config := &github_util.Config{}
+		config.Org = "o"
+		config.Project = "r"
+		config.SetClient(client)
+
+		s := StaleUnitTestMunger{}
+		err := s.Initialize(config)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		obj, err := config.GetObject(issueNum)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		s.Munge(obj)
+
+		if tested != test.tested {
+			t.Errorf("%d:%s tested=%t but should be %t", testNum, test.name, tested, test.tested)
+		}
+		server.Close()
+	}
+}

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -41,6 +41,7 @@ var (
 
 func stringPtr(val string) *string { return &val }
 func boolPtr(val bool) *bool       { return &val }
+func intPtr(val int) *int          { return &val }
 
 const noWhitelistUser = "UserNotInWhitelist"
 const whitelistUser = "WhitelistUser"


### PR DESCRIPTION
We don't actually test every PR every 48 hours. Only those which seem close to merge. They have LGTM, their tests look good, etc.  If this were to run right this instant, it would hit against 4 PRs.