### PR TITLE
[ansible] Use | for nil check, fixes #323

### DIFF
--- a/ansible/roles/flannel/templates/flanneld.j2
+++ b/ansible/roles/flannel/templates/flanneld.j2
@@ -9,4 +9,4 @@ FLANNEL_ETCD_KEY="/{{ cluster_name }}/network"
 
 # Any additional options that you want to pass
 # By default, we just add a good guess for the network interface on Vbox.  Otherwise, Flannel will probably make the right guess.
-FLANNEL_OPTIONS="{% if flannel_opts %}{{ flannel_opts }}{% endif %}"
+FLANNEL_OPTIONS="{{ flannel_opts | default('') }}"


### PR DESCRIPTION
this is the "right" way to do default filters. I don't think the "if" statement works they way i assumed it did.  My fault for not testing the negative case (i.e. where param was missing).  

- I got this from http://docs.ansible.com/ansible/playbooks_filters.html .

- It appears to work properly, tested both with and without flannel_opts defined...