### PR TITLE
Tollerate issue URLs in rebuild requests

### DIFF
--- a/mungegithub/mungers/rebuild.go
+++ b/mungegithub/mungers/rebuild.go
@@ -34,9 +34,13 @@ type RebuildMunger struct {
 	robots sets.String
 }
 
+const (
+	issueURLRe = "(?:https?://)?github.com/kubernetes/kubernetes/issues/[0-9]+"
+)
+
 var (
 	buildMatcher = regexp.MustCompile("@k8s-bot\\s+(?:e2e\\s+)?(?:unit\\s+)?test\\s+this.*")
-	issueMatcher = regexp.MustCompile("\\s+(?:github\\s+)?(issue|flake)\\:?\\s+#(?:IGNORE|[0-9]+)")
+	issueMatcher = regexp.MustCompile("\\s+(?:github\\s+)?(issue|flake)\\:?\\s+(?:#(?:IGNORE|[0-9]+)|" + issueURLRe + ")")
 )
 
 func init() {

--- a/mungegithub/mungers/rebuild_test.go
+++ b/mungegithub/mungers/rebuild_test.go
@@ -104,6 +104,18 @@ func TestRebuildMissingIssue(t *testing.T) {
 			value:         "@k8s-bot test this please flake: #12345",
 			expectMissing: false,
 		},
+		{
+			value:         "@k8s-bot test this please flake: https://github.com/kubernetes/kubernetes/issues/12345",
+			expectMissing: false,
+		},
+		{
+			value:         "@k8s-bot test this please flake: http://github.com/kubernetes/kubernetes/issues/12345",
+			expectMissing: false,
+		},
+		{
+			value:         "@k8s-bot test this please flake: github.com/kubernetes/kubernetes/issues/12345",
+			expectMissing: false,
+		},
 	}
 	for _, test := range tests {
 		comment := &githubapi.IssueComment{


### PR DESCRIPTION
The following are rendered equivalently, but currently treated differently by the rebuild munger. This PR fixes that.

- @k8s-bot test this issue: #522 

  `@k8s-bot test this issue: #522`
- @k8s-bot test this issue: https://github.com/kubernetes/contrib/issues/522

  `@k8s-bot test this issue: https://github.com/kubernetes/contrib/issues/522`

  (the kubernetes/kubernetes repo is hardcoded, but I changed it to contrib for illustration)