### PR TITLE
Default to --dry-run

### DIFF
--- a/mungegithub/Makefile
+++ b/mungegithub/Makefile
@@ -61,9 +61,9 @@ rc:
 	sed -e 's|[[:digit:]]\{4\}-[[:digit:]]\{2\}-[[:digit:]]\{2\}-[[:xdigit:]]\+|$(TAG)|g' rc.yaml > local.rc.yaml
 	# update the rc.yaml with the current repo (if not gcr.io
 	sed -i -e 's|gcr.io/google_containers|$(REPO)|g' local.rc.yaml
-ifneq ($(READONLY),false)
-	# update the rc.yaml with --dry-run
-	sed -i -e 's!^\([[:space:]]\+\)- --token-file=/etc/secret-volume/token!\1- --token-file=/etc/secret-volume/token\n\1- --dry-run!g' local.rc.yaml
+ifeq ($(READONLY),false)
+	# update the rc.yaml with --dry-run=false
+	sed -i -e 's!^\([[:space:]]\+\)- --dry-run=true!\1- --dry-run=false!g' local.rc.yaml
 endif
 	# update the rc.yaml with label "readonly: true"
 	sed -i -e 's!^\([[:space:]]\+\)app: mungegithub!\1app: mungegithub\n\1readonly: "$(READONLY)"!g' local.rc.yaml

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -268,7 +268,7 @@ func (config *Config) AddRootFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&config.TokenFile, "token-file", "", "The file containing the OAuth Token to use for requests.")
 	cmd.PersistentFlags().IntVar(&config.MinPRNumber, "min-pr-number", 0, "The minimum PR to start with")
 	cmd.PersistentFlags().IntVar(&config.MaxPRNumber, "max-pr-number", maxInt, "The maximum PR to start with")
-	cmd.PersistentFlags().BoolVar(&config.DryRun, "dry-run", false, "If true, don't actually merge anything")
+	cmd.PersistentFlags().BoolVar(&config.DryRun, "dry-run", true, "If true, don't actually merge anything")
 	cmd.PersistentFlags().BoolVar(&config.useMemoryCache, "use-http-cache", true, "If true, use a client side HTTP cache for API requests.")
 	cmd.PersistentFlags().StringVar(&config.Org, "organization", "kubernetes", "The github organization to scan")
 	cmd.PersistentFlags().StringVar(&config.Project, "project", "kubernetes", "The github project to scan")

--- a/mungegithub/rc.yaml
+++ b/mungegithub/rc.yaml
@@ -27,6 +27,7 @@ spec:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
         - --pr-mungers=blunderbuss,lgtm-after-commit,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,submit-queue
+        - --dry-run=true
         image: gcr.io/google_containers/mungegithub:2015-10-26-2a7f8fd
         imagePullPolicy: IfNotPresent
         name: mungegithub


### PR DESCRIPTION
Must use --dry-run=false if you want to make changes to github.

Helps make sure developers don't accidentally make changes to github.