### PR TITLE
Changes ansible_fqdn to ansible_default_ipv4.address in Ansible

### DIFF
--- a/ansible/roles/etcd/defaults/main.yaml
+++ b/ansible/roles/etcd/defaults/main.yaml
@@ -19,9 +19,9 @@ etcd_peer_key_file: "{{ etcd_conf_dir }}/peer.key"
 etcd_initial_cluster_state: new
 etcd_initial_cluster_token: etcd-k8-cluster
 
-etcd_initial_advertise_peer_urls: "{{ etcd_peer_url_scheme }}://{{ ansible_fqdn }}:{{ etcd_peer_port }}"
+etcd_initial_advertise_peer_urls: "{{ etcd_peer_url_scheme }}://{{ ansible_default_ipv4.address }}:{{ etcd_peer_port }}"
 etcd_listen_peer_urls: "{{ etcd_peer_url_scheme }}://0.0.0.0:{{ etcd_peer_port }}"
-etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ ansible_fqdn }}:{{ etcd_client_port }}"
+etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ ansible_default_ipv4.address }}:{{ etcd_client_port }}"
 etcd_listen_client_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port }}"
 
 etcd_data_dir: /var/lib/etcd

--- a/ansible/roles/etcd/templates/etcd.conf.j2
+++ b/ansible/roles/etcd/templates/etcd.conf.j2
@@ -1,9 +1,9 @@
 {% macro initial_cluster() -%}
 {% for host in groups[etcd_peers_group] -%}
 {% if loop.last -%}
-{{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['ansible_fqdn'] }}:{{ etcd_peer_port }}
+{{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['ansible_default_ipv4.address'] }}:{{ etcd_peer_port }}
 {%- else -%}
-{{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['ansible_fqdn'] }}:{{ etcd_peer_port }},
+{{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['ansible_default_ipv4.address'] }}:{{ etcd_peer_port }},
 {%- endif -%}
 {% endfor -%}
 {% endmacro -%}


### PR DESCRIPTION
Previously ansible_fqdn was being used to set certain config
parameters. This resolves to 'localhost.localdomain' in too many
situations. This commit replaces ansible_fqdn with
ansible_default_ipv4.address to remove the need for name
resolution.

Fixes Issue: https://github.com/kubernetes/contrib/issues/508