### PR TITLE
add ansible configuration for running it from vagrant directory

### DIFF
--- a/ansible/vagrant/ansible.cfg
+++ b/ansible/vagrant/ansible.cfg
@@ -1,0 +1,11 @@
+# Ansible configuration to use in Vagrant environment.
+
+[defaults]
+# VM fingerprint changes when you recreate VM, so let's disable its validation.
+host_key_checking = False
+
+# Use vagrant private key.
+ansible_ssh_private_key_file: ~/.vagrant.d/insecure_private_key
+
+# Vagrant prepares inventory file with proper auth settings.
+inventory = .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory


### PR DESCRIPTION
This allows to run ansible directly on provisioned with Vagrant cluster
(from the `vagrant` directory).