### PR TITLE
[submit queue] Refresh issues in the submit queue

### DIFF
--- a/mungegithub/Dockerfile
+++ b/mungegithub/Dockerfile
@@ -16,15 +16,15 @@ FROM google/debian:wheezy
 MAINTAINER Brendan Burns <bburns@google.com>
 RUN apt-get update
 RUN apt-get install -y -qq ca-certificates
-ADD mungegithub /mungegithub
-ADD blunderbuss.yml /blunderbuss.yml
 ADD path-label.txt /path-label.txt
 ADD generated-files.txt /generated-files.txt
+ADD blunderbuss.yml /blunderbuss.yml
 # User lists for submit-queue and 'needs-ok-to-merge'
 ADD committers.txt /committers.txt
 ADD whitelist.txt /whitelist.txt
 # Submit queue web interface
 ADD www /www
+ADD mungegithub /mungegithub
 EXPOSE 8080
 ENTRYPOINT ["/mungegithub"]
 CMD ["--dry-run", "--token-file=/token"]

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -88,7 +88,7 @@ func UserNotInWhitelistOKToMergeIssue() *github.Issue {
 }
 
 func DontRequireGithubE2EIssue() *github.Issue {
-	return github_test.Issue(whitelistUser, 1, []string{"cla: yes", "lgtm", "e2e-not-required"}, true)
+	return github_test.Issue(whitelistUser, 1, []string{"cla: yes", "lgtm", e2eNotRequiredLabel}, true)
 }
 
 func OldLGTMEvents() []github.IssueEvent {
@@ -224,6 +224,17 @@ func TestQueueOrder(t *testing.T) {
 				*github_test.Issue(whitelistUser, 5, nil, true),
 			},
 			expected: []int{4, 2, 3, 5},
+		},
+		{
+			name: "e2e-not-required counts as P-negative 1",
+			issues: []github.Issue{
+				*github_test.Issue(whitelistUser, 2, nil, true),
+				*github_test.Issue(whitelistUser, 3, []string{"priority/P3"}, true),
+				*github_test.Issue(whitelistUser, 4, []string{"priority/P2"}, true),
+				*github_test.Issue(whitelistUser, 5, nil, true),
+				*github_test.Issue(whitelistUser, 6, []string{"priority/P3", e2eNotRequiredLabel}, true),
+			},
+			expected: []int{6, 4, 2, 3, 5},
 		},
 	}
 	for testNum, test := range tests {


### PR DESCRIPTION
This actually has 2 side effects.
- If LGTM was removed from an issue after it was queued it could still merge
- If labels which affected the queue position were changed after it was queued the position would not be updated
    
Historically #1 wasn't a huge problem since the queue was constantly cleared by e2e flakes/failures and so we got fresh data. Now we aren't clearing the queue constantly the issue data could get way out of date.
