### PR TITLE
Submit Queue: better track github rate limit tokens

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -60,7 +60,11 @@ func (c *callLimitRoundTripper) getTokenExcept(remaining int) {
 	resetTime := c.resetTime
 	c.Unlock()
 	sleepTime := resetTime.Sub(time.Now()) + (1 * time.Minute)
-	glog.Errorf("Ran out of github API tokens. Sleeping for %v minutes", sleepTime.Minutes())
+	if sleepTime > 0 {
+		glog.Errorf("*****************")
+		glog.Errorf("Ran out of github API tokens. Sleeping for %v minutes", sleepTime.Minutes())
+		glog.Errorf("*****************")
+	}
 	// negative duration is fine, it means we are past the github api reset and we won't sleep
 	time.Sleep(sleepTime)
 }


### PR DESCRIPTION
The code would collect how many tokens were left at the end of the loop
but when the tokens would reset at the beginning of the next loop. So if
we slept just before a token reset we would wake up thinking we didn't
have many tokens and that the next reset was an hour away.

This parses the github headers on every API response and updates the
timeout and remaining count. Thus we should always be correct.