### PR TITLE
service-loadbalancer: HAProxy: Disallow concurrent reload attempts, should fix #321

### DIFF
--- a/service-loadbalancer/haproxy_reload
+++ b/service-loadbalancer/haproxy_reload
@@ -23,6 +23,12 @@
 # -s soft reload, wait for pids to finish handling requests
 # -f send pids a resume signal if reload of new config fails
 
+exec 200<$0
+# Block till we can acquire an exclusive file lock:
+flock 200
+
 socat /tmp/haproxy - <<< "show servers state" > /var/state/haproxy/global
 
 haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)
+
+flock -u 200


### PR DESCRIPTION
The script-file itself is used as a mutex, idea borrowed from https://github.com/mesosphere/marathon-lb/commit/598ff09b0c80349418c38c44808a616e77efec74.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/327)

<!-- Reviewable:end -->
