### PR TITLE
Remove the ciphers option from the httpsfrontend

### DIFF
--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -84,7 +84,7 @@ listen stats
 {{ if ne .sslCert "" }}
 frontend httpsfrontend
     mode http
-    bind :443 ssl {{ .sslCert }} ciphers no-sslv3
+    bind :443 ssl {{ .sslCert }} no-sslv3
 
     # HSTS (15768000 seconds = 6 months)
     rspadd  Strict-Transport-Security:\ max-age=15768000


### PR DESCRIPTION
ciphers requires an argument and the following string (no-sslv3) isn't a
valid cipher, so haproxy was failing to start. The template config still
selects ciphers via ssl-default-bind-ciphers in global.