### PR TITLE
updated symlink endpoint

### DIFF
--- a/ansible/roles/etcd/tasks/github-release.yml
+++ b/ansible/roles/etcd/tasks/github-release.yml
@@ -24,7 +24,7 @@
 - name: Create symlinks
   file:
     src: /usr/local/etcd-{{ etcd_version }}-linux-amd64/{{ item }}
-    dest: /usr/local/bin/{{ item }}
+    dest: /usr/bin/{{ item }}
     state: link
   with_items:
     - etcd


### PR DESCRIPTION
Fixes #429. Will create symlink at /usr/bin instead of /usr/local/bin.