### PR TITLE
Remove old haproxy childs after reload

### DIFF
--- a/service-loadbalancer/Dockerfile
+++ b/service-loadbalancer/Dockerfile
@@ -26,6 +26,12 @@ RUN mkdir -p /etc/haproxy/errors /var/state/haproxy
 RUN for ERROR_CODE in 400 403 404 408 500 502 503 504;do curl -sSL -o /etc/haproxy/errors/$ERROR_CODE.http \
 	https://raw.githubusercontent.com/haproxy/haproxy-1.5/master/examples/errorfiles/$ERROR_CODE.http;done
 
+# https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem
+RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64 && \
+  chmod +x /sbin/dumb-init
+
+ENTRYPOINT ["dumb-init", "/service_loadbalancer"]
+
 ADD haproxy.cfg /etc/haproxy/haproxy.cfg
 ADD service_loadbalancer service_loadbalancer
 ADD service_loadbalancer.go service_loadbalancer.go
@@ -34,4 +40,5 @@ ADD loadbalancer.json loadbalancer.json
 ADD haproxy_reload haproxy_reload
 ADD README.md README.md
 
-ENTRYPOINT ["/service_loadbalancer"]
+RUN touch /var/run/haproxy.pid
+

--- a/service-loadbalancer/Makefile
+++ b/service-loadbalancer/Makefile
@@ -18,9 +18,9 @@ haproxy:
 	docker build -t $(HAPROXY_IMAGE):$(TAG) build
 	docker create --name $(HAPROXY_IMAGE) $(HAPROXY_IMAGE):$(TAG) true
 	# docker cp semantics changed between 1.7 and 1.8, so we cp the file to cwd and rename it.
-	docker cp $(HAPROXY_IMAGE):/work/x86_64/haproxy-1.6-r2.apk .
+	docker cp $(HAPROXY_IMAGE):/work/x86_64/haproxy-1.6-r3.apk .
 	docker rm -f $(HAPROXY_IMAGE)
-	mv haproxy-1.6-r2.apk haproxy.apk
+	mv haproxy-1.6-r3.apk haproxy.apk
 
 clean:
 	rm -f service_loadbalancer haproxy.apk

--- a/service-loadbalancer/build/src/APKBUILD
+++ b/service-loadbalancer/build/src/APKBUILD
@@ -14,7 +14,7 @@
 
 pkgname=haproxy
 pkgver=1.6
-pkgrel=2
+pkgrel=3
 pkgdesc="HAProxy is a free, very fast and reliable solution offering high availability, load balancing"
 url="http://www.haproxy.org/"
 arch="x86_64"
@@ -26,7 +26,7 @@ source="http://www.haproxy.org/download/1.6/src/$pkgfullname.tar.gz"
 
 build() {
 	cd "$srcdir/$pkgfullname"
-	make TARGET=linux2628 USE_PCRE=1 USE_PCRE_JIT=1 USE_OPENSSL=1 USE_LUA=1 LUA_LIB=/usr/lib/lua5.3/ LUA_INC=/usr/include/lua5.3 CFLAGS="$CFLAGS" || return 1
+	make TARGET=linux2628 USE_PCRE=1 USE_PCRE_JIT=1 USE_OPENSSL=1 USE_LUA=1 CPU=x86_64 USE_LINUX_TPROXY=1 LUA_LIB=/usr/lib/lua5.3/ LUA_INC=/usr/include/lua5.3 CFLAGS="$CFLAGS" || return 1
 }
 
 package() {
@@ -36,6 +36,6 @@ package() {
 	install -d "$pkgdir"/var/lib/haproxy
 }
 
-md5sums="d0ebd3d123191a8136e2e5eb8aaff039  haproxy-1.6.2.tar.gz"
-sha256sums="bd4a7eee79e1bfd25af59d956bb60e82acbb6f146f3fb3b30636036f4c9548d3  haproxy-1.6.2.tar.gz"
-sha512sums="8cb1f2bb7e63e75b1350e37b4a06dae9627bc6004ceefc0e3dac7c6f56ea66cdc41ebaee0e536a5acbd4e5b067feba2589d3e360dd7fdc6d3d67c000f6c83ba9  haproxy-1.6.2.tar.gz"
+md5sums="3362d1e268c78155c2474cb73e7f03f9  haproxy-1.6.3.tar.gz"
+sha256sums="fd06b45054cde2c69cb3322dfdd8a4bcfc46eb9d0c4b36d20d3ea19d84e338a7  haproxy-1.6.3.tar.gz"
+sha512sums="79ed526cd857dcd68d9b8289df4d4a2d87594e8d0d119f4d7c618597db7563a0cedc8417ddcfefb464a322d1fb50cb044656a2fbe78867f58052e0ddaa894bb9  haproxy-1.6.3.tar.gz"

--- a/service-loadbalancer/haproxy.cfg
+++ b/service-loadbalancer/haproxy.cfg
@@ -2,17 +2,17 @@
 # go templates (http://golang.org/pkg/text/template/) to
 # generate the config dynamically.
 global
-    daemon
-    stats socket /tmp/haproxy
+	daemon
+	stats socket /tmp/haproxy
 
 defaults
 	log	global
 	mode	http
 	option	httplog
 	option	dontlognull
-    timeout connect 5000
-    timeout client 50000
-    timeout server 50000
+	timeout connect 5000
+	timeout client 50000
+	timeout server 50000
 	errorfile 400 /etc/haproxy/errors/400.http
 	errorfile 403 /etc/haproxy/errors/403.http
 	errorfile 408 /etc/haproxy/errors/408.http
@@ -20,21 +20,21 @@ defaults
 	errorfile 502 /etc/haproxy/errors/502.http
 	errorfile 503 /etc/haproxy/errors/503.http
 	errorfile 504 /etc/haproxy/errors/504.http
-    # default default_backend. This allows custom default_backend in frontends
-    default_backend default-backend
+	# default default_backend. This allows custom default_backend in frontends
+	default_backend default-backend
 
 backend default-backend
-  server localhost 127.0.0.1:8081
+	server localhost 127.0.0.1:8081
 
 # haproxy stats, required hostport and firewall rules for :1936
-listen stats :1936
-    mode http
+listen stats
+    bind *:1936
     stats enable
     stats hide-version
     stats realm Haproxy\ Statistics
     stats uri /
 
 frontend httpfrontend
-    # Frontend bound on all network interfaces on port 80
-    bind *:80
-    mode	http
+	# Frontend bound on all network interfaces on port 80
+	bind *:80
+	mode	http

--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/openshift/origin/pkg/util/proc"
 	flag "github.com/spf13/pflag"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
@@ -458,7 +457,7 @@ func (lbc *loadBalancerController) sync(dryRun bool) error {
 
 	httpSvc, tcpSvc := lbc.getServices()
 	if len(httpSvc) == 0 && len(tcpSvc) == 0 {
-		glog.Warning("There is no available services to be used in the load balancer")
+		glog.Info("There is no available services to be used in the load balancer")
 		return nil
 	}
 	if err := lbc.cfg.write(
@@ -480,7 +479,7 @@ func (lbc *loadBalancerController) worker() {
 		key, _ := lbc.queue.Get()
 		glog.Infof("Sync triggered by service %v", key)
 		if err := lbc.sync(false); err != nil {
-			glog.Infof("Requeuing %v because of error: %v", key, err)
+			glog.Warningf("Requeuing %v because of error: %v", key, err)
 			lbc.queue.Add(key)
 		}
 		lbc.queue.Done(key)
@@ -488,8 +487,7 @@ func (lbc *loadBalancerController) worker() {
 }
 
 // newLoadBalancerController creates a new controller from the given config.
-func newLoadBalancerController(cfg *loadBalancerConfig, kubeClient *unversioned.Client, namespace string) *loadBalancerController {
-
+func newLoadBalancerController(cfg *loadBalancerConfig, kubeClient *unversioned.Client, namespace string, tcpServices map[string]int) *loadBalancerController {
 	lbc := loadBalancerController{
 		cfg:    cfg,
 		client: kubeClient,
@@ -499,24 +497,7 @@ func newLoadBalancerController(cfg *loadBalancerConfig, kubeClient *unversioned.
 		targetService:   *targetService,
 		forwardServices: *forwardServices,
 		httpPort:        *httpPort,
-		tcpServices:     map[string]int{},
-	}
-
-	if *tcpServices != "" {
-		for _, service := range strings.Split(*tcpServices, ",") {
-			portSplit := strings.Split(service, ":")
-			if len(portSplit) != 2 {
-				glog.Errorf("Ignoring misconfigured TCP service %v", service)
-				continue
-			}
-			if port, err := strconv.Atoi(portSplit[1]); err != nil {
-				glog.Errorf("Ignoring misconfigured TCP service %v: %v", service, err)
-				continue
-			} else {
-				glog.Infof("Adding TCP service %v", service)
-				lbc.tcpServices[portSplit[0]] = port
-			}
-		}
+		tcpServices:     tcpServices,
 	}
 
 	enqueue := func(obj interface{}) {
@@ -599,6 +580,26 @@ func registerHandlers(s *staticPageHandler) {
 	glog.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", lbApiPort), nil))
 }
 
+func parseTCPServices(tcpServices string) map[string]int {
+	tcpSvcs := make(map[string]int)
+	for _, service := range strings.Split(tcpServices, ",") {
+		portSplit := strings.Split(service, ":")
+		if len(portSplit) != 2 {
+			glog.Errorf("Ignoring misconfigured TCP service %v", service)
+			continue
+		}
+		if port, err := strconv.Atoi(portSplit[1]); err != nil {
+			glog.Errorf("Ignoring misconfigured TCP service %v: %v", service, err)
+			continue
+		} else {
+			glog.Infof("Adding TCP service %v", service)
+			tcpSvcs[portSplit[0]] = port
+		}
+	}
+
+	return tcpSvcs
+}
+
 func dryRun(lbc *loadBalancerController) {
 	var err error
 	for err = lbc.sync(true); err == errDeferredSync; err = lbc.sync(true) {
@@ -612,9 +613,6 @@ func main() {
 	clientConfig := kubectl_util.DefaultClientConfig(flags)
 	flags.Parse(os.Args)
 	cfg := parseCfg(*config, *lbDefAlgorithm)
-	if len(*tcpServices) == 0 {
-		glog.Infof("No tcp/https services specified")
-	}
 
 	var kubeClient *unversioned.Client
 	var err error
@@ -626,7 +624,12 @@ func main() {
 
 	go registerHandlers(defErrorPage)
 
-	proc.StartReaper()
+	var tcpSvcs map[string]int
+	if *tcpServices != "" {
+		tcpSvcs = parseTCPServices(*tcpServices)
+	} else {
+		glog.Infof("No tcp/https services specified")
+	}
 
 	if *startSyslog {
 		cfg.startSyslog = true
@@ -652,11 +655,11 @@ func main() {
 		glog.Fatalf("unexpected error: %v", err)
 	}
 	if !specified {
-		namespace = api.NamespaceDefault
+		namespace = api.NamespaceAll
 	}
 
 	// TODO: Handle multiple namespaces
-	lbc := newLoadBalancerController(cfg, kubeClient, namespace)
+	lbc := newLoadBalancerController(cfg, kubeClient, namespace, tcpSvcs)
 	go lbc.epController.Run(util.NeverStop)
 	go lbc.svcController.Run(util.NeverStop)
 	if *dry {


### PR DESCRIPTION
- Update haproxy to 1.6.3
- Use dumb-init to remove old haproxy child processes
  https://github.com/Yelp/dumb-init
- Fix template identation
- Remove confusing logs messages

closes #321
closes #366