### PR TITLE
munger: update location of WordSepNormalizeFunc

### DIFF
--- a/mungegithub/mungegithub.go
+++ b/mungegithub/mungegithub.go
@@ -26,7 +26,7 @@ import (
 	github_util "k8s.io/contrib/mungegithub/github"
 	"k8s.io/contrib/mungegithub/mungers"
 	"k8s.io/contrib/mungegithub/reports"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/flag"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -106,7 +106,7 @@ func main() {
 			return doMungers(config)
 		},
 	}
-	root.SetGlobalNormalizationFunc(util.WordSepNormalizeFunc)
+	root.SetGlobalNormalizationFunc(flag.WordSepNormalizeFunc)
 	config.AddRootFlags(root)
 	addMungeFlags(config, root)
 	config.Features.AddFlags(root)


### PR DESCRIPTION
It moved from k8s.io/kubernetes/pkg/util to
k8s.io/kubernetes/pkg/util/flag