### PR TITLE
[service-loadbalancer] Update README

### DIFF
--- a/service-loadbalancer/README.md
+++ b/service-loadbalancer/README.md
@@ -51,7 +51,7 @@ $ kubectl get svc --all-namespaces -o yaml  | grep -i "selfLink"
     selfLink: /api/v1/namespaces/kube-system/services/monitoring-heapster
     selfLink: /api/v1/namespaces/kube-system/services/monitoring-influxdb
 ```
-These are all the [cluster addon](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons) services in `namespace=kube-system`.
+These are all the [cluster addon](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons) services in all namespaces `--all-namespaces`.
 
 #### Create a loadbalancer
 * Loadbalancers are created via a ReplicationController.


### PR DESCRIPTION
In the service-loadbalancer Examples we use all-namespaces and the description say 'namespace=kube-system'

Just a little update to fix the description

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/569)

<!-- Reviewable:end -->
