### PR TITLE
Don't comment "Labelling this PR as size/X", that's redundant.

### DIFF
--- a/mungegithub/mungers/size.go
+++ b/mungegithub/mungers/size.go
@@ -18,7 +18,6 @@ package mungers
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strings"
 
@@ -189,9 +188,6 @@ func (s *SizeMunger) Munge(obj *github.MungeObject) {
 	}
 	if needsUpdate {
 		obj.AddLabels([]string{newLabel})
-
-		body := fmt.Sprintf("Labelling this PR as %s", newLabel)
-		obj.WriteComment(body)
 	}
 }
 


### PR DESCRIPTION
I haven't tested this. The comment doesn't tell us anything new.  The only reason I can think of for it to exist is if you want an email notification or something, but that seems like a stretch.
