### PR TITLE
Ansible tasks to install latest version of Docker

### DIFF
--- a/ansible/roles/docker/tasks/getdocker-install.yml
+++ b/ansible/roles/docker/tasks/getdocker-install.yml
@@ -1,0 +1,26 @@
+---
+- name: get.docker.com | Create temp dir
+  local_action: command mktemp -d -t docker.XXXXXXXXXX
+  register: docker_temp_dir
+  sudo: no
+
+- name: get.docker.com | Create remote temp dir
+  command: mktemp -d -t docker.XXXXXXXXXX
+  register: remote_docker_temp_dir
+
+- name: get.docker.com | Download Docker shell script locally to workaround SNI 
+  local_action: get_url url=https://get.docker.com dest="{{ docker_temp_dir.stdout }}/docker-install.sh"
+  sudo: no
+
+- name: get.docker.com | Copy the Docker installer to remote
+  copy: src="{{ docker_temp_dir.stdout }}/docker-install.sh" dest={{ remote_docker_temp_dir.stdout }}/docker-install.sh mode=0755
+
+- name: get.docker.com | Install latest Docker
+  command: "{{ remote_docker_temp_dir.stdout }}/docker-install.sh"
+
+- name: get.docker.com | Clean Up Remote
+  file: path="{{ remote_docker_temp_dir.stdout }}" state=absent
+
+- name: get.docker.com | Clean up locally
+  local_action: file path="{{ docker_temp_dir.stdout }}" state=absent
+  sudo: no

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,12 +1,15 @@
 ---
 - include: debian-install.yml
-  when: ansible_distribution == "Debian"
+  when: ansible_distribution == "Debian" and source_type == "packageManager"
 
 - include: apt-docker-install.yml
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_distribution == "Ubuntu" and source_type == "packageManager"
 
 - include: generic-install.yml
-  when: ansible_distribution != "Debian" and ansible_distribution != "Ubuntu"
+  when: ansible_distribution != "Debian" and ansible_distribution != "Ubuntu" and source_type == "packageManager"
+
+- include: getdocker-install.yml
+  when: source_type == "localBuild"
 
 #
 # systemd service configuration uses EnvironmentFile (docker and docker-network)


### PR DESCRIPTION
I ran the Ansible playbook on CentOS 7 and it installed Docker 1.8 rather than 1.9.  I'm assuming that someone that wants a `localBuild` rather than `packageManager` for Kubernetes probably wants the latest for Docker too.  I certainly did.

I'm downloading the script locally first so that I don't have to use the `validate_certs=False` to work around SNI and Python.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/291)

<!-- Reviewable:end -->
