### PR TITLE
Replacing the virtualbox vm.box with the official centos box

### DIFF
--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -60,7 +60,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   def set_vbox(vb, config)
-    config.vm.box = "chef/centos-7.0"
+    config.vm.box = "centos/7"
     config.vm.network "private_network", type: "dhcp"
     vb.gui = false
     vb.memory = 2048


### PR DESCRIPTION
The `chef/centos-7.0` box is no more available on Atlas.
This PR replace it with the official centos 7 box.