### PR TITLE
 [service-loadbalancer] SSL termination support with HAProxy

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -1,0 +1,11 @@
+Ingress/controllers/nginx-third-party/nginx.tmpl:        require("error_page")
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 403 @custom_403;
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 404 @custom_404;
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 405 @custom_405;
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 408 @custom_408;
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 413 @custom_413;
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 500 @custom_500;
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 501 @custom_501;
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 502 @custom_502;
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 503 @custom_503;
+Ingress/controllers/nginx-third-party/nginx.tmpl:    error_page 504 @custom_504;

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -59,4 +59,5 @@ whitelist-override-label
 configuration-name
 custom-error-service
 use-unicast
-
+ssl-ca-cert
+ssl-cert

--- a/service-loadbalancer/README.md
+++ b/service-loadbalancer/README.md
@@ -115,6 +115,56 @@ A couple of points to note:
 - The https service is accessible directly on the specified port, which matches the *service port*.
 - You need to take care of ensuring there is no collision between these service ports on the node.
 
+#### SSL Termination
+
+- Annotate a service
+
+```yaml
+metadata:
+  name: myservice
+  annotations:
+    serviceloadbalancer/lb.sslTerm: "true"
+    serviceloadbalancer/lb.aclMatch: "-i /t1 /t2"
+  labels:
+```
+
+- Create a secret with one of your favorite tool
+
+- Add secrets to your loadbalancer pod
+
+```yaml
+        ports:
+        # All http services
+        - containerPort: 80
+          hostPort: 80
+          protocol: TCP
+        # ssl term
+        - containerPort: 443
+          hostPort: 443
+          protocol: TCP       
+        # haproxy stats
+        - containerPort: 1936
+          hostPort: 1936
+          protocol: TCP
+        resources: {}     
+        volumes:
+        - name: secret-volume
+          secret:
+            secretName: my-secret
+        volumeMounts:
+        - mountPath: "/ssl"
+          name: secret-volume
+```
+
+- Add your SSL configuration to loadbalancer pod
+
+```yaml
+      args:
+      - --ssl-cert=/ssl/crt.pem
+      - --ssl-ca-cert=/ssl/ca.crt
+      - --namespace=default
+```
+
 #### TCP
 
 ```yaml
@@ -325,9 +375,8 @@ status of the services or stats about the traffic
 - Scrape :1926 and scale replica count of the loadbalancer rc from a helper pod (this is basically ELB)
 - Scrape :1936/;csv and autoscale services
 - Better https support. 3 options to handle ssl:
-  1. __Termination__: certificate lives on load balancer. All traffic to load balancer is encrypted, traffic from load balancer to service is not.
-  2. __Pass Through__: Load balancer drops down to L4 balancing and forwards TCP encrypted packets to destination.
-  3. __Redirect__: All traffic is https. HTTP connections are encrypted using load balancer certs.
+  1. __Pass Through__: Load balancer drops down to L4 balancing and forwards TCP encrypted packets to destination.
+  2. __Redirect__: All traffic is https. HTTP connections are encrypted using load balancer certs.
 
   Currently you need to trigger TCP loadbalancing for your https service by specifying it in loadbalancer.json. Support for the other 2 would be nice.
 - Multinamespace support: Currently the controller only watches a single namespace for services.

--- a/service-loadbalancer/loadbalancer.json
+++ b/service-loadbalancer/loadbalancer.json
@@ -4,3 +4,4 @@
     "config": "/etc/haproxy/haproxy.cfg",
     "template": "template.cfg"
 }
+

--- a/service-loadbalancer/service_loadbalancer_test.go
+++ b/service-loadbalancer/service_loadbalancer_test.go
@@ -155,11 +155,11 @@ func TestGetServices(t *testing.T) {
 
 	flb := newFakeLoadBalancerController(endpoints, []*api.Service{svc1, svc2})
 	cfg, _ := filepath.Abs("./test-samples/loadbalancer_test.json")
-	flb.cfg = parseCfg(cfg, "roundrobin")
+	flb.cfg = parseCfg(cfg, "roundrobin", "", "")
 	flb.tcpServices = map[string]int{
 		svc1.Name: 20,
 	}
-	http, tcp := flb.getServices()
+	http, _, tcp := flb.getServices()
 	serviceURLEp := fmt.Sprintf("%v:%v", svc1.Name, 20)
 	if len(tcp) != 1 || tcp[0].Name != serviceURLEp || tcp[0].FrontendPort != 20 {
 		t.Fatalf("Unexpected tcp service %+v expected %+v", tcp, svc1.Name)
@@ -263,7 +263,7 @@ func buildTestLoadBalancer(lbDefAlgorithm string) *loadBalancerController {
 		lbDefAlgorithm = "roundrobin"
 	}
 
-	flb.cfg = parseCfg(cfg, lbDefAlgorithm)
+	flb.cfg = parseCfg(cfg, lbDefAlgorithm, "", "")
 	cfgFile, _ := filepath.Abs("test-" + string(util.NewUUID()))
 	flb.cfg.Config = cfgFile
 	flb.tcpServices = map[string]int{
@@ -291,7 +291,7 @@ func compareCfgFiles(t *testing.T, orig, template string) {
 
 func TestDefaultAlgorithm(t *testing.T) {
 	flb := buildTestLoadBalancer("")
-	httpSvc, tcpSvc := flb.getServices()
+	httpSvc, _, tcpSvc := flb.getServices()
 	if err := flb.cfg.write(
 		map[string][]service{
 			"http": httpSvc,
@@ -306,7 +306,7 @@ func TestDefaultAlgorithm(t *testing.T) {
 
 func TestDefaultCustomAlgorithm(t *testing.T) {
 	flb := buildTestLoadBalancer("leastconn")
-	httpSvc, tcpSvc := flb.getServices()
+	httpSvc, _, tcpSvc := flb.getServices()
 	if err := flb.cfg.write(
 		map[string][]service{
 			"http": httpSvc,
@@ -321,7 +321,7 @@ func TestDefaultCustomAlgorithm(t *testing.T) {
 
 func TestSyslog(t *testing.T) {
 	flb := buildTestLoadBalancer("")
-	httpSvc, tcpSvc := flb.getServices()
+	httpSvc, _, tcpSvc := flb.getServices()
 	flb.cfg.startSyslog = true
 	if err := flb.cfg.write(
 		map[string][]service{
@@ -337,7 +337,7 @@ func TestSyslog(t *testing.T) {
 
 func TestSvcCustomAlgorithm(t *testing.T) {
 	flb := buildTestLoadBalancer("")
-	httpSvc, tcpSvc := flb.getServices()
+	httpSvc, _, tcpSvc := flb.getServices()
 	httpSvc[0].Algorithm = "leastconn"
 	if err := flb.cfg.write(
 		map[string][]service{
@@ -353,7 +353,7 @@ func TestSvcCustomAlgorithm(t *testing.T) {
 
 func TestCustomDefaultAndSvcAlgorithm(t *testing.T) {
 	flb := buildTestLoadBalancer("leastconn")
-	httpSvc, tcpSvc := flb.getServices()
+	httpSvc, _, tcpSvc := flb.getServices()
 	httpSvc[0].Algorithm = "roundrobin"
 	if err := flb.cfg.write(
 		map[string][]service{
@@ -369,7 +369,7 @@ func TestCustomDefaultAndSvcAlgorithm(t *testing.T) {
 
 func TestServiceAffinity(t *testing.T) {
 	flb := buildTestLoadBalancer("")
-	httpSvc, tcpSvc := flb.getServices()
+	httpSvc, _, tcpSvc := flb.getServices()
 	httpSvc[0].SessionAffinity = true
 	if err := flb.cfg.write(
 		map[string][]service{
@@ -385,7 +385,7 @@ func TestServiceAffinity(t *testing.T) {
 
 func TestServiceAffinityWithCookies(t *testing.T) {
 	flb := buildTestLoadBalancer("")
-	httpSvc, tcpSvc := flb.getServices()
+	httpSvc, _, tcpSvc := flb.getServices()
 	httpSvc[0].SessionAffinity = true
 	httpSvc[0].CookieStickySession = true
 	if err := flb.cfg.write(

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -12,6 +12,11 @@ global
     log /var/run/haproxy.log.socket local0 notice
 {{ end }}
 
+{{ if ne .sslCert "" }}
+    ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK
+    ssl-default-bind-options no-tls-tickets
+{{ end }}
+
 defaults
     log global
    
@@ -76,6 +81,24 @@ listen stats
     stats realm Haproxy\ Statistics
     stats uri /
 
+{{ if ne .sslCert "" }}
+frontend httpsfrontend
+    mode http
+    bind :443 ssl {{ .sslCert }} ciphers no-sslv3
+
+    # HSTS (15768000 seconds = 6 months)
+    rspadd  Strict-Transport-Security:\ max-age=15768000
+
+{{range $i, $svc := .services.httpsTerm}}
+    acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
+    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
+    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
+    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
+{{ end }}
+{{end}}
+{{end}}
+
+
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80
     bind *:80
@@ -130,7 +153,40 @@ backend {{$svc.Name}}
 {{end}}
 {{end}}
 
+{{range $i, $svc := .services.httpsTerm}}
+{{ $svcName := $svc.Name }}
+backend {{$svc.Name}}
+    option  httplog
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
 
+    balance {{$svc.Algorithm}}
+
+{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
+    # create a stickiness table using client IP address as key
+    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
+    stick-table type ip size 100k expire 30m
+    stick on src
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} check port {{$svc.BackendPort}} inter 5
+    {{end}}
+{{end}}
+{{if and $svc.SessionAffinity $svc.CookieStickySession}}
+    # insert a cookie with name SERVERID to stick a client with a backend server
+    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
+    cookie SERVERID insert indirect nocache
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}} check port {{$svc.BackendPort}} inter 5
+    {{end}}
+{{end}}
+{{if and (not $svc.SessionAffinity) (not $svc.CookieStickySession)}}
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} check port {{$svc.BackendPort}} inter 5
+    {{end}}
+{{end}}
+{{end}}
 
 {{range $i, $svc := .services.tcp}}
 {{ $svcName := $svc.Name }}

--- a/service-loadbalancer/test-samples/TestCustomDefaultAndSvcAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestCustomDefaultAndSvcAlgorithm.cfg
@@ -8,6 +8,8 @@ global
 
 
 
+
+
 defaults
     log global
    
@@ -71,6 +73,9 @@ listen stats
     stats hide-version
     stats realm Haproxy\ Statistics
     stats uri /
+
+
+
 
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80

--- a/service-loadbalancer/test-samples/TestDefaultAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestDefaultAlgorithm.cfg
@@ -8,6 +8,8 @@ global
 
 
 
+
+
 defaults
     log global
    
@@ -71,6 +73,9 @@ listen stats
     stats hide-version
     stats realm Haproxy\ Statistics
     stats uri /
+
+
+
 
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80

--- a/service-loadbalancer/test-samples/TestDefaultCustomAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestDefaultCustomAlgorithm.cfg
@@ -8,6 +8,8 @@ global
 
 
 
+
+
 defaults
     log global
    
@@ -71,6 +73,9 @@ listen stats
     stats hide-version
     stats realm Haproxy\ Statistics
     stats uri /
+
+
+
 
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80

--- a/service-loadbalancer/test-samples/TestServiceAffinity.cfg
+++ b/service-loadbalancer/test-samples/TestServiceAffinity.cfg
@@ -8,6 +8,8 @@ global
 
 
 
+
+
 defaults
     log global
    
@@ -71,6 +73,9 @@ listen stats
     stats hide-version
     stats realm Haproxy\ Statistics
     stats uri /
+
+
+
 
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80

--- a/service-loadbalancer/test-samples/TestServiceAffinityWithCookies.cfg
+++ b/service-loadbalancer/test-samples/TestServiceAffinityWithCookies.cfg
@@ -8,6 +8,8 @@ global
 
 
 
+
+
 defaults
     log global
    
@@ -71,6 +73,9 @@ listen stats
     stats hide-version
     stats realm Haproxy\ Statistics
     stats uri /
+
+
+
 
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80

--- a/service-loadbalancer/test-samples/TestSvcCustomAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestSvcCustomAlgorithm.cfg
@@ -8,6 +8,8 @@ global
 
 
 
+
+
 defaults
     log global
    
@@ -71,6 +73,9 @@ listen stats
     stats hide-version
     stats realm Haproxy\ Statistics
     stats uri /
+
+
+
 
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80

--- a/service-loadbalancer/test-samples/TestSyslog.cfg
+++ b/service-loadbalancer/test-samples/TestSyslog.cfg
@@ -12,6 +12,8 @@ global
     log /var/run/haproxy.log.socket local0 notice
 
 
+
+
 defaults
     log global
    
@@ -75,6 +77,9 @@ listen stats
     stats hide-version
     stats realm Haproxy\ Statistics
     stats uri /
+
+
+
 
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80


### PR DESCRIPTION
This pull request adds support for SSL termination.
## Installation instructions
- Add annotations to your service:

``` yaml
metadata:
  name: myservice
  annotations:
    serviceloadbalancer/lb.sslTerm: "true"
    serviceloadbalancer/lb.aclMatch: "-i /t1 /t2"
  labels:
```
- Create a secret with one of your favorite tool
- Update your loadbalancer POD to something like the following

``` yaml
        ports:
        # All http services
        - containerPort: 80
          hostPort: 80
          protocol: TCP
        # ssl term
        - containerPort: 443
          hostPort: 443
          protocol: TCP       
        # haproxy stats
        - containerPort: 1936
          hostPort: 1936
          protocol: TCP
        resources: {}     
        volumes:
        - name: secret-volume
          secret:
            secretName: my-secret
        volumeMounts:
        - mountPath: "/ssl"
          name: secret-volume
```
- Add your SSL configuration to loadbalancer POD

``` yaml
      args:
      - --ssl-cert=/ssl/crt.pem
      - --ssl-ca-cert=/ssl/ca.crt
      - --namespace=default
```
- Define your https-frontend section in template.cfg

```
{{ if ne .sslCert "" }}
frontend httpsfrontend
    mode http
    bind :443 ssl {{ .sslCert }} ciphers ALL:!HIGH:!LOW:!MD5:!SEED:!EXP:MEDIUM:RC4-SHA verify required

{{range $i, $svc := .services.httpsTerm}}
    acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
    {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
    use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
    {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
{{ end }}
{{end}}
{{end}}
```

Im not that experienced in english to be able to update the readme for instructions. I hope someone can help to finish this up.
