### PR TITLE
Fixups for release-notes.go: end-of-branch issues, API rate limiting, and release-note filter flag

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -1,4 +1,3 @@
-Found flags in golang files not in the list of known flags. Please add these to hack/verify-flags/known-flags.txt
 api-token
 balance-algorithm
 blunderbuss-config
@@ -35,6 +34,7 @@ poll-period
 pr-mungers
 rate-limit
 rate-limit-burst
+relnote-filter
 required-contexts
 running-in-cluster
 shame-cc

--- a/release-notes/release-notes.go
+++ b/release-notes/release-notes.go
@@ -97,6 +97,10 @@ func main() {
 		}
 		unmerged := 0
 		merged := 0
+		if len(results) == 0 {
+			done = true
+			break
+		}
 		for ix := range results {
 			result := &results[ix]
 			// Skip Closed but not Merged PRs
@@ -130,6 +134,7 @@ func main() {
 			// Check to see if it has the release-note label.
 			fmt.Printf(".")
 			labels, _, err := client.Issues.ListLabelsByIssue("kubernetes", "kubernetes", *pr.Number, &github.ListOptions{})
+			time.Sleep(5 * time.Second)
 			if err != nil {
 				fmt.Printf("Error contacting github: %v", err)
 				os.Exit(1)

--- a/release-notes/release-notes.go
+++ b/release-notes/release-notes.go
@@ -30,10 +30,11 @@ import (
 )
 
 var (
-	base    string
-	last    int
-	current int
-	token   string
+	base          string
+	last          int
+	current       int
+	token         string
+	relnoteFilter bool
 )
 
 type byMerged []*github.PullRequest
@@ -47,6 +48,7 @@ func init() {
 	flag.IntVar(&current, "current-release-pr", 0, "The PR number of the current versioned release.")
 	flag.StringVar(&token, "api-token", "", "Github api token for rate limiting. Background: https://developer.github.com/v3/#rate-limiting and create a token: https://github.com/settings/tokens")
 	flag.StringVar(&base, "base", "master", "The base branch name for PRs to look for.")
+	flag.BoolVar(&relnoteFilter, "relnote-filter", true, "Whether to filter PRs by the release-note label.")
 }
 
 func usage() {
@@ -131,17 +133,22 @@ func main() {
 	buffer := &bytes.Buffer{}
 	for _, pr := range prs {
 		if lastVersionMerged.Before(*pr.MergedAt) && (pr.MergedAt.Before(*currentVersionMerged) || (*pr.Number == current)) {
-			// Check to see if it has the release-note label.
-			fmt.Printf(".")
-			labels, _, err := client.Issues.ListLabelsByIssue("kubernetes", "kubernetes", *pr.Number, &github.ListOptions{})
-			time.Sleep(5 * time.Second)
-			if err != nil {
-				fmt.Printf("Error contacting github: %v", err)
-				os.Exit(1)
-			}
-			for _, label := range labels {
-				if *label.Name == "release-note" {
-					fmt.Fprintf(buffer, "   * %s (#%d, @%s)\n", *pr.Title, *pr.Number, *pr.User.Login)
+			if !relnoteFilter {
+				fmt.Fprintf(buffer, "   * %s (#%d, @%s)\n", *pr.Title, *pr.Number, *pr.User.Login)
+			} else {
+				// Check to see if it has the release-note label.
+				fmt.Printf(".")
+				labels, _, err := client.Issues.ListLabelsByIssue("kubernetes", "kubernetes", *pr.Number, &github.ListOptions{})
+				// Sleep for 5 seconds to avoid irritating the API rate limiter.
+				time.Sleep(5 * time.Second)
+				if err != nil {
+					fmt.Printf("Error contacting github: %v", err)
+					os.Exit(1)
+				}
+				for _, label := range labels {
+					if *label.Name == "release-note" {
+						fmt.Fprintf(buffer, "   * %s (#%d, @%s)\n", *pr.Title, *pr.Number, *pr.User.Login)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
There were some issues with finding PRs and falling off the end of the branch, and the API rate limit, which I've resolved here.

This also adds a flag to allow a user to not filter on the `release-note` label, to list all PRs between two.
