### PR TITLE
submit-queue: Remove closed PRs from queue

### DIFF
--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -71,6 +71,10 @@ func NoOKToMergeIssue() *github.Issue {
 	return github_test.Issue(whitelistUser, 1, []string{"cla: yes", "lgtm"}, true)
 }
 
+func DoNotMergeIssue() *github.Issue {
+	return github_test.Issue(whitelistUser, 1, []string{"cla: yes", "lgtm", doNotMergeLabel}, true)
+}
+
 func NoCLAIssue() *github.Issue {
 	return github_test.Issue(whitelistUser, 1, []string{"lgtm", "ok-to-merge"}, true)
 }
@@ -592,6 +596,19 @@ func TestSubmitQueue(t *testing.T) {
 			e2ePass:    false,
 			unitPass:   true,
 			reason:     ghE2EFailed,
+			state:      "pending",
+		},
+		{
+			name:       "Fail because doNotMerge label is present",
+			pr:         ValidPR(),
+			issue:      DoNotMergeIssue(),
+			events:     NewLGTMEvents(),
+			commits:    Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus:   SuccessStatus(),
+			jenkinsJob: SuccessJenkins(),
+			e2ePass:    true,
+			unitPass:   true,
+			reason:     noMerge,
 			state:      "pending",
 		},
 	}


### PR DESCRIPTION
Little bit of code de-dup/refactor. Then every time we run all PRs, we check those on the queue a second time. Thus those on the queue that get merged/closed will get noticed before they get to the top.