### PR TITLE
Merge Bot: Fix infinite loop possible with missing CI tests

### DIFF
--- a/mungegithub/mungers/ok-to-test.go
+++ b/mungegithub/mungers/ok-to-test.go
@@ -52,12 +52,13 @@ func (OkToTestMunger) Munge(obj *github.MungeObject) {
 	if !obj.HasLabel("lgtm") {
 		return
 	}
-	state := obj.GetStatusState([]string{"Jenkins GCE e2e"})
+	state := obj.GetStatusState([]string{jenkinsE2EContext, jenkinsUnitContext})
 	if state == "incomplete" {
 		glog.V(2).Infof("status is incomplete, adding ok to test")
 		msg := `@k8s-bot ok to test
+@k8s-bot test this
 
-	pr builder appears to be missing, activating due to 'lgtm' label.`
+pr builder appears to be missing, activating due to 'lgtm' label.`
 		obj.WriteComment(msg)
 	}
 }

--- a/mungegithub/mungers/ping_ci.go
+++ b/mungegithub/mungers/ping_ci.go
@@ -63,8 +63,8 @@ func (PingCIMunger) Munge(obj *github.MungeObject) {
 		glog.V(2).Infof("Skipping %d - not mergeable", *obj.Issue.Number)
 		return
 	}
-	if state := obj.GetStatusState([]string{jenkinsCIContext, travisContext}); state != "incomplete" {
-		glog.V(2).Info("Have %s status - skipping ping CI", jenkinsCIContext)
+	if state := obj.GetStatusState([]string{jenkinsUnitContext, travisContext}); state != "incomplete" {
+		glog.V(2).Info("Have %s status - skipping ping CI", jenkinsUnitContext)
 		return
 	}
 	state := obj.GetStatusState([]string{shippableContext, travisContext})

--- a/mungegithub/mungers/ping_ci.go
+++ b/mungegithub/mungers/ping_ci.go
@@ -67,7 +67,7 @@ func (PingCIMunger) Munge(obj *github.MungeObject) {
 		glog.V(2).Info("Have %s status - skipping ping CI", jenkinsUnitContext)
 		return
 	}
-	state := obj.GetStatusState([]string{shippableContext, travisContext})
+	state := obj.GetStatusState([]string{travisContext})
 	if state == "incomplete" {
 		msg := "Continuous integration appears to have missed, closing and re-opening to trigger it"
 		obj.WriteComment(msg)

--- a/mungegithub/mungers/ping_ci.go
+++ b/mungegithub/mungers/ping_ci.go
@@ -56,20 +56,15 @@ func (PingCIMunger) Munge(obj *github.MungeObject) {
 	}
 	mergeable, err := obj.IsMergeable()
 	if err != nil {
-		glog.V(2).Infof("Skipping %d - problem determining mergeability", *obj.Issue.Number)
+		glog.V(2).Infof("ping CI skipping %d - problem determining mergeability", *obj.Issue.Number)
 		return
 	}
 	if !mergeable {
-		glog.V(2).Infof("Skipping %d - not mergeable", *obj.Issue.Number)
+		glog.V(2).Infof("ping CI skipping %d - not mergeable", *obj.Issue.Number)
 		return
 	}
-	if state := obj.GetStatusState([]string{jenkinsUnitContext, travisContext}); state != "incomplete" {
-		glog.V(2).Info("Have %s status - skipping ping CI", jenkinsUnitContext)
-		return
-	}
-	state := obj.GetStatusState([]string{travisContext})
-	if state == "incomplete" {
-		msg := "Continuous integration appears to have missed, closing and re-opening to trigger it"
+	if state := obj.GetStatusState([]string{travisContext}); state == "incomplete" {
+		msg := "Travis continuous integration appears to have missed, closing and re-opening to trigger it"
 		obj.WriteComment(msg)
 
 		obj.ClosePR()

--- a/mungegithub/mungers/stale-unit-test.go
+++ b/mungegithub/mungers/stale-unit-test.go
@@ -52,7 +52,7 @@ func (StaleUnitTestMunger) AddFlags(cmd *cobra.Command, config *github.Config) {
 
 // Munge is the workhorse the will actually make updates to the PR
 func (StaleUnitTestMunger) Munge(obj *github.MungeObject) {
-	requiredContexts := []string{jenkinsCIContext, gceE2EContext}
+	requiredContexts := []string{jenkinsUnitContext, jenkinsE2EContext}
 
 	if !obj.IsPR() {
 		return

--- a/mungegithub/mungers/stale-unit-test_test.go
+++ b/mungegithub/mungers/stale-unit-test_test.go
@@ -40,7 +40,7 @@ var (
 func timePtr(t time.Time) *time.Time { return &t }
 
 func NowStatus() *github.CombinedStatus {
-	status := github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsUnitContext, jenkinsE2EContext}, nil, nil, nil)
+	status := github_test.Status("mysha", []string{travisContext, jenkinsUnitContext, jenkinsE2EContext}, nil, nil, nil)
 	for i := range status.Statuses {
 		s := &status.Statuses[i]
 		s.CreatedAt = timePtr(time.Now())

--- a/mungegithub/mungers/stale-unit-test_test.go
+++ b/mungegithub/mungers/stale-unit-test_test.go
@@ -40,7 +40,7 @@ var (
 func timePtr(t time.Time) *time.Time { return &t }
 
 func NowStatus() *github.CombinedStatus {
-	status := github_test.Status("mysha", []string{claContext, shippableContext, travisContext, jenkinsCIContext, gceE2EContext}, nil, nil, nil)
+	status := github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsCIContext, gceE2EContext}, nil, nil, nil)
 	for i := range status.Statuses {
 		s := &status.Statuses[i]
 		s.CreatedAt = timePtr(time.Now())

--- a/mungegithub/mungers/stale-unit-test_test.go
+++ b/mungegithub/mungers/stale-unit-test_test.go
@@ -40,7 +40,7 @@ var (
 func timePtr(t time.Time) *time.Time { return &t }
 
 func NowStatus() *github.CombinedStatus {
-	status := github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsCIContext, gceE2EContext}, nil, nil, nil)
+	status := github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsUnitContext, jenkinsE2EContext}, nil, nil, nil)
 	for i := range status.Statuses {
 		s := &status.Statuses[i]
 		s.CreatedAt = timePtr(time.Now())
@@ -95,7 +95,7 @@ func TestOldUnitTestMunge(t *testing.T) {
 				test.ciStatus.State = stringPtr("pending")
 				for id := range test.ciStatus.Statuses {
 					status := &test.ciStatus.Statuses[id]
-					if *status.Context == gceE2EContext || *status.Context == jenkinsCIContext {
+					if *status.Context == jenkinsE2EContext || *status.Context == jenkinsUnitContext {
 						status.State = stringPtr("pending")
 						break
 					}

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -39,11 +39,11 @@ const (
 	claYes              = "cla: yes"
 	claHuman            = "cla: human-approved"
 
-	shippableContext = "Shippable"
-	gceE2EContext    = "Jenkins GCE e2e"
-	jenkinsCIContext = "Jenkins unit/integration"
-	travisContext    = "continuous-integration/travis-ci/pr"
-	sqContext        = "Submit Queue"
+	shippableContext   = "Shippable"
+	jenkinsE2EContext  = "Jenkins GCE e2e"
+	jenkinsUnitContext = "Jenkins unit/integration"
+	travisContext      = "continuous-integration/travis-ci/pr"
+	sqContext          = "Submit Queue"
 )
 
 var (
@@ -205,7 +205,7 @@ func (sq *SubmitQueue) AddFlags(cmd *cobra.Command, config *github.Config) {
 	cmd.Flags().StringSliceVar(&sq.RequiredStatusContexts, "required-contexts", []string{travisContext}, "Comma separate list of status contexts required for a PR to be considered ok to merge")
 	cmd.Flags().StringVar(&sq.Address, "address", ":8080", "The address to listen on for HTTP Status")
 	cmd.Flags().StringVar(&sq.DontRequireE2ELabel, "dont-require-e2e-label", "e2e-not-required", "If non-empty, a PR with this label will be merged automatically without looking at e2e results")
-	cmd.Flags().StringVar(&sq.E2EStatusContext, "e2e-status-context", gceE2EContext, "The name of the github status context for the e2e PR Builder")
+	cmd.Flags().StringVar(&sq.E2EStatusContext, "e2e-status-context", jenkinsE2EContext, "The name of the github status context for the e2e PR Builder")
 	cmd.Flags().StringVar(&sq.WWWRoot, "www", "www", "Path to static web files to serve from the webserver")
 	sq.addWhitelistCommand(cmd, config)
 }
@@ -390,8 +390,8 @@ func (sq *SubmitQueue) requiredStatusContexts(obj *github.MungeObject) []string 
 	contexts := sq.RequiredStatusContexts
 
 	// If the pr has a jenkins ci status, require it, otherwise require shippable
-	if state := obj.GetStatusState([]string{jenkinsCIContext}); state != "incomplete" {
-		contexts = append(contexts, jenkinsCIContext)
+	if state := obj.GetStatusState([]string{jenkinsUnitContext}); state != "incomplete" {
+		contexts = append(contexts, jenkinsUnitContext)
 	} else {
 		contexts = append(contexts, shippableContext)
 	}

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -201,7 +201,7 @@ func (sq *SubmitQueue) AddFlags(cmd *cobra.Command, config *github.Config) {
 		"kubernetes-kubemark-gce",
 	}, "Comma separated list of jobs in Jenkins to use for stability testing")
 	cmd.Flags().StringVar(&sq.JenkinsHost, "jenkins-host", "http://jenkins-master:8080", "The URL for the jenkins job to watch")
-	cmd.Flags().StringSliceVar(&sq.RequiredStatusContexts, "required-contexts", []string{travisContext}, "Comma separate list of status contexts required for a PR to be considered ok to merge")
+	cmd.Flags().StringSliceVar(&sq.RequiredStatusContexts, "required-contexts", []string{travisContext, jenkinsUnitContext}, "Comma separate list of status contexts required for a PR to be considered ok to merge")
 	cmd.Flags().StringVar(&sq.Address, "address", ":8080", "The address to listen on for HTTP Status")
 	cmd.Flags().StringVar(&sq.E2EStatusContext, "e2e-status-context", jenkinsE2EContext, "The name of the github status context for the e2e PR Builder")
 	cmd.Flags().StringVar(&sq.WWWRoot, "www", "www", "Path to static web files to serve from the webserver")
@@ -386,9 +386,6 @@ const (
 
 func (sq *SubmitQueue) requiredStatusContexts(obj *github.MungeObject) []string {
 	contexts := sq.RequiredStatusContexts
-
-	contexts = append(contexts, jenkinsUnitContext)
-
 	if len(sq.E2EStatusContext) > 0 && !obj.HasLabel(e2eNotRequiredLabel) {
 		contexts = append(contexts, sq.E2EStatusContext)
 	}

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -36,14 +36,14 @@ import (
 
 const (
 	needsOKToMergeLabel = "needs-ok-to-merge"
-	claContext          = "cla/google"
-	gceE2EContext       = "Jenkins GCE e2e"
-	jenkinsCIContext    = "Jenkins unit/integration"
-	shippableContext    = "Shippable"
-	travisContext       = "continuous-integration/travis-ci/pr"
 	claYes              = "cla: yes"
 	claHuman            = "cla: human-approved"
-	sqContext           = "Submit Queue"
+
+	shippableContext = "Shippable"
+	gceE2EContext    = "Jenkins GCE e2e"
+	jenkinsCIContext = "Jenkins unit/integration"
+	travisContext    = "continuous-integration/travis-ci/pr"
+	sqContext        = "Submit Queue"
 )
 
 var (

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -39,7 +39,6 @@ const (
 	claYes              = "cla: yes"
 	claHuman            = "cla: human-approved"
 
-	shippableContext   = "Shippable"
 	jenkinsE2EContext  = "Jenkins GCE e2e"
 	jenkinsUnitContext = "Jenkins unit/integration"
 	travisContext      = "continuous-integration/travis-ci/pr"
@@ -389,12 +388,8 @@ const (
 func (sq *SubmitQueue) requiredStatusContexts(obj *github.MungeObject) []string {
 	contexts := sq.RequiredStatusContexts
 
-	// If the pr has a jenkins ci status, require it, otherwise require shippable
-	if state := obj.GetStatusState([]string{jenkinsUnitContext}); state != "incomplete" {
-		contexts = append(contexts, jenkinsUnitContext)
-	} else {
-		contexts = append(contexts, shippableContext)
-	}
+	contexts = append(contexts, jenkinsUnitContext)
+
 	if len(sq.E2EStatusContext) > 0 && (len(sq.DontRequireE2ELabel) == 0 || !obj.HasLabel(sq.DontRequireE2ELabel)) {
 		contexts = append(contexts, sq.E2EStatusContext)
 	}

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -121,19 +121,11 @@ func Commits() []github.RepositoryCommit {
 }
 
 func SuccessStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsUnitContext, jenkinsE2EContext}, nil, nil, nil)
-}
-
-func JenkinsCIGreenShippablePendingStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{jenkinsUnitContext, travisContext, jenkinsE2EContext}, nil, []string{shippableContext}, nil)
-}
-
-func ShippableGreenStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsE2EContext}, nil, nil, nil)
+	return github_test.Status("mysha", []string{travisContext, jenkinsUnitContext, jenkinsE2EContext}, nil, nil, nil)
 }
 
 func GithubE2EFailStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{shippableContext, travisContext}, []string{jenkinsE2EContext}, nil, nil)
+	return github_test.Status("mysha", []string{travisContext, jenkinsUnitContext}, []string{jenkinsE2EContext}, nil, nil)
 }
 
 func SuccessJenkins() jenkins.Job {
@@ -403,35 +395,9 @@ func TestMunge(t *testing.T) {
 			reason:     ghE2EFailed,
 			state:      "pending",
 		},
-		// Should pass because the jenkins ci is green even tho shippable is pending.
-		{
-			name:       "Test15",
-			pr:         ValidPR(),
-			issue:      NoOKToMergeIssue(),
-			events:     NewLGTMEvents(),
-			commits:    Commits(),
-			ciStatus:   JenkinsCIGreenShippablePendingStatus(),
-			jenkinsJob: SuccessJenkins(),
-			shouldPass: true,
-			reason:     merged,
-			state:      "success",
-		},
-		// Should pass because the shippable is green (no jenkins ci).
-		{
-			name:       "Test16",
-			pr:         ValidPR(),
-			issue:      NoOKToMergeIssue(),
-			events:     NewLGTMEvents(),
-			commits:    Commits(),
-			ciStatus:   ShippableGreenStatus(),
-			jenkinsJob: SuccessJenkins(),
-			shouldPass: true,
-			reason:     merged,
-			state:      "success",
-		},
 		// When we check the reason it may be queued or it may already have failed.
 		{
-			name:       "Test17",
+			name:       "Test15",
 			pr:         ValidPR(),
 			issue:      NoOKToMergeIssue(),
 			ciStatus:   SuccessStatus(),
@@ -447,7 +413,7 @@ func TestMunge(t *testing.T) {
 		},
 		// Fail because the second run of github e2e tests failed
 		{
-			name:       "Test18",
+			name:       "Test16",
 			pr:         ValidPR(),
 			issue:      NoOKToMergeIssue(),
 			ciStatus:   SuccessStatus(),

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -121,19 +121,19 @@ func Commits() []github.RepositoryCommit {
 }
 
 func SuccessStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{claContext, shippableContext, travisContext, jenkinsCIContext, gceE2EContext}, nil, nil, nil)
+	return github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsCIContext, gceE2EContext}, nil, nil, nil)
 }
 
 func JenkinsCIGreenShippablePendingStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{claContext, jenkinsCIContext, travisContext, gceE2EContext}, nil, []string{shippableContext}, nil)
+	return github_test.Status("mysha", []string{jenkinsCIContext, travisContext, gceE2EContext}, nil, []string{shippableContext}, nil)
 }
 
 func ShippableGreenStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{claContext, shippableContext, travisContext, gceE2EContext}, nil, nil, nil)
+	return github_test.Status("mysha", []string{shippableContext, travisContext, gceE2EContext}, nil, nil, nil)
 }
 
 func GithubE2EFailStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{claContext, shippableContext, travisContext}, []string{gceE2EContext}, nil, nil)
+	return github_test.Status("mysha", []string{shippableContext, travisContext}, []string{gceE2EContext}, nil, nil)
 }
 
 func SuccessJenkins() jenkins.Job {
@@ -559,7 +559,7 @@ func TestMunge(t *testing.T) {
 		})
 
 		sq := SubmitQueue{}
-		sq.RequiredStatusContexts = []string{claContext}
+		sq.RequiredStatusContexts = []string{}
 		sq.DontRequireE2ELabel = "e2e-not-required"
 		sq.E2EStatusContext = gceE2EContext
 		sq.JenkinsHost = server.URL

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -526,7 +526,6 @@ func TestMunge(t *testing.T) {
 
 		sq := SubmitQueue{}
 		sq.RequiredStatusContexts = []string{}
-		sq.DontRequireE2ELabel = "e2e-not-required"
 		sq.E2EStatusContext = jenkinsE2EContext
 		sq.JenkinsHost = server.URL
 		sq.JenkinsJobs = []string{"foo"}

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -121,19 +121,19 @@ func Commits() []github.RepositoryCommit {
 }
 
 func SuccessStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsCIContext, gceE2EContext}, nil, nil, nil)
+	return github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsUnitContext, jenkinsE2EContext}, nil, nil, nil)
 }
 
 func JenkinsCIGreenShippablePendingStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{jenkinsCIContext, travisContext, gceE2EContext}, nil, []string{shippableContext}, nil)
+	return github_test.Status("mysha", []string{jenkinsUnitContext, travisContext, jenkinsE2EContext}, nil, []string{shippableContext}, nil)
 }
 
 func ShippableGreenStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{shippableContext, travisContext, gceE2EContext}, nil, nil, nil)
+	return github_test.Status("mysha", []string{shippableContext, travisContext, jenkinsE2EContext}, nil, nil, nil)
 }
 
 func GithubE2EFailStatus() *github.CombinedStatus {
-	return github_test.Status("mysha", []string{shippableContext, travisContext}, []string{gceE2EContext}, nil, nil)
+	return github_test.Status("mysha", []string{shippableContext, travisContext}, []string{jenkinsE2EContext}, nil, nil)
 }
 
 func SuccessJenkins() jenkins.Job {
@@ -209,7 +209,7 @@ func fakeRunGithubE2ESuccess(ciStatus *github.CombinedStatus, shouldPass bool) {
 	ciStatus.State = stringPtr("pending")
 	for id := range ciStatus.Statuses {
 		status := &ciStatus.Statuses[id]
-		if *status.Context == gceE2EContext {
+		if *status.Context == jenkinsE2EContext {
 			status.State = stringPtr("pending")
 			break
 		}
@@ -220,7 +220,7 @@ func fakeRunGithubE2ESuccess(ciStatus *github.CombinedStatus, shouldPass bool) {
 	found := false
 	for id := range ciStatus.Statuses {
 		status := &ciStatus.Statuses[id]
-		if *status.Context == gceE2EContext {
+		if *status.Context == jenkinsE2EContext {
 			if shouldPass {
 				status.State = stringPtr("success")
 			} else {
@@ -232,7 +232,7 @@ func fakeRunGithubE2ESuccess(ciStatus *github.CombinedStatus, shouldPass bool) {
 	}
 	if !found {
 		e2eStatus := github.RepoStatus{
-			Context: stringPtr(gceE2EContext),
+			Context: stringPtr(jenkinsE2EContext),
 			State:   stringPtr("success"),
 		}
 		ciStatus.Statuses = append(ciStatus.Statuses, e2eStatus)
@@ -561,7 +561,7 @@ func TestMunge(t *testing.T) {
 		sq := SubmitQueue{}
 		sq.RequiredStatusContexts = []string{}
 		sq.DontRequireE2ELabel = "e2e-not-required"
-		sq.E2EStatusContext = gceE2EContext
+		sq.E2EStatusContext = jenkinsE2EContext
 		sq.JenkinsHost = server.URL
 		sq.JenkinsJobs = []string{"foo"}
 		sq.WhitelistOverride = "ok-to-merge"

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -525,7 +525,7 @@ func TestMunge(t *testing.T) {
 		})
 
 		sq := SubmitQueue{}
-		sq.RequiredStatusContexts = []string{}
+		sq.RequiredStatusContexts = []string{jenkinsUnitContext}
 		sq.E2EStatusContext = jenkinsE2EContext
 		sq.JenkinsHost = server.URL
 		sq.JenkinsJobs = []string{"foo"}


### PR DESCRIPTION
Number of cleanups, but the main fix is in the last commit. After we stop paying attention to shippable altogether we can simplify the `ping_ci` and `ok-to-test` mungers. ping_ci was able to go into an infinite loop. Ping CI seemed to be able to trigger a bug in jenkins where only the e2e was getting run, instead of both e2e and unit. So make sure we get both of them.