### PR TITLE
service-loadbalancer: When set targetPort by string name and didnot have a port name, will found no endpoints in that service

### DIFF
--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -341,7 +341,10 @@ func (lbc *loadBalancerController) getEndpoints(
 					targetPort = epPort.Port
 				}
 			case util.IntstrString:
-				if epPort.Name == servicePort.TargetPort.StrVal {
+				// two situations:
+				// 1. A service's every port have an attr name (more than one port the spec.ports[i].name was required value)
+				// 2. only one port and didnot have an attr name and it must have only one endpoint. In this situation the servicePort.Name and epPort.Name was empty, but servicePort.TargetPort.StrVal was not
+				if servicePort.Name == epPort.Name {
 					targetPort = epPort.Port
 				}
 			}

--- a/service-loadbalancer/service_loadbalancer_test.go
+++ b/service-loadbalancer/service_loadbalancer_test.go
@@ -106,7 +106,7 @@ func TestGetEndpoints(t *testing.T) {
 	servicePorts := []api.ServicePort{
 		{Port: ports[0], TargetPort: util.NewIntOrStringFromInt(ports[0])},
 		{Port: ports[1], TargetPort: util.NewIntOrStringFromInt(ports[1])},
-		{Port: ports[2], TargetPort: util.NewIntOrStringFromString("mysql")},
+		{Port: ports[2], TargetPort: util.NewIntOrStringFromString("api"), Name: "mysql"},
 	}
 
 	svc := getService(servicePorts)


### PR DESCRIPTION
The EndpointPorts's Name attr was corresponds to the ServicePort.Name. If we set EndpointPort Name, then we must set the same name to the corresponds ServiePort.Name on test file.
https://github.com/kubernetes/kubernetes/blob/master/pkg/api/types.go#L1420-L1431

We use a string name to represent TargetPort, which might set in Pod spec, and we do not set a ServicePort.Name or the TargetPort different with ServicePortName
https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-elasticsearch/es-service.yaml#L12-L14
If I create the above service in kubernetes and it works well. But this service did not found any endpoints in service-loadbalancer.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/336)

<!-- Reviewable:end -->
