### PR TITLE
Add do-not-merge to all cherry-picks which have not been approved

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -583,7 +583,12 @@ func GetLabelsWithPrefix(labels []github.Label, prefix string) []string {
 	return ret
 }
 
-// AddLabels will add all of the named `labels` to the PR
+// AddLabel adds a single `label` to the issue
+func (obj *MungeObject) AddLabel(label string) error {
+	return obj.AddLabels([]string{label})
+}
+
+// AddLabels will add all of the named `labels` to the issue
 func (obj *MungeObject) AddLabels(labels []string) error {
 	config := obj.config
 	prNum := *obj.Issue.Number

--- a/mungegithub/mungers/label-unapproved-cherrypicks.go
+++ b/mungegithub/mungers/label-unapproved-cherrypicks.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"fmt"
+
+	"k8s.io/contrib/mungegithub/features"
+	"k8s.io/contrib/mungegithub/github"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	labelUnapprovedPicksName = "label-unapproved-picks"
+)
+
+// LabelUnapprovedPicks will remove the LGTM flag from an PR which has been
+// updated since the reviewer added LGTM
+type LabelUnapprovedPicks struct{}
+
+func init() {
+	RegisterMungerOrDie(LabelUnapprovedPicks{})
+}
+
+// Name is the name usable in --pr-mungers
+func (LabelUnapprovedPicks) Name() string { return labelUnapprovedPicksName }
+
+// RequiredFeatures is a slice of 'features' that must be provided
+func (LabelUnapprovedPicks) RequiredFeatures() []string { return []string{} }
+
+// Initialize will initialize the munger
+func (LabelUnapprovedPicks) Initialize(config *github.Config, features *features.Features) error {
+	return nil
+}
+
+// EachLoop is called at the start of every munge loop
+func (LabelUnapprovedPicks) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (LabelUnapprovedPicks) AddFlags(cmd *cobra.Command, config *github.Config) {}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (LabelUnapprovedPicks) Munge(obj *github.MungeObject) {
+	if !obj.IsPR() {
+		return
+	}
+
+	if obj.IsForBranch("master") {
+		return
+	}
+
+	if obj.HasLabel(cpApprovedLabel) {
+		return
+	}
+
+	obj.AddLabel(doNotMergeLabel)
+
+	msg := fmt.Sprintf("This PR is not for the master branch but does not have the `%s` label. Adding the `%s` label.", cpApprovedLabel, doNotMergeLabel)
+	obj.WriteComment(msg)
+}

--- a/mungegithub/submit-queue/rc.yaml
+++ b/mungegithub/submit-queue/rc.yaml
@@ -23,7 +23,7 @@ spec:
       - command:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
-        - --pr-mungers=blunderbuss,lgtm-after-commit,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,submit-queue
+        - --pr-mungers=blunderbuss,lgtm-after-commit,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,submit-queue
         - --dry-run=true
         image: gcr.io/google_containers/submit-queue:2015-10-26-2a7f8fd
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
We do not remove the label when the approval is given, since its hard to
know if this is the only reason not to merge the PR....