### PR TITLE
support overlayfs for non-atomic hosts

### DIFF
--- a/ansible/roles/docker/files/docker-storage
+++ b/ansible/roles/docker/files/docker-storage
@@ -1,0 +1,1 @@
+DOCKER_STORAGE_OPTIONS= -s overlay

--- a/ansible/roles/docker/tasks/generic-install.yml
+++ b/ansible/roles/docker/tasks/generic-install.yml
@@ -5,3 +5,7 @@
     name: docker
     state: latest
   when: not is_atomic
+
+- name: Generic | Lay down storage config
+  copy: src=docker-storage dest=/etc/sysconfig/docker-storage
+  when: not is_atomic


### PR DESCRIPTION
This will resolve issue #458. I'm also willing to add a group_var for "docker_storage_driver" or similar if that's something folks think would be useful as part of this. But it seems like this would be a required change anyways for any Fedora or CentOS non-atomic image in OpenStack, and I presume any other cloud using the provided "Generic Cloud" images from CentOS/Fedora.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/459)

<!-- Reviewable:end -->
