### PR TITLE
Replace the (unused) url-list flag with a paths flag 

### DIFF
--- a/scale-demo/vegeta/Makefile
+++ b/scale-demo/vegeta/Makefile
@@ -1,10 +1,10 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 0.4
+TAG = 0.5
 
 loader: loader.go
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o loader
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 godep go build -a -installsuffix cgo -ldflags '-w' -o loader
 
 container: loader
 	docker build -t gcr.io/google_containers/loader:$(TAG) .


### PR DESCRIPTION
To allow the loader to hit multiple url paths and/or override the default url path on the host under test.

Fix the Makefile to work properly with godeps.
