### PR TITLE
[mungegithub] Add  label to block submit-queue

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -39,6 +39,7 @@ const (
 	e2eNotRequiredLabel = "e2e-not-required"
 	claYes              = "cla: yes"
 	claHuman            = "cla: human-approved"
+	dependenciesLabel   = "unmerged-dependencies"
 
 	jenkinsE2EContext  = "Jenkins GCE e2e"
 	jenkinsUnitContext = "Jenkins unit/integration"
@@ -376,6 +377,7 @@ const (
 	needsok                 = "PR does not have 'ok-to-merge' label"
 	lgtmEarly               = "The PR was changed after the LGTM label was added."
 	unmergeable             = "PR is unable to be automatically merged. Needs rebase."
+	hasDependencies         = "PR has unmerged dependencies"
 	undeterminedMergability = "Unable to determine is PR is mergeable. Will try again later."
 	ciFailure               = "Github CI tests are not green."
 	e2eFailure              = "The e2e tests are failing. The entire submit queue is blocked."
@@ -443,6 +445,11 @@ func (sq *SubmitQueue) Munge(obj *github.MungeObject) {
 
 	if !obj.HasLabels([]string{"lgtm"}) {
 		sq.SetMergeStatus(obj, noLGTM, false)
+		return
+	}
+
+	if obj.HasLabels([]string{dependenciesLabel}) {
+		sq.SetMergeStatus(obj, hasDependencies, false)
 		return
 	}
 


### PR DESCRIPTION
Add a `unmerged-dependencies` label that blocks automatic merging. I'm open to changing this to a more generic label, such as `no-merge`. See associated issue https://github.com/kubernetes/contrib/issues/359 for more details.
