### PR TITLE
Show valid options

### DIFF
--- a/hack/for-go-proj.sh
+++ b/hack/for-go-proj.sh
@@ -22,6 +22,11 @@ CONTRIB_ROOT="$(dirname ${BASH_SOURCE})/.."
 
 godep_projects=$(find "${CONTRIB_ROOT}" -wholename '*Godeps/Godeps.json')
 
+if [ $# -ne 1 ];then
+  echo "missing subcommand: [build|install|test]"
+  exit 1
+fi
+
 CMD="${1}"
 
 case "${CMD}" in


### PR DESCRIPTION
Replace error

```
$ ./hack/for-go-proj.sh
./hack/for-go-proj.sh: line 25: 1: unbound variable
```

with

```
$ ./hack/for-go-proj.sh
missing subcommand: [build|install|test]
```
