### PR TITLE
[mungegithub] New munger to rerun CI if it is 'pending' for 24 hours

### DIFF
--- a/mungegithub/mungegithub.go
+++ b/mungegithub/mungegithub.go
@@ -46,7 +46,7 @@ type mungeConfig struct {
 
 func addMungeFlags(config *mungeConfig, cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&config.Once, "once", false, "If true, run one loop and exit")
-	cmd.Flags().StringSliceVar(&config.PRMungersList, "pr-mungers", []string{"blunderbuss", "lgtm-after-commit", "needs-rebase", "ok-to-test", "path-label", "ping-ci", "size", "stale-unit-test", "submit-queue"}, "A list of pull request mungers to run")
+	cmd.Flags().StringSliceVar(&config.PRMungersList, "pr-mungers", []string{"blunderbuss", "lgtm-after-commit", "needs-rebase", "ok-to-test", "path-label", "ping-ci", "size", "stale-pending-ci", "stale-green-ci", "submit-queue"}, "A list of pull request mungers to run")
 	cmd.Flags().StringSliceVar(&config.IssueReportsList, "issue-reports", []string{}, "A list of issue reports to run. If set, will run the reports and exit.")
 	cmd.Flags().DurationVar(&config.Period, "period", 10*time.Minute, "The period for running mungers")
 }

--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -27,31 +27,31 @@ import (
 )
 
 const (
-	staleHours = 48
+	staleGreenCIHours = 48
 )
 
-// StaleUnitTestMunger will remove the LGTM flag from an PR which has been
+// StaleGreenCI will remove the LGTM flag from an PR which has been
 // updated since the reviewer added LGTM
-type StaleUnitTestMunger struct{}
+type StaleGreenCI struct{}
 
 func init() {
-	RegisterMungerOrDie(StaleUnitTestMunger{})
+	RegisterMungerOrDie(StaleGreenCI{})
 }
 
 // Name is the name usable in --pr-mungers
-func (StaleUnitTestMunger) Name() string { return "stale-unit-test" }
+func (StaleGreenCI) Name() string { return "stale-green-ci" }
 
 // Initialize will initialize the munger
-func (StaleUnitTestMunger) Initialize(config *github.Config) error { return nil }
+func (StaleGreenCI) Initialize(config *github.Config) error { return nil }
 
 // EachLoop is called at the start of every munge loop
-func (StaleUnitTestMunger) EachLoop() error { return nil }
+func (StaleGreenCI) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
-func (StaleUnitTestMunger) AddFlags(cmd *cobra.Command, config *github.Config) {}
+func (StaleGreenCI) AddFlags(cmd *cobra.Command, config *github.Config) {}
 
 // Munge is the workhorse the will actually make updates to the PR
-func (StaleUnitTestMunger) Munge(obj *github.MungeObject) {
+func (StaleGreenCI) Munge(obj *github.MungeObject) {
 	requiredContexts := []string{jenkinsUnitContext, jenkinsE2EContext}
 
 	if !obj.IsPR() {
@@ -76,11 +76,11 @@ func (StaleUnitTestMunger) Munge(obj *github.MungeObject) {
 			glog.Errorf("%d: unable to determine time %q context was set", *obj.Issue.Number, context)
 			return
 		}
-		if time.Since(*statusTime) > staleHours*time.Hour {
+		if time.Since(*statusTime) > staleGreenCIHours*time.Hour {
 			msgFormat := `@k8s-bot test this
 
 Tests are more than %d hours old. Re-running tests.`
-			msg := fmt.Sprintf(msgFormat, staleHours)
+			msg := fmt.Sprintf(msgFormat, staleGreenCIHours)
 			obj.WriteComment(msg)
 			err := obj.WaitForPending(requiredContexts)
 			if err != nil {

--- a/mungegithub/mungers/stale-green-ci_test.go
+++ b/mungegithub/mungers/stale-green-ci_test.go
@@ -115,7 +115,7 @@ func TestOldUnitTestMunge(t *testing.T) {
 		config.Project = "r"
 		config.SetClient(client)
 
-		s := StaleUnitTestMunger{}
+		s := StaleGreenCI{}
 		err := s.Initialize(config)
 		if err != nil {
 			t.Fatalf("%v", err)

--- a/mungegithub/mungers/stale-pending-ci.go
+++ b/mungegithub/mungers/stale-pending-ci.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/contrib/mungegithub/github"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+const (
+	stalePendingCIHours = 24
+)
+
+// StalePendingCI will ask the k8s-bot to test any PR with a LGTM that has
+// been pending for more than 24 hours. This can happen when the jenkins VM
+// is restarted.
+//
+// The real fix would be for the jenkins VM restart to not move every single
+// PR to pending without actually testing...
+//
+// But this is our world and so we should really do this for all PRs which
+// aren't likely to get another push (everything that is mergeable). Since that
+// can be a lot of PRs, I'm just doing it for the LGTM PRs automatically...
+//
+// With minor modification this can be run easily by hand. Remove the LGTM check
+// godep go build
+// ./mungegithub --token-file=/PATH/TO/YOUR/TOKEN --pr-mungers=rerun-old-pending-ci --once (--dry-run)
+type StalePendingCI struct{}
+
+func init() {
+	RegisterMungerOrDie(StalePendingCI{})
+}
+
+// Name is the name usable in --pr-mungers
+func (StalePendingCI) Name() string { return "stale-pending-ci" }
+
+// Initialize will initialize the munger
+func (StalePendingCI) Initialize(config *github.Config) error { return nil }
+
+// EachLoop is called at the start of every munge loop
+func (StalePendingCI) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (StalePendingCI) AddFlags(cmd *cobra.Command, config *github.Config) {}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (StalePendingCI) Munge(obj *github.MungeObject) {
+	requiredContexts := []string{jenkinsUnitContext, jenkinsE2EContext}
+
+	if !obj.IsPR() {
+		return
+	}
+
+	if !obj.HasLabel("lgtm") {
+		return
+	}
+
+	if mergeable, err := obj.IsMergeable(); !mergeable || err != nil {
+		return
+	}
+
+	status := obj.GetStatusState(requiredContexts)
+	if status != "pending" {
+		return
+	}
+
+	for _, context := range requiredContexts {
+		statusTime := obj.GetStatusTime(context)
+		if statusTime == nil {
+			glog.Errorf("%d: unable to determine time %q context was set", *obj.Issue.Number, context)
+			return
+		}
+		if time.Since(*statusTime) > stalePendingCIHours*time.Hour {
+			msgFormat := `@k8s-bot test this issue: #IGNORE
+
+Tests have been pending for %d hours`
+			msg := fmt.Sprintf(msgFormat, stalePendingCIHours)
+			obj.WriteComment(msg)
+			return
+		}
+	}
+}


### PR DESCRIPTION
At times the CI can mess up, say it is testing a PR, but not actually be
testings.  This munger will request a retest when it finds a mergeable
PR with LGTM which has been 'pending' for 24 hours.

We should really retest every PR which is mergeable and has been
'pending' for greater than some length of time, but at least LGTM will
keep the jenkins queue from exploding...