### PR TITLE
Block submit-queue on new jobs

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -193,15 +193,14 @@ func (sq *SubmitQueue) EachLoop() error {
 // AddFlags will add any request flags to the cobra `cmd`
 func (sq *SubmitQueue) AddFlags(cmd *cobra.Command, config *github.Config) {
 	cmd.Flags().StringSliceVar(&sq.JenkinsJobs, "jenkins-jobs", []string{
-		"kubernetes-e2e-gce",
-		"kubernetes-e2e-gke-ci",
 		"kubernetes-build",
-		"kubernetes-e2e-gce-parallel",
-		"kubernetes-e2e-gce-autoscaling",
-		"kubernetes-e2e-gce-reboot",
+		"kubernetes-test-go",
+		"kubernetes-e2e-gce",
+		"kubernetes-e2e-gce-slow",
+		"kubernetes-e2e-gke",
+		"kubernetes-e2e-gke-slow",
 		"kubernetes-e2e-gce-scalability",
 		"kubernetes-kubemark-gce",
-		"kubernetes-test-go",
 	}, "Comma separated list of jobs in Jenkins to use for stability testing")
 	cmd.Flags().StringVar(&sq.JenkinsHost, "jenkins-host", "http://jenkins-master:8080", "The URL for the jenkins job to watch")
 	cmd.Flags().StringSliceVar(&sq.RequiredStatusContexts, "required-contexts", []string{travisContext}, "Comma separate list of status contexts required for a PR to be considered ok to merge")


### PR DESCRIPTION
- put `-test-go` at the top with `-build`
- rename `-gke-ci` to `-gke` (https://github.com/kubernetes/kubernetes/pull/20278)
- add `-gce-slow` and `-gke-slow` (https://github.com/kubernetes/kubernetes/pull/20278)
- remove `-gce-reboot` (will eventually be included in `-gce-serial` if we want to block submit queue on it)
- remove `-gce-parallel` (now covered by `-gce`; see https://github.com/kubernetes/kubernetes/pull/20278)
- remove `-autoscaling` (all GA tests now in `-slow`; see https://github.com/kubernetes/kubernetes/pull/20274)
