### PR TITLE
Fix perfdash

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -45,6 +45,7 @@ shame-cc
 shame-from
 shame-report-cmd
 source-file
+start-from
 stats-port
 sync-period
 tcp-services

--- a/perfdash/Dockerfile
+++ b/perfdash/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/debian:wheezy
+FROM google/debian:jessie
 MAINTAINER Brendan Burns <bburns@google.com>
 RUN apt-get update
 RUN apt-get install -y -qq ca-certificates

--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 0.1
+TAG = 0.3
 
 perfdash: perfdash.go
 	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o perfdash

--- a/perfdash/perfdash.go
+++ b/perfdash/perfdash.go
@@ -51,6 +51,9 @@ type Histogram map[string]float64
 // ResourceToHistogram is a map from resource names (e.g. "pods") to the relevant latency data
 type ResourceToHistogram map[string][]APICallLatency
 
+// TestToHistogram is a map from test name to ResourceToHistogram
+type TestToHistogram map[string]ResourceToHistogram
+
 // BuildLatencyData is a map from build number to latency data
 type BuildLatencyData map[string]ResourceToHistogram
 
@@ -67,6 +70,58 @@ func (buildLatency *BuildLatencyData) ServeHTTP(res http.ResponseWriter, req *ht
 	res.Write(data)
 }
 
+const (
+	scanning   = iota
+	inTest     = iota
+	processing = iota
+)
+
+// Assumes that *resources* and *methods* are already initialized.
+func parseTestOutput(scanner *bufio.Scanner, buildNumber int, resources sets.String, methods sets.String) ResourceToHistogram {
+	buff := &bytes.Buffer{}
+	hist := TestToHistogram{}
+	state := scanning
+	testNameSeparator := "[It] [Feature:Performance]"
+	testName := ""
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, testNameSeparator) {
+			state = inTest
+			testName = strings.Trim(strings.Split(line, testNameSeparator)[1], " ")
+			hist[testName] = make(ResourceToHistogram)
+		}
+		if state == processing {
+			// TODO: This is brittle, we should emit a tail delimiter too
+			if strings.Contains(line, "INFO") || strings.Contains(line, "STEP") || strings.Contains(line, "Failure") || strings.Contains(line, "[AfterEach]") {
+				obj := LatencyData{}
+				if err := json.Unmarshal(buff.Bytes(), &obj); err != nil {
+					fmt.Printf("error parsing JSON in build %d: %v %s\n", buildNumber, err, buff.String())
+					// reset state and try again with more input
+					state = scanning
+					continue
+				}
+
+				for _, call := range obj.APICalls {
+					hist[testName][call.Resource] = append(hist[testName][call.Resource], call)
+					resources.Insert(call.Resource)
+					methods.Insert(call.Verb)
+				}
+
+				buff.Reset()
+				state = scanning
+			}
+		}
+		if state == inTest && strings.Contains(line, "API calls latencies") {
+			state = processing
+			line = line[strings.Index(line, "{"):]
+		}
+		if state == processing {
+			buff.WriteString(line + " ")
+		}
+	}
+	return hist["should allow starting 30 pods per node"]
+}
+
 func getLatencyData(client *jenkins.JenkinsClient, job string) (BuildLatencyData, sets.String, sets.String, error) {
 	buildLatency := BuildLatencyData{}
 	resources := sets.NewString()
@@ -79,65 +134,21 @@ func getLatencyData(client *jenkins.JenkinsClient, job string) (BuildLatencyData
 
 	for ix := range queue.Builds {
 		build := queue.Builds[ix]
+		if build.Number < *startFrom {
+			continue
+		}
 		reader, err := client.GetConsoleLog(job, build.Number)
 		if err != nil {
-			fmt.Printf("error getting logs: %v", err)
+			fmt.Printf("error getting logs: %v\n", err)
 			continue
 		}
 		defer reader.Close()
 		scanner := bufio.NewScanner(reader)
-		buff := &bytes.Buffer{}
-		inLatency := false
+		hist := parseTestOutput(scanner, build.Number, resources, methods)
 
-		hist := ResourceToHistogram{}
-		found := false
-		testNameSeparator := "[It] [Feature:Performance]"
-		testName := ""
-		for scanner.Scan() {
-			line := scanner.Text()
-			if strings.Contains(line, testNameSeparator) {
-				testName = strings.Trim(strings.Split(line, testNameSeparator)[1], " ")
-			}
-			// TODO: This is brittle, we should emit a tail delimiter too
-			if strings.Contains(line, "INFO") || strings.Contains(line, "STEP") || strings.Contains(line, "Failure") {
-				if inLatency {
-					obj := LatencyData{}
-					if err := json.Unmarshal(buff.Bytes(), &obj); err != nil {
-						fmt.Printf("error parsing JSON in build %d: %v %s\n", build.Number, err, buff.String())
-						// reset state and try again with more input
-						inLatency = false
-						continue
-					}
-
-					if testName == "should allow starting 30 pods per node" {
-						for _, call := range obj.APICalls {
-							list := hist[call.Resource]
-							list = append(list, call)
-							hist[call.Resource] = list
-							resources.Insert(call.Resource)
-							methods.Insert(call.Verb)
-						}
-					}
-
-					buff.Reset()
-				}
-				inLatency = false
-			}
-			if strings.Contains(line, "API calls latencies") {
-				found = true
-				inLatency = true
-				ix = strings.Index(line, "{")
-				line = line[ix:]
-			}
-			if inLatency {
-				buff.WriteString(line + " ")
-			}
+		if len(hist) > 0 {
+			buildLatency[fmt.Sprintf("%d", build.Number)] = hist
 		}
-		if !found {
-			continue
-		}
-
-		buildLatency[fmt.Sprintf("%d", build.Number)] = hist
 	}
 	return buildLatency, resources, methods, nil
 }
@@ -187,6 +198,7 @@ var (
 	addr        = flag.String("address", ":8080", "The address to serve web data on, only used if -www is true")
 	wwwDir      = flag.String("dir", "", "If non-empty, add a file server for this directory at the root of the web server")
 	jenkinsHost = flag.String("jenkins-host", "", "The URL for the jenkins server.")
+	startFrom   = flag.Int("start-from", 0, "First build number to include in the results")
 
 	pollDuration = 10 * time.Minute
 	errorDelay   = 10 * time.Second

--- a/perfdash/pod.yaml
+++ b/perfdash/pod.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "0.1"
+    version: "0.3"
 spec:
   containers:
-  - image: gcr.io/google_containers/perfdash:0.1
+  - image: gcr.io/google_containers/perfdash:0.3
     command:
       - /perfdash
       -   --jenkins-host=http://jenkins-master:8080
@@ -26,4 +26,11 @@ spec:
         port: 8080
       initialDelaySeconds: 10
       timeoutSeconds: 1
+    resources:
+      requests:
+        cpu: 300m
+        memory: 300Mi
+      limits:
+        cpu: 300m
+        memory: 300Mi
   restartPolicy: OnFailure


### PR DESCRIPTION
This change should make perfdash usable as a place that gathers performance data from various sources. It extracts information from output of (mainly) density.go test, but it's able to use load.go results as well.

I'll try to get someone who knows JS to update the page, so there will be possible to have multiple tabs for different sources (e.g. Google, CoreOS, etc.). After it's done, if you want to publish your performance test data, you'll need to publish test outputs somewhere in the net, and add a scraper for it to this code.

Perfdash is running at http://perf-dash.k8s.io/

cc @hongchaodeng @timothysc @spiffxp 
