### PR TITLE
keepalived-vip: Add support for custom templates, routes and routing rules

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -66,3 +66,9 @@ use-unicast
 ssl-ca-cert
 ssl-cert
 vrrp-password
+debug-keepalived-conf
+enable-ipvs-conntrack
+keepalived-ip
+keepalived-conf
+keepalived-conf-template
+keepalived-pid

--- a/keepalived-vip/Dockerfile
+++ b/keepalived-vip/Dockerfile
@@ -15,10 +15,11 @@
 FROM alpine:3.3
 
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-  apk add -U --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
+  apk add -U --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted --no-cache \
   bash curl ipvsadm iproute2 keepalived && \
   rm -rf /var/cache/apk/* /etc/keepalived/keepalived.conf
   
+#COPY keepalived.conf.template /etc/keepalived/keepalived.conf.template
 COPY kube-keepalived-vip /kube-keepalived-vip
 
-ENTRYPOINT ["/kube-keepalived-vip"]
+ENTRYPOINT ["/kube-keepalived-vip", ""]

--- a/keepalived-vip/Dockerfile
+++ b/keepalived-vip/Dockerfile
@@ -22,4 +22,4 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositor
 #COPY keepalived.conf.template /etc/keepalived/keepalived.conf.template
 COPY kube-keepalived-vip /kube-keepalived-vip
 
-ENTRYPOINT ["/kube-keepalived-vip", ""]
+ENTRYPOINT ["/kube-keepalived-vip", "--keepalivedPidFilename=/keepalived.pid"]

--- a/keepalived-vip/controller.go
+++ b/keepalived-vip/controller.go
@@ -140,7 +140,7 @@ func (ipvsc *ipvsControllerController) getServices() []service {
 		annotations := s.GetAnnotations()
 
 		if externalIP, ok := annotations[ipvsPublicVIP]; ok {
-			var externalRoute string = ""
+			var externalRoute string
 			var externalRouteSubnet = 32
 
 			if externalRoute, ok = annotations[ipvsPublicVIPRoute]; ok {
@@ -202,7 +202,7 @@ func (ipvsc *ipvsControllerController) getRoutes(svcs []service) []vroute {
 	routes := []vroute{}
 
 	for _, s := range svcs {
-		var currentRoute *vroute = nil
+		var currentRoute *vroute
 
 		for _, r := range routes {
 			if r.Route != s.Route {

--- a/keepalived-vip/keepalived.conf.template
+++ b/keepalived-vip/keepalived.conf.template
@@ -1,0 +1,68 @@
+{{ $iface := .iface }}{{ $netmask := .netmask }}
+vrrp_sync_group VG_1 {
+  group {
+    vips
+  }
+}
+
+vrrp_instance vips {
+  state BACKUP
+  interface {{ $iface }}
+  virtual_router_id 50
+  priority {{ .priority }}
+  accept
+  nopreempt
+  advert_int 1
+
+  track_interface {
+    {{ $iface }}
+  }
+
+  {{ if .useUnicast }}
+  unicast_src_ip {{ .myIP }}
+  unicast_peer { {{ range .nodes }}
+    {{ . }}{{ end }}
+  }
+  {{ end }}
+
+  virtual_ipaddress { {{ range $i, $svc := .svcs }}
+    {{ $svc.IP }}/{{ $svc.Netmask }}{{ end }}
+  }
+
+  {{ if .routes }}virtual_routes { {{ range $i, $route := .routes }}
+    default via {{ $route.Route }} dev {{ $iface }} table {{ $route.Table }}{{ end }}
+  }
+
+  virtual_rules { {{ range $i, $route := .routes }}
+    from {{ $route.Network }}/{{ $route.Netmask }} table {{ $route.Table }}{{ end }}
+  }{{ end }}
+
+  authentication {
+    auth_type AH
+    auth_pass {{ .authPass }}
+  }
+}
+
+{{ range $i, $svc := .svcs }}# Start {{$svc.Name}}
+{{ range $j, $port := $svc.Ports }}# Start {{$port.Port}} {{$port.Protocol}}
+virtual_server {{ $svc.IP }} {{ $port.Port }} {
+  delay_loop 5
+  lvs_sched wlc
+  lvs_method NAT
+  persistence_timeout 1800
+  protocol {{ $port.Protocol }}
+  alpha
+
+  {{ range $k, $backend := $port.Backends }}
+  real_server {{ $backend.IP }} {{ $backend.Port }} {
+    weight 1
+    TCP_CHECK {
+      connect_port {{ $backend.Port }}
+      connect_timeout 3
+    }
+  }
+  {{ end }}
+}
+# End {{$port.Port}} {{$port.Protocol}}
+{{ end }}# End {{$svc.Name}}
+{{ end }}

--- a/keepalived-vip/keepalived.go
+++ b/keepalived-vip/keepalived.go
@@ -68,54 +68,73 @@ vrrp_instance vips {
   }
 }
 
-{{ range $i, $svc := .svcs }}
-virtual_server {{ $svc.Ip }} {{ $svc.Port }} {
+{{ range $i, $svc := .svcs }}# Start {{$svc.Name}}
+{{ range $j, $port := $svc.Ports }}# Start {{$port.Port}} {{$port.Protocol}}
+virtual_server {{ $svc.IP }} {{ $port.Port }} {
   delay_loop 5
   lvs_sched wlc
   lvs_method NAT
   persistence_timeout 1800
-  protocol TCP
+  protocol {{ $port.Protocol }}
 
-  {{ range $j, $backend := $svc.Backends }}
-  real_server {{ $backend.Ip }} {{ $backend.Port }} {
+  {{ range $k, $backend := $port.Backends }}
+  real_server {{ $backend.IP }} {{ $backend.Port }} {
     weight 1
     TCP_CHECK {
       connect_port {{ $backend.Port }}
       connect_timeout 3
     }
   }
-{{ end }}
-}    
+  {{ end }}
+}
+# End {{$port.Port}} {{$port.Protocol}}
+{{ end }}# End {{$svc.Name}}
 {{ end }}
 `
 )
 
 type keepalived struct {
-	iface      string
-	ip         string
-	netmask    int
-	priority   int
-	nodes      []string
-	neighbors  []string
-	useUnicast bool
-	password   string
-	started    bool
-	vips       []string
+	iface          string
+	ip             string
+	netmask        int
+	priority       int
+	nodes          []string
+	neighbors      []string
+	useUnicast     bool
+	password       string
+	vips           []string
+	keepalivedTmpl *template.Template
+	cmd            *exec.Cmd
 }
+
+var (
+	keepalivedPath = flags.String("keepalived", "keepalived",
+		`Path to keepalived`)
+	keepalivedTemplateFilename = flags.String("keepalivedconftemplate",
+		"/etc/keepalived/keepalived.conf.template", `Path to keepalived.conf.template`)
+	keepalivedConfFilename = flags.String("keepalivedconf", "/etc/keepalived/keepalived.conf",
+		`Path to keepalived.conf`)
+	keepalivedPidFilename = flags.String("keepalivedpid", "/run/keepalived.pid",
+		`Path to keepalived.conf`)
+	debugKeeplivedConf = flags.Bool("debug-keepalived-conf", false,
+		`debug keepalived.conf generation`)
+)
 
 // WriteCfg creates a new keepalived configuration file.
 // In case of an error with the generation it returns the error
-func (k *keepalived) WriteCfg(svcs []vip) error {
-	w, err := os.Create("/etc/keepalived/keepalived.conf")
+func (k *keepalived) WriteCfg(svcs []service, routes []vroute) error {
+	if k.keepalivedTmpl == nil {
+		err := k.loadTemplate()
+		if err != nil {
+			return err
+		}
+	}
+
+	w, err := os.Create(*keepalivedConfFilename)
 	if err != nil {
 		return err
 	}
 	defer w.Close()
-
-	t, err := template.New("keepalived").Parse(keepalivedTmpl)
-	if err != nil {
-		return err
-	}
 
 	k.vips = getVIPs(svcs)
 
@@ -124,13 +143,15 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	conf["myIP"] = k.ip
 	conf["netmask"] = k.netmask
 	conf["svcs"] = svcs
-	conf["vips"] = getVIPs(svcs)
+	conf["vips"] = k.vips
+	conf["routes"] = routes
 	conf["nodes"] = k.neighbors
 	conf["priority"] = k.priority
 	// password to protect the access to the vrrp_instance group
-	conf["authPass"] = k.getSha()[0:8]
 	if k.password != "" {
 		conf["authPass"] = k.password[0:8]
+	} else {
+		conf["authPass"] = k.getSha()[0:8]
 	}
 	conf["useUnicast"] = k.useUnicast
 
@@ -139,15 +160,15 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 		glog.Infof("%v", string(b))
 	}
 
-	return t.Execute(w, conf)
+	return k.keepalivedTmpl.Execute(w, conf)
 }
 
 // getVIPs returns a list of the virtual IP addresses to be used in keepalived
 // without duplicates (a service can use more than one port)
-func getVIPs(svcs []vip) []string {
+func getVIPs(svcs []service) []string {
 	result := []string{}
 	for _, svc := range svcs {
-		result = appendIfMissing(result, svc.Ip)
+		result = appendIfMissing(result, svc.IP)
 	}
 
 	return result
@@ -155,17 +176,22 @@ func getVIPs(svcs []vip) []string {
 
 // Start starts a keepalived process in foreground.
 // In case of any error it will terminate the execution with a fatal error
-func (k *keepalived) Start() {
-	cmd := exec.Command("keepalived",
+func (k *keepalived) Start() error {
+	if *debugKeeplivedConf {
+		return nil
+	}
+	glog.Info("starting keepalived to announce VIPs")
+
+	k.cmd = exec.Command(*keepalivedPath,
 		"--dont-fork",
 		"--log-console",
 		"--release-vips",
-		"--pid", "/keepalived.pid")
+		"-D",
+		"--pid", *keepalivedPidFilename,
+		"--use-file", *keepalivedConfFilename)
 
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	k.started = true
+	k.cmd.Stdout = os.Stdout
+	k.cmd.Stderr = os.Stderr
 
 	// in case the pod is terminated we need to check that the vips are removed
 	c := make(chan os.Signal, 2)
@@ -179,27 +205,32 @@ func (k *keepalived) Start() {
 		}
 	}()
 
-	if err := cmd.Start(); err != nil {
+	if err := k.cmd.Start(); err != nil {
 		glog.Errorf("keepalived error: %v", err)
+		return err
 	}
 
-	if err := cmd.Wait(); err != nil {
+	/*
+	if err := k.cmd.Wait(); err != nil {
 		glog.Fatalf("keepalived error: %v", err)
+		return err
 	}
+	*/
+	return nil
 }
 
 // Reload sends SIGHUP to keepalived to reload the configuration.
 func (k *keepalived) Reload() error {
-	if !k.started {
+	if k.cmd == nil {
 		// TODO: add a warning indicating that keepalived is not started?
 		return nil
 	}
 
 	glog.Info("reloading keepalived")
-	out, err := k8sexec.New().Command("killall", "-1", "keepalived").CombinedOutput()
+	err := syscall.Kill(k.cmd.Process.Pid, syscall.SIGHUP)
 
 	if err != nil {
-		return fmt.Errorf("error reloading keepalived: %v\n%s", err, out)
+		return fmt.Errorf("error reloading keepalived: %v\n", err)
 	}
 
 	return nil
@@ -214,6 +245,7 @@ func (k *keepalived) getSha() string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// Reset virtual ips
 func resetIPVS() error {
 	glog.Info("cleaning ipvs configuration")
 	_, err := k8sexec.New().Command("ipvsadm", "-C").CombinedOutput()
@@ -224,11 +256,31 @@ func resetIPVS() error {
 	return nil
 }
 
+// Remove virtual ips
 func (k *keepalived) removeVIP(vip string) error {
 	glog.Infof("removing configred VIP %v", vip)
-	out, err := k8sexec.New().Command("ip", "add", "del", vip+"/32", "dev", k.iface).CombinedOutput()
+	out, err := k8sexec.New().Command("ip", "addr", "del", vip+"/32", "dev", k.iface).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error reloading keepalived: %v\n%s", err, out)
+	}
+	return nil
+}
+
+// Initialize template from file or constant
+func (k *keepalived) loadTemplate() error {
+	if _, err := os.Stat(*keepalivedTemplateFilename); os.IsNotExist(err) {
+		k.keepalivedTmpl, err = template.New("keepalived").Parse(keepalivedTmpl)
+		if err != nil {
+			return err
+		}
+	} else {
+		k.keepalivedTmpl, err = template.ParseFiles(*keepalivedTemplateFilename)
+
+		if err != nil {
+			glog.Fatalf("cannot read keepalived.conf template at %v: %v",
+				*keepalivedTemplateFilename, err)
+			return err
+		}
 	}
 	return nil
 }

--- a/keepalived-vip/keepalived.go
+++ b/keepalived-vip/keepalived.go
@@ -110,11 +110,11 @@ type keepalived struct {
 var (
 	keepalivedPath = flags.String("keepalived", "keepalived",
 		`Path to keepalived`)
-	keepalivedTemplateFilename = flags.String("keepalivedconftemplate",
+	keepalivedTemplateFilename = flags.String("keepalived-conf-template",
 		"/etc/keepalived/keepalived.conf.template", `Path to keepalived.conf.template`)
-	keepalivedConfFilename = flags.String("keepalivedconf", "/etc/keepalived/keepalived.conf",
+	keepalivedConfFilename = flags.String("keepalived-conf", "/etc/keepalived/keepalived.conf",
 		`Path to keepalived.conf`)
-	keepalivedPidFilename = flags.String("keepalivedpid", "/run/keepalived.pid",
+	keepalivedPidFilename = flags.String("keepalived-pid", "/run/keepalived.pid",
 		`Path to keepalived.conf`)
 	debugKeeplivedConf = flags.Bool("debug-keepalived-conf", false,
 		`debug keepalived.conf generation`)
@@ -211,10 +211,10 @@ func (k *keepalived) Start() error {
 	}
 
 	/*
-	if err := k.cmd.Wait(); err != nil {
-		glog.Fatalf("keepalived error: %v", err)
-		return err
-	}
+		if err := k.cmd.Wait(); err != nil {
+			glog.Fatalf("keepalived error: %v", err)
+			return err
+		}
 	*/
 	return nil
 }

--- a/keepalived-vip/main.go
+++ b/keepalived-vip/main.go
@@ -23,8 +23,8 @@ import (
 	"github.com/golang/glog"
 	flag "github.com/spf13/pflag"
 
-	"k8s.io/kubernetes/pkg/client/unversioned"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned"
 	kubectl_util "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/wait"
 )

--- a/keepalived-vip/main.go
+++ b/keepalived-vip/main.go
@@ -24,6 +24,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"k8s.io/kubernetes/pkg/client/unversioned"
+	kapi "k8s.io/kubernetes/pkg/api"
 	kubectl_util "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/wait"
 )
@@ -39,8 +40,11 @@ var (
 	useUnicast = flags.Bool("use-unicast", false, `use unicast instead of multicast for communication
 		with other keepalived instances`)
 
-	password = flags.String("vrrp-password", "", `If set it will use it as keepalived password instead of the 
+	password = flags.String("vrrp-password", "", `If set it will use it as keepalived password instead of the
 		generated one using information about the nodes`)
+
+	enableIPVSConntrack = flags.Bool("enable-ipvs-conntrack", false,
+		`enable ipvs conntrack in net/ipv4/vs/conntrack`)
 
 	// sysctl changes required by keepalived
 	sysctlAdjustments = map[string]int{
@@ -49,11 +53,22 @@ var (
 		// enable connection tracking for LVS connections
 		"net/ipv4/vs/conntrack": 1,
 	}
+
+	// kernel modules to load and proc files to check
+	kernelModules = map[string]string{
+		// Linux ip virtual server
+		"ip_vs": "/proc/net/ip_vs",
+	}
 )
 
 func main() {
 	clientConfig := kubectl_util.DefaultClientConfig(flags)
 	flags.Parse(os.Args)
+
+	if enableIPVSConntrack != nil && *enableIPVSConntrack {
+		// enables ipvs connection tracking using nf_conntrack
+		sysctlAdjustments["net/ipv4/vs/conntrack"] = 1
+	}
 
 	var err error
 	var kubeClient *unversioned.Client
@@ -76,17 +91,19 @@ func main() {
 	}
 
 	if !specified {
-		namespace = ""
+		namespace = kapi.NamespaceAll
 	}
 
-	err = loadIPVModule()
-	if err != nil {
-		glog.Fatalf("Terminating execution: %v", err)
-	}
+	if !*debugKeeplivedConf {
+		err = loadKernelModules()
+		if err != nil {
+			glog.Fatalf("Terminating execution: %v", err)
+		}
 
-	err = changeSysctl()
-	if err != nil {
-		glog.Fatalf("Terminating execution: %v", err)
+		err = changeSysctl()
+		if err != nil {
+			glog.Fatalf("Terminating execution: %v", err)
+		}
 	}
 
 	err = resetIPVS()
@@ -104,6 +121,6 @@ func main() {
 	go wait.Until(ipvsc.worker, time.Second, wait.NeverStop)
 
 	time.Sleep(5 * time.Second)
-	glog.Info("starting keepalived to announce VIPs")
+
 	ipvsc.keepalived.Start()
 }

--- a/keepalived-vip/main.go
+++ b/keepalived-vip/main.go
@@ -43,15 +43,13 @@ var (
 	password = flags.String("vrrp-password", "", `If set it will use it as keepalived password instead of the
 		generated one using information about the nodes`)
 
-	enableIPVSConntrack = flags.Bool("enable-ipvs-conntrack", false,
+	enableIPVSConntrack = flags.Bool("enable-ipvs-conntrack", true,
 		`enable ipvs conntrack in net/ipv4/vs/conntrack`)
 
 	// sysctl changes required by keepalived
 	sysctlAdjustments = map[string]int{
 		// allows processes to bind() to non-local IP addresses
 		"net/ipv4/ip_nonlocal_bind": 1,
-		// enable connection tracking for LVS connections
-		"net/ipv4/vs/conntrack": 1,
 	}
 
 	// kernel modules to load and proc files to check
@@ -66,7 +64,7 @@ func main() {
 	flags.Parse(os.Args)
 
 	if enableIPVSConntrack != nil && *enableIPVSConntrack {
-		// enables ipvs connection tracking using nf_conntrack
+		// enable connection tracking for LVS connections using nf_conntrack
 		sysctlAdjustments["net/ipv4/vs/conntrack"] = 1
 	}
 

--- a/keepalived-vip/utils.go
+++ b/keepalived-vip/utils.go
@@ -65,10 +65,9 @@ func getNodeInfo(nodes []string, forcedIP string) (*nodeInfo, error) {
 func getEffectiveIP(nodes []string, forcedIP string) (string, error) {
 	if len(forcedIP) > 0 {
 		return forcedIP, nil
-	} else {
-		ip, err := myIP(nodes)
-		return ip, err
 	}
+	ip, err := myIP(nodes)
+	return ip, err
 }
 
 // myIP returns the local IP address of this node comparing the

--- a/keepalived-vip/utils.go
+++ b/keepalived-vip/utils.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
@@ -46,8 +47,8 @@ type nodeInfo struct {
 }
 
 // getNodeInfo returns information of the node where the pod is running
-func getNodeInfo(nodes []string) (*nodeInfo, error) {
-	ip, err := myIP(nodes)
+func getNodeInfo(nodes []string, forcedIP string) (*nodeInfo, error) {
+	ip, err := getEffectiveIP(nodes, forcedIP)
 	if err != nil {
 		return &nodeInfo{}, err
 	}
@@ -57,6 +58,17 @@ func getNodeInfo(nodes []string) (*nodeInfo, error) {
 		ip:      ip,
 		netmask: maskForLocalIP(ip),
 	}, nil
+}
+
+// getEffectiveIP returns the forcedIP if it was given on the cmdline.
+// If forcedIP is not set it will return the node address
+func getEffectiveIP(nodes []string, forcedIP string) (string, error) {
+	if len(forcedIP) > 0 {
+		return forcedIP, nil
+	} else {
+		ip, err := myIP(nodes)
+		return ip, err
+	}
 }
 
 // myIP returns the local IP address of this node comparing the
@@ -193,16 +205,20 @@ func getNodePriority(ip string, nodes []string) int {
 }
 
 // loadIPVModule load module require to use keepalived
-func loadIPVModule() error {
-	out, err := k8sexec.New().Command("modprobe", "ip_vs").CombinedOutput()
-	if err != nil {
-		glog.V(2).Infof("Error loading ip_vip: %s, %v", string(out), err)
-		return err
-	}
+func loadKernelModules() error {
+	for k, v := range kernelModules {
+		out, err := k8sexec.New().Command("modprobe", k).CombinedOutput()
+		if err != nil {
+			glog.V(2).Infof("Error loading %s: %s, %v", k, string(out), err)
+			return err
+		}
 
-	_, err = os.Stat("/proc/net/ip_vs")
-	if err != nil {
-		return err
+		if len(v) > 0 {
+			_, err := os.Stat(v)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -227,4 +243,14 @@ func appendIfMissing(slice []string, item string) []string {
 		}
 	}
 	return append(slice, item)
+}
+
+func calculateNetwork(ip string, netmask int) (string, error) {
+	_, parsedNet, err := net.ParseCIDR(ip + "/" + strconv.FormatInt(int64(netmask), 10))
+
+	if err != nil {
+		return "", err
+	}
+
+	return parsedNet.IP.String(), nil
 }


### PR DESCRIPTION
This PR adds support for custom templates by adding a flag to set a custom template file.
It also supports defining routes and routing rules using additional annotations.
The next release of keepalived is going to add support for routing rules.

New annotations are:
- k8s.io/public-vip-netmask 
- k8s.io/public-vip-route

This looks like this:

```
k8s.io/public-vip: "11.22.33.44"
k8s.io/public-vip-netmask: "24"
k8s.io/public-vip-route: "11.22.33.254"
```

Add flags for:
- path to keepalived binary
- path to template filename
- path to keepalived.conf
- path to keepalived.pid
- template generation debug (does not start keepalived)
- to enable ipvs conntrack (implemented it before it was upstream and added to flag to keep upstream behavior by default)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/513)

<!-- Reviewable:end -->
