### PR TITLE
Delay starting services until network is actually up

### DIFF
--- a/ansible/roles/master/files/delay-master-services.target
+++ b/ansible/roles/master/files/delay-master-services.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Delay Kubernetes services until network is actually online
+Wants=network-online.target
+After=network-online.target
+Before=flanneld.service
+Before=kube-apiserver.service
+
+[Install]
+WantedBy=flanneld.service
+WantedBy=kube-apiserver.service

--- a/ansible/roles/master/tasks/main.yml
+++ b/ansible/roles/master/tasks/main.yml
@@ -82,6 +82,12 @@
   service: name=kubelet enabled=yes state=started
   when: networking == 'opencontrail'
 
+- name: write the delay-master-services target
+  copy: src=delay-master-services.target dest=/etc/systemd/system/ mode=0644
+
+- name: Enable delay-master-services
+  service: name=delay-master-services.target enabled=yes
+
 - include: firewalld.yml
   when: has_firewalld
 

--- a/ansible/roles/node/files/delay-node-services.target
+++ b/ansible/roles/node/files/delay-node-services.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Delay Kubernetes services until network is actually online
+Wants=network-online.target
+After=network-online.target
+Before=flanneld.service
+Before=kube-proxy.service
+
+[Install]
+WantedBy=flanneld.service
+WantedBy=kube-proxy.service

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -70,6 +70,12 @@
   service: name=kube-proxy enabled=yes state=started
   when: networking != "opencontrail"
 
+- name: write the delay-node-services target
+  copy: src=delay-node-services.target dest=/etc/systemd/system/ mode=0644
+
+- name: Enable delay-node-services
+  service: name=delay-node-services.target enabled=yes
+
 - include: firewalld.yml
   when: has_firewalld
 


### PR DESCRIPTION
Some services may attempt to start before a network interface is up, and then fail badly. A simple master or node server reboot is enough to reproduce - it will fail to bring up all required services more often than not (tested on Fedora 23). The services in question are:

- flanneld and kube-apiserver (on masters)
- flanneld and kube-proxy (on minion nodes)

The systemd unit files could have been updated directly to fix this, but as flanneld is installed from a distro package, a less invasive approach was taken instead: A dummy systemd target unit is introduced, which starts after network-online.target, but before the fragile services.