### PR TITLE
Resolved ansible errors in cluster-monitoring setup

### DIFF
--- a/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
@@ -21,11 +21,25 @@
     - influxdb-grafana-controller.yaml
     - influxdb-service.yaml
 
-- name: MONITORING | Convert pillar vars to ansible vars for monitoring files
-  local_action: replace
+- name: MONITORING | Remove instances of getting pillar dicts
+  local_action: lineinfile
     dest="{{ local_temp_addon_dir }}/cluster-monitoring/{{ item }}.j2"
-    regexp="pillar\[\'(\w*)\'\]"
-    replace="\1"
+    regexp="set\s+\w+\s+=\s+pillar\.get\("
+    state=absent
+  sudo: no
+  with_items:
+    - grafana-service.yaml
+    - heapster-controller.yaml
+    - heapster-service.yaml
+    - influxdb-grafana-controller.yaml
+    - influxdb-service.yaml
+
+- name: MONITORING | Add tests for pillar vars converted to ansible vars
+  local_action: lineinfile
+    dest="{{ local_temp_addon_dir }}/cluster-monitoring/{{ item }}.j2"
+    regexp="(.*)if\s+(\w+)\s+([<>=]+.*)"
+    line="\1if \2 is defined and \2 \3"
+    backrefs=yes
   sudo: no
   with_items:
     - grafana-service.yaml


### PR DESCRIPTION
Due to changes made in commit [3da8d80](https://github.com/kubernetes/kubernetes/commit/3da8d80187b12db4e505bd2be5ef41dc819f0506]) in the kubernetes repo, this ansible playbook fails when trying to convert the pillar vars to ansible vars. This resolves that by changing the regex to match the new logic in the template.

I tested this in my lab and am able to setup cluster monitoring via the ansible role successfully now.

This also is reported in issue [395](https://github.com/kubernetes/contrib/issues/395)