### PR TITLE
CoreOS Support: fix detection of CoreOS related tasks

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Set the bin directory path for CoreOS
   set_fact:
     bin_dir: "/opt/bin"
-  when: ansible_lsb.id == "CoreOS"
+  when: ansible_distribution == "CoreOS"
 
 - name: Create the directory used to store binaries
   file: path={{ bin_dir }} state=directory

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -6,10 +6,10 @@
   when: ansible_distribution == "Ubuntu"
 
 - include: generic-install.yml
-  when: ansible_distribution != "Debian" and ansible_distribution != "Ubuntu" and ansible_lsb.id != "CoreOS"
+  when: ansible_distribution != "Debian" and ansible_distribution != "Ubuntu" and ansible_distribution != "CoreOS"
 
 - include: coreos.yml
-  when: ansible_lsb.id == "CoreOS"
+  when: ansible_distribution == "CoreOS"
 #
 # systemd service configuration uses EnvironmentFile (docker and docker-network)
 # upstart service configuration sources docker_config_dir / docker

--- a/ansible/roles/etcd/tasks/main.yml
+++ b/ansible/roles/etcd/tasks/main.yml
@@ -6,7 +6,7 @@
         state: latest
   notify:
     - restart etcd
-  when: not is_atomic and ansible_distribution != "Ubuntu" and ansible_lsb.id != "CoreOS"
+  when: not is_atomic and ansible_distribution != "Ubuntu" and ansible_distribution != "CoreOS"
 
 - name: Force etcd_source_type to github when packages are not available
   set_fact:
@@ -24,7 +24,7 @@
   template: src=etcd.conf.j2 dest=/etc/etcd/etcd.conf
   notify:
     - restart etcd
-  when: ansible_lsb.id != "CoreOS"
+  when: ansible_distribution != "CoreOS"
 
 - name: Write etcd systemd unit file for Debian
   copy: src=etcd.service dest=/etc/systemd/system
@@ -35,15 +35,15 @@
 
 - name: Enable etcd
   service: name=etcd enabled=yes
-  when: ansible_lsb.id != "CoreOS"
+  when: ansible_distribution != "CoreOS"
 
 - name: Start etcd
   service: name=etcd state=started
   register: etcd_started
-  when: ansible_lsb.id != "CoreOS"
+  when: ansible_distribution != "CoreOS"
 
 - include: coreos.yml
-  when: ansible_lsb.id == "CoreOS"
+  when: ansible_distribution == "CoreOS"
 
 - include: firewalld.yml
   when: has_firewalld

--- a/ansible/roles/flannel/tasks/client.yml
+++ b/ansible/roles/flannel/tasks/client.yml
@@ -4,25 +4,20 @@
   args:
         name: flannel
         state: latest
-  when: not is_atomic and ansible_lsb.id != "CoreOS"
-
-- name: Force flannel_source_type to github when packages are not available
-  set_fact:
-    flannel_source_type: "github-release"
-  when: ansible_lsb.id == "CoreOS"
+  when: not is_atomic and ansible_distribution != "CoreOS"
 
 - name: Install from github
   include: github-release.yml
-  when: flannel_source_type == "github-release"
+  when: ansible_distribution == "CoreOS"
 
 - name: Install Flannel config file
   template: src=flanneld.j2 dest=/etc/sysconfig/flanneld
-  when: ansible_lsb.id != "CoreOS"
+  when: ansible_distribution != "CoreOS"
   notify:
     - restart flannel
 
 - name: Install Flannel config file
   template: src=flanneld-coreos.j2 dest=/etc/sysconfig/flanneld
-  when: ansible_lsb.id == "CoreOS"
+  when: ansible_distribution == "CoreOS"
   notify:
     - restart flannel

--- a/ansible/roles/flannel/tasks/main.yml
+++ b/ansible/roles/flannel/tasks/main.yml
@@ -5,7 +5,7 @@
   when: inventory_hostname in groups['masters'] + groups['nodes']
 
 - include: coreos.yml
-  when: ansible_lsb.id == "CoreOS"
+  when: ansible_distribution == "CoreOS"
 
 - include: firewalld.yml
   when: has_firewalld

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -2,13 +2,16 @@
 - name: Set python_bin fact for CoreOS
   set_fact:
     python_bin: "/opt/bin/python"
-  when: ansible_lsb.id == "CoreOS"
+  when: ansible_distribution == "CoreOS"
+  set_fact:
+    python_bin: "python"
+  when: python_bin is not defined
 
 - name: Assures addons dir exists
   file: path={{ kube_addons_dir }} state=directory
 
 - include: generic-install.yml
-  when: not is_atomic and ansible_lsb.id != "CoreOS"
+  when: not is_atomic and ansible_distribution != "CoreOS"
 
 - name: Assures local addon dir exists
   local_action: file

--- a/ansible/roles/kubernetes/tasks/gen_certs.yml
+++ b/ansible/roles/kubernetes/tasks/gen_certs.yml
@@ -7,7 +7,7 @@
   with_items:
     - openssl
     - curl
-  when: not is_atomic and ansible_lsb.id != "CoreOS"
+  when: not is_atomic and ansible_distribution != "CoreOS"
 
 #- name: Get create ca cert script from Kubernetes
 #  get_url:

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -11,7 +11,7 @@
   set_fact:
     bin_dir: "/opt/bin"
     kube_script_dir: "/opt/bin/kubernetes"
-  when: ansible_lsb.id == "CoreOS" and kube_script_dir == "/usr/libexec/kubernetes"
+  when: ansible_distribution == "CoreOS" and kube_script_dir == "/usr/libexec/kubernetes"
 
 - name: Create kubernetes config directory
   file: path={{ kube_config_dir }} state=directory
@@ -28,7 +28,7 @@
     - restart daemons
 
 - include: download_bins.yml
-  when: ansible_lsb.id == "CoreOS"
+  when: ansible_distribution == "CoreOS"
 
 - include: secrets.yml
   tags:

--- a/ansible/roles/master/handlers/main.yml
+++ b/ansible/roles/master/handlers/main.yml
@@ -3,7 +3,7 @@
   command: systemctl --system daemon-reload
   notify:
     - restart daemons
-  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15) or (ansible_lsb.id == "CoreOS")
+  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15) or (ansible_distribution == "CoreOS")
 
 - name: restart daemons
   command: /bin/true

--- a/ansible/roles/master/tasks/main.yml
+++ b/ansible/roles/master/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: coreos.yml
-  when: ansible_lsb.id == "CoreOS"
+  when: ansible_distribution == "CoreOS"
 
 - include: packageManagerInstall.yml
   when: source_type == "packageManager"
@@ -23,7 +23,7 @@
 
 - name: add cap_net_bind_service to kube-apiserver
   capabilities: path=/usr/bin/kube-apiserver capability=cap_net_bind_service=ep state=present
-  when: not is_atomic and ansible_lsb.id != "CoreOS"
+  when: not is_atomic and ansible_distribution != "CoreOS"
 
 - name: Enable apiserver
   service: name=kube-apiserver enabled=yes state=started

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: coreos.yml
-  when: ansible_lsb.id == "CoreOS"
+  when: ansible_distribution == "CoreOS"
 
 - name: Set selinux permissive because tokens and selinux don't work together
   selinux: state=permissive policy={{ ansible_selinux.type }}


### PR DESCRIPTION
Currently, the playbook is broken on RHEL due to undefined facts:

* change ansible_lsb.id to ansible_distribution
* install flannel from github only on CoreOS

Fixes #599 