### PR TITLE
Set file permissions so another container can read them

### DIFF
--- a/git-sync/main.go
+++ b/git-sync/main.go
@@ -110,5 +110,14 @@ func syncRepo(repo, dest, branch, rev string) error {
 		return fmt.Errorf("error running command %q : %v: %s", strings.Join(cmd.Args, " "), err, string(output))
 	}
 	log.Printf("reset %q: %v", rev, string(output))
+
+	// set file permissions
+	cmd = exec.Command("chmod", "-R", "744", dest)
+	cmd.Dir = dest
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error running command %q : %v: %s", strings.Join(cmd.Args, " "), err, string(output))
+	}
+
 	return nil
 }


### PR DESCRIPTION
When used on Kubernetes as a side-car, the other container should have read permissions to the cloned files. This is not necessarily the case without explicitly setting it.

I ran into this problem in combination with an Nginx container and a shared volume.