### PR TITLE
Add kubelet-gce-e2e-ci jenkins job as merge queue blocker

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -212,6 +212,7 @@ func (sq *SubmitQueue) EachLoop() error {
 // AddFlags will add any request flags to the cobra `cmd`
 func (sq *SubmitQueue) AddFlags(cmd *cobra.Command, config *github.Config) {
 	cmd.Flags().StringSliceVar(&sq.JobNames, "jenkins-jobs", []string{
+		"kubelet-gce-e2e-ci",
 		"kubernetes-build",
 		"kubernetes-test-go",
 		"kubernetes-e2e-gce",


### PR DESCRIPTION
History:
http://kubekins.dls.corp.google.com/view/Node/job/kubelet-gce-e2e-ci/buildTimeTrend
