### PR TITLE
Add @fejta and @spxtr to blunderbuss config for test/

### DIFF
--- a/mungegithub/blunderbuss.yml
+++ b/mungegithub/blunderbuss.yml
@@ -233,4 +233,6 @@ prefixMap:
     - ihmccreery
 
   test:
+    - fejta
     - ixdy
+    - spxtr


### PR DESCRIPTION
Largely `test/` PRs have mostly involve triaging to proper owners, but I'd like not to have to do that all myself.

cc @fejta @spxtr and also @kubernetes/sig-testing in case anyone else feels they should be on this