### PR TITLE
Add a 'kind/old-docs' label to PRs which touch files moving out of tree

### DIFF
--- a/mungegithub/path-label.txt
+++ b/mungegithub/path-label.txt
@@ -14,3 +14,8 @@
 # pkg/apis/*/*/types.go
 ^pkg/apis/[^/]+/([^/]+/)?types.go$    kind/api-change
 ^pkg/apis/[^/]+/([^/]+/)?register.go$ kind/new-api
+
+# docs which are going away with move to separate doc repo
+^docs/getting-started-guides	kind/old-docs
+^docs/admin			kind/old-docs
+^docs/user-guide		kind/old-docs


### PR DESCRIPTION
... as we split the docs to their own repo