### PR TITLE
Bump kube-keepalived-vip to 0.2

### DIFF
--- a/keepalived-vip/Makefile
+++ b/keepalived-vip/Makefile
@@ -1,6 +1,6 @@
 all: push
 
-# 0.0 shouldn't clobber any release builds
+# 0.0 shouldn't clobber any release builds, current "latest" is 0.2
 TAG = 0.0
 PREFIX = gcr.io/google_containers/kube-keepalived-vip
 BUILD_IMAGE = build-keepalived
@@ -12,7 +12,7 @@ container: controller
 	docker build -t $(PREFIX):$(TAG) .
 
 push: container
-	docker push $(PREFIX):$(TAG)
+	gcloud docker push $(PREFIX):$(TAG)
 
 clean:
 	rm -f kube-keepalived-vip

--- a/keepalived-vip/vip-daemonset.yaml
+++ b/keepalived-vip/vip-daemonset.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-        - image: gcr.io/google_containers/kube-keepalived-vip:0.1
+        - image: gcr.io/google_containers/kube-keepalived-vip:0.2
           name: kube-keepalived-vip
           imagePullPolicy: Always
           securityContext:

--- a/keepalived-vip/vip-rc.yaml
+++ b/keepalived-vip/vip-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: gcr.io/google_containers/kube-keepalived-vip:0.1
+      - image: gcr.io/google_containers/kube-keepalived-vip:0.2
         name: kube-keepalived-vip
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
Use gcr.io/google_containers/kube-keepalived-vip:0.2 in examples.
@aledbf @wienczny 