### PR TITLE
Fixed wrong KUBECTL_BIN

### DIFF
--- a/ansible/roles/kubernetes-addons/templates/kube-addons.service.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-addons.service.j2
@@ -4,7 +4,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
 Environment="TOKEN_DIR={{ kube_token_dir }}"
-Environment="KUBECTL_BIN={{ bin_dir }}/kubectl"
+Environment="KUBECTL_BIN=/usr/bin/kubectl"
 Environment="PYTHON_BIN={{ python_bin }}"
 Environment="KUBERNETES_MASTER_NAME={{ groups['masters'][0] }}"
 ExecStart={{ kube_script_dir }}/kube-addons.sh

--- a/ansible/roles/kubernetes-addons/templates/kube-addons.upstart.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-addons.upstart.j2
@@ -4,7 +4,7 @@ start on started kube-apiserver
 stop on runlevel [!2345]
 
 env TOKEN_DIR={{ kube_token_dir }}
-env KUBECTL_BIN={{ bin_dir }}/kubectl
+env KUBECTL_BIN=/usr/bin/kubectl
 env PYTHON_BIN={{ python_bin }}
 env KUBERNETES_MASTER_NAME={{ groups['masters'][0] }}
 


### PR DESCRIPTION
Reverted the KUBECTL_BIN to the correct value: /usr/bin/kubectl, since the new one {{ bin_dir }} was referencing the common.yaml default which is /usr/local/bin
And there is not kubectl overthere, thus the addon services were not running

Here is the kube-addons service logs with the {{ bin_dir }} value:

`[root@kube-master system]# systemctl status -l kube-addons
● kube-addons.service - Kubernetes Addon Object Manager
   Loaded: loaded (/etc/systemd/system/kube-addons.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2016-03-23 21:01:15 GMT; 12h ago
     Docs: https://github.com/GoogleCloudPlatform/kubernetes
 Main PID: 27455 (kube-addons.sh)
   CGroup: /system.slice/kube-addons.service
           ├─27455 /bin/bash /usr/libexec/kubernetes/kube-addons.sh
           └─93200 sleep .5

Mar 24 09:17:43 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
Mar 24 09:17:43 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
Mar 24 09:17:44 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
Mar 24 09:17:44 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
Mar 24 09:17:45 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
Mar 24 09:17:45 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
Mar 24 09:17:46 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
Mar 24 09:17:46 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
Mar 24 09:17:47 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
Mar 24 09:17:47 kube-master kube-addons.sh[27455]: /usr/libexec/kubernetes/kube-addons.sh: line 155: /usr/local/bin/kubectl: No such file or directory
[root@kube-master system]# which kubectl
/bin/kubectl
[root@kube-master system]# ps -`