### PR TITLE
add Vagrant working directory to gitignore

### DIFF
--- a/ansible/vagrant/.gitignore
+++ b/ansible/vagrant/.gitignore
@@ -1,1 +1,2 @@
+/.vagrant/
 openstack_config.yml


### PR DESCRIPTION
Vagrant writes in `.vagrant` directory cache information.