### PR TITLE
Add ability to deploy kube-dash

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -73,6 +73,9 @@ cluster_monitoring: true
 # Turn to false to disable the kube-ui addon for this cluster
 kube-ui: false
 
+# Turn to false to disable the kube-dash addon for this cluster
+kube-dash: false
+
 # Turn this varable to 'false' to disable whole DNS configuration.
 dns_setup: true
 # How many replicas in the Replication Controller

--- a/ansible/roles/kubernetes-addons/tasks/kube-dash.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-dash.yml
@@ -1,0 +1,13 @@
+---
+- name: KUBE-DASH | Assures {{ kube_addons_dir }}/kube-dash dir exists
+  file: path={{ kube_addons_dir }}/kube-dash state=directory
+
+- name: KUBE-DASH | Download kube-dash files from Kubernetes repo
+  get_url:
+    url=https://raw.githubusercontent.com/kubernetes/kubedash/master/deploy/kube-config.yaml
+    dest="{{ kube_addons_dir }}/kube-dash/"
+    force=yes
+    validate_certs=False
+  environment:
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"

--- a/ansible/roles/kubernetes-addons/tasks/kube-dash.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-dash.yml
@@ -4,10 +4,13 @@
 
 - name: KUBE-DASH | Download kube-dash files from Kubernetes repo
   get_url:
-    url=https://raw.githubusercontent.com/kubernetes/kubedash/master/deploy/kube-config.yaml
+    url=https://raw.githubusercontent.com/kubernetes/kubedash/master/deploy/{{ item }}
     dest="{{ kube_addons_dir }}/kube-dash/"
     force=yes
     validate_certs=False
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+  with_items:
+    - kube-dash-rc.yaml
+    - kube-dash-svc.yaml

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -33,6 +33,9 @@
 - include: kube-ui.yml
   when: kube-ui
 
+- include: kube-dash.yml
+  when: kube-dash
+
 #- name: Get kube-addons script from Kubernetes
 #  get_url:
 #    url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/saltbase/salt/kube-addons/kube-addons.sh


### PR DESCRIPTION
Closes #182. This will allow for kube-dash to be deployed by simply setting `kube-dash: true` in the all.yml variable file.