### PR TITLE
SubmitQueue: Less log spam when we run out of tokens

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -60,7 +60,11 @@ func (c *callLimitRoundTripper) getTokenExcept(remaining int) {
 	resetTime := c.resetTime
 	c.Unlock()
 	sleepTime := resetTime.Sub(time.Now()) + (1 * time.Minute)
-	glog.Errorf("Ran out of github API tokens. Sleeping for %v minutes", sleepTime.Minutes())
+	if sleepTime > 0 {
+		glog.Errorf("*****************")
+		glog.Errorf("Ran out of github API tokens. Sleeping for %v minutes", sleepTime.Minutes())
+		glog.Errorf("*****************")
+	}
 	// negative duration is fine, it means we are past the github api reset and we won't sleep
 	time.Sleep(sleepTime)
 }


### PR DESCRIPTION
The spam was nice, since it was easy to find, but it was bad, because
all of the 'negative' sleeps weren't really sleeps. No one will see this
unless they look at the container logs.