### PR TITLE
Add DNS to requirements and troubleshooting tips for 1.2.0a7

### DIFF
--- a/Ingress/controllers/nginx-third-party/README.md
+++ b/Ingress/controllers/nginx-third-party/README.md
@@ -16,7 +16,7 @@ This is a nginx Ingress controller that uses [ConfigMap](https://github.com/kube
 
 ## Requirements
 - default backend [404-server](https://github.com/kubernetes/contrib/tree/master/404-server) (or a custom compatible image)
-
+- DNS must be operational and able to resolve default-http-backend.default.svc.cluster.local
 
 ## SSL
 
@@ -314,6 +314,12 @@ The route `/error` expects two arguments: code and format
 
 Using a volume pointing to `/var/www/html` directory is possible to use a custom error
 
+## Troubleshooting
+
+Problems encountered during [1.2.0-alpha7 deployment](https://github.com/kubernetes/kubernetes/blob/master/docs/getting-started-guides/docker.md):
+* make setup-files.sh file in hypercube does not provide 10.0.0.1 IP to make-ca-certs, resulting in CA certs that are issued to the external cluster IP address rather then 10.0.0.1 -> this results in nginx-third-party-lb appearing to get stuck at "Utils.go:177 - Waiting for default/default-http-backend" in the docker logs.  Kubernetes will eventually kill the container before nginx-third-party-lb times out with a message indicating that the CA certificate issuer is invalid (wrong ip), to verify this add zeros to the end of initialDelaySeconds and timeoutSeconds and reload the RC, and docker will log this error before kubernetes kills the container.
+  * To fix the above, setup-files.sh must be patched before the cluster is inited (refer to https://github.com/kubernetes/kubernetes/pull/21504)
+* if once the nginx-third-party-lb starts, its docker log spams this message continously "utils.go:(line #)] Requeuing default/echomap, err Post http://127.0.0.1:8080/update-ingress: dial tcp 127.0.0.1:8080: getsockopt: connection refused", it means that the container is unable to use DNS to resolve the service address, DNS autoconfigure is broken on 1.2.0-alpha7 (refer again to https://github.com/kubernetes/kubernetes/pull/21504 for fixes)
 
 ## TODO:
 - multiple SSL certificates


### PR DESCRIPTION
Update nginx-third-party docs to include requirement for working DNS and troubleshooting tips for 1.2.0-alpha7

FYI @aledbf 
