### PR TITLE
New munger to manage 'release-note' labels

### DIFF
--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"fmt"
+
+	"k8s.io/contrib/mungegithub/features"
+	"k8s.io/contrib/mungegithub/github"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	releaseNoteLabeler = "release-note-label"
+
+	releaseNoteLabelNeeded    = "release-note-label-needed"
+	releaseNote               = "release-note"
+	releaseNoteNone           = "release-note-none"
+	releaseNoteActionRequired = "release-note-action-required"
+)
+
+// ReleaseNoteLabel will remove the LGTM label from an PR which has not
+// set one of the appropriete 'release-note-*' labels.
+type ReleaseNoteLabel struct{}
+
+func init() {
+	RegisterMungerOrDie(ReleaseNoteLabel{})
+}
+
+// Name is the name usable in --pr-mungers
+func (ReleaseNoteLabel) Name() string { return releaseNoteLabeler }
+
+// RequiredFeatures is a slice of 'features' that must be provided
+func (ReleaseNoteLabel) RequiredFeatures() []string { return []string{} }
+
+// Initialize will initialize the munger
+func (ReleaseNoteLabel) Initialize(config *github.Config, features *features.Features) error {
+	return nil
+}
+
+// EachLoop is called at the start of every munge loop
+func (ReleaseNoteLabel) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (ReleaseNoteLabel) AddFlags(cmd *cobra.Command, config *github.Config) {}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (ReleaseNoteLabel) Munge(obj *github.MungeObject) {
+	if !obj.IsPR() {
+		return
+	}
+
+	if obj.HasLabel(releaseNote) || obj.HasLabel(releaseNoteActionRequired) || obj.HasLabel(releaseNoteNone) {
+		if obj.HasLabel(releaseNoteLabelNeeded) {
+			obj.RemoveLabel(releaseNoteLabelNeeded)
+		}
+		return
+	}
+
+	if !obj.HasLabel(releaseNoteLabelNeeded) {
+		obj.AddLabel(releaseNoteLabelNeeded)
+	}
+
+	if !obj.HasLabel("lgtm") {
+		return
+	}
+
+	msgFmt := `Removing LGTM because the release note process has not been followed.
+One of the following labels is required %q, %q, or %q
+Please see: https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/release-notes.md`
+	msg := fmt.Sprintf(msgFmt, releaseNote, releaseNoteNone, releaseNoteActionRequired)
+	obj.WriteComment(msg)
+	obj.RemoveLabel("lgtm")
+}

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime"
+	"testing"
+
+	github_util "k8s.io/contrib/mungegithub/github"
+	github_test "k8s.io/contrib/mungegithub/github/testing"
+
+	"github.com/golang/glog"
+	"github.com/google/go-github/github"
+)
+
+var (
+	_ = fmt.Printf
+	_ = glog.Errorf
+)
+
+func TestReleaseNoteLabel(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	tests := []struct {
+		name        string
+		issue       *github.Issue
+		mustHave    []string
+		mustNotHave []string
+	}{
+		{
+			name:        "LGTM with release-note",
+			issue:       github_test.Issue(botName, 1, []string{"lgtm", releaseNote}, true),
+			mustHave:    []string{"lgtm", releaseNote},
+			mustNotHave: []string{releaseNoteLabelNeeded},
+		},
+		{
+			name:        "LGTM with release-note-none",
+			issue:       github_test.Issue(botName, 1, []string{"lgtm", releaseNoteNone}, true),
+			mustHave:    []string{"lgtm", releaseNoteNone},
+			mustNotHave: []string{releaseNoteLabelNeeded},
+		},
+		{
+			name:        "LGTM with release-note-action-required",
+			issue:       github_test.Issue(botName, 1, []string{"lgtm", releaseNoteActionRequired}, true),
+			mustHave:    []string{"lgtm", releaseNoteActionRequired},
+			mustNotHave: []string{releaseNoteLabelNeeded},
+		},
+		{
+			name:        "LGTM with release-note-label-needed",
+			issue:       github_test.Issue(botName, 1, []string{"lgtm", releaseNoteLabelNeeded}, true),
+			mustHave:    []string{releaseNoteLabelNeeded},
+			mustNotHave: []string{"lgtm"},
+		},
+		{
+			name:        "LGTM only",
+			issue:       github_test.Issue(botName, 1, []string{"lgtm"}, true),
+			mustHave:    []string{releaseNoteLabelNeeded},
+			mustNotHave: []string{"lgtm"},
+		},
+		{
+			name:     "No labels",
+			issue:    github_test.Issue(botName, 1, []string{}, true),
+			mustHave: []string{releaseNoteLabelNeeded},
+		},
+		{
+			name:     "release-note",
+			issue:    github_test.Issue(botName, 1, []string{releaseNote}, true),
+			mustHave: []string{releaseNote},
+		},
+		{
+			name:     "release-note-none",
+			issue:    github_test.Issue(botName, 1, []string{releaseNoteNone}, true),
+			mustHave: []string{releaseNoteNone},
+		},
+		{
+			name:     "release-note-action-required",
+			issue:    github_test.Issue(botName, 1, []string{releaseNoteActionRequired}, true),
+			mustHave: []string{releaseNoteActionRequired},
+		},
+		{
+			name:        "release-note and release-note-label-needed",
+			issue:       github_test.Issue(botName, 1, []string{releaseNote, releaseNoteLabelNeeded}, true),
+			mustHave:    []string{releaseNote},
+			mustNotHave: []string{releaseNoteLabelNeeded},
+		},
+		{
+			name:        "release-note-none and release-note-label-needed",
+			issue:       github_test.Issue(botName, 1, []string{releaseNoteNone, releaseNoteLabelNeeded}, true),
+			mustHave:    []string{releaseNoteNone},
+			mustNotHave: []string{releaseNoteLabelNeeded},
+		},
+		{
+			name:        "release-note-action-required and release-note-label-needed",
+			issue:       github_test.Issue(botName, 1, []string{releaseNoteActionRequired, releaseNoteLabelNeeded}, true),
+			mustHave:    []string{releaseNoteActionRequired},
+			mustNotHave: []string{releaseNoteLabelNeeded},
+		},
+	}
+	for testNum, test := range tests {
+		client, server, mux := github_test.InitServer(t, test.issue, ValidPR(), nil, nil, nil)
+		path := fmt.Sprintf("/repos/o/r/issue/%s/labels", *test.issue.Number)
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			out := []github.Label{{}}
+			data, err := json.Marshal(out)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			w.Write(data)
+		})
+
+		config := &github_util.Config{}
+		config.Org = "o"
+		config.Project = "r"
+		config.SetClient(client)
+
+		r := ReleaseNoteLabel{}
+		err := r.Initialize(config, nil)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		err = r.EachLoop()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		obj, err := config.GetObject(*test.issue.Number)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		r.Munge(obj)
+
+		for _, l := range test.mustHave {
+			if !obj.HasLabel(l) {
+				t.Errorf("%s:%d Did not find label %q, labels: %v", test.name, testNum, l, obj.Issue.Labels)
+			}
+		}
+		for _, l := range test.mustNotHave {
+			if obj.HasLabel(l) {
+				t.Errorf("%s:%d: Found label %q and should not have, labels: %v", test.name, testNum, l, obj.Issue.Labels)
+			}
+		}
+		server.Close()
+	}
+}


### PR DESCRIPTION
Rules:
All PRs must have one of
- `release-note`
- `release-note-action-required`
- `release-note-none`
- `release-note-label-needed`

Add `release-note-label-needed` to any PR without one of the above.

If a PR gets lgtm and still has `release-note-label-needed` remove LGTM and
message where to get more info.