### PR TITLE
Update nginx and replace lua5.1 with luajit 

### DIFF
--- a/Ingress/images/nginx-slim/rc.yaml
+++ b/Ingress/images/nginx-slim/rc.yaml
@@ -29,6 +29,6 @@ spec:
     spec:
       containers:
       - name: nginxslim
-        image: gcr.io/google_containers/nginx-slim:0.1
+        image: gcr.io/google_containers/nginx-slim:0.2
         ports:
         - containerPort: 80


### PR DESCRIPTION
The reason to replace lua with luajit is the support of [yield/resume in coroutines](https://github.com/openresty/lua-nginx-module#lua-coroutine-yieldingresuming)