### PR TITLE
fix ansible+vagrant+virtualbox+centos7 configuration

### DIFF
--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -8,7 +8,7 @@ require "yaml"
 require 'vagrant-openstack-provider'
 
 $num_nodes = (ENV['NUM_NODES'] || 2).to_i
-ansible_tags = ENV['ANSIBLE_TAGS']
+$ansible_tags = ENV['ANSIBLE_TAGS']
 
 VAGRANTFILE_API_VERSION = "2"
 
@@ -92,6 +92,48 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
+  def common_ansible_provision(ansible)
+    # This sets up both flannel and kube.
+    ansible.groups = $groups
+    ansible.playbook = "../cluster.yml"
+    ansible.limit = "all" #otherwise the metadata wont be there for ipv4?
+    ansible.tags = $ansible_tags unless $ansible_tags.nil?
+    ansible.raw_ssh_args = ['-o ControlMaster=no']
+  end
+
+  def ansible_provision_openstack(os, override)
+    override.vm.provision :ansible do |ansible|
+      common_ansible_provision(ansible)
+    end
+  end
+
+  def ansible_provision_virtualbox(os, override)
+    override.vm.provision :ansible do |ansible|
+      common_ansible_provision(ansible)
+
+      # for some hypervisors, like vbox, eth0 is not the right interface to bind to.
+      ansible.extra_vars = { flannel_opts: "--iface=eth1" }
+    end
+  end
+
+  def ansible_provision_libvirt(os, override)
+    override.vm.provision :ansible do |ansible|
+      common_ansible_provision(ansible)
+    end
+  end
+
+  def ansible_provision(n)
+    n.vm.provider :openstack do |os, override|
+      ansible_provision_openstack(os, override)
+    end
+    n.vm.provider :virtualbox do |vb, override|
+      ansible_provision_virtualbox(vb, override)
+    end
+    n.vm.provider :libvirt do |lv, override|
+      ansible_provision_libvirt(lv, override)
+    end
+  end
+
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   nodes = Array.new()
@@ -108,7 +150,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # This is how we create the ansible inventory, see it in .vagrant
   # if you want to debug, run 'VAGRANT_LOG=info vagrant up'
   # and you'll see exactly how the cluster comes up via ansible inv.
-  groups = {
+  $groups = {
      "etcd" => ["kube-master"],
      "masters" => ["kube-master"],
      "nodes" => nodes,
@@ -120,27 +162,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     n.vm.hostname = name
     set_provider(n)
 
-    if ansible_tags.nil?
+    if $ansible_tags.nil?
       # This set up the vagrant hosts before we run the main playbook
       # Today this just creates /etc/hosts so machines can talk via their
       # 'internal' IPs instead of the openstack public ip.
       n.vm.provision :ansible do |ansible|
-        ansible.groups = groups
+        common_ansible_provision(ansible)
         ansible.playbook = "./vagrant-ansible.yml"
-        ansible.limit = "all" #otherwise the metadata wont be there for ipv4?
-        ansible.raw_ssh_args = ['-o ControlMaster=no']
       end
     end
 
-    # This sets up both flannel and kube.
-    n.vm.provision :ansible do |ansible|
-      ansible.groups = groups
-      ansible.playbook = "../cluster.yml"
-      ansible.limit = "all" #otherwise the metadata wont be there for ipv4?
-      # for some hypervisors, like vbox, eth0 is not the right interface to bind to.
-      # ansible.extra_vars = { flannel_opts: "--iface=eth1"}
-      ansible.tags = ansible_tags
-      ansible.raw_ssh_args = ['-o ControlMaster=no']
-    end
+    ansible_provision(n)
   end
 end

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -106,7 +106,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # 'internal' IPs instead of the openstack public ip.
     ansible.playbook = "./vagrant-ansible.yml"
 
-    ansible.extra_vars = { vagrant_provider: provider.to_s }
+    if provider == :virtualbox
+      # On VirtualBox eth0 is used for NAT-ed internet connection,
+      # and actual connectivity with the host and other VMs is done
+      # using eth1 interface.
+      ansible.extra_vars = { public_iface: "eth1" }
+    end
   end
 
   def cluster_ansible_provision(ansible, provider)
@@ -116,7 +121,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.playbook = "../cluster.yml"
 
     if provider == :virtualbox
-      # for some hypervisors, like vbox, eth0 is not the right interface to bind to.
+      # On VirtualBox eth0 is used for NAT-ed internet connection,
+      # and actual connectivity with the host and other VMs is done
+      # using eth1 interface.
       ansible.extra_vars = { flannel_opts: "--iface=eth1" }
     end
   end

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -92,45 +92,50 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  def common_ansible_provision(ansible)
-    # This sets up both flannel and kube.
+  def set_common_ansible_options(ansible)
     ansible.groups = $groups
-    ansible.playbook = "../cluster.yml"
     ansible.limit = "all" #otherwise the metadata wont be there for ipv4?
     ansible.tags = $ansible_tags unless $ansible_tags.nil?
     ansible.raw_ssh_args = ['-o ControlMaster=no']
   end
 
-  def ansible_provision_openstack(os, override)
-    override.vm.provision :ansible do |ansible|
-      common_ansible_provision(ansible)
-    end
+  def vagrant_ansible_provision(ansible, provider)
+    set_common_ansible_options(ansible)
+    # This set up the vagrant hosts before we run the main playbook
+    # Today this just creates /etc/hosts so machines can talk via their
+    # 'internal' IPs instead of the openstack public ip.
+    ansible.playbook = "./vagrant-ansible.yml"
+
+    ansible.extra_vars = { vagrant_provider: provider.to_s }
   end
 
-  def ansible_provision_virtualbox(os, override)
-    override.vm.provision :ansible do |ansible|
-      common_ansible_provision(ansible)
+  def cluster_ansible_provision(ansible, provider)
+    set_common_ansible_options(ansible)
 
+    # This sets up both flannel and kube.
+    ansible.playbook = "../cluster.yml"
+
+    if provider == :virtualbox
       # for some hypervisors, like vbox, eth0 is not the right interface to bind to.
       ansible.extra_vars = { flannel_opts: "--iface=eth1" }
     end
   end
 
-  def ansible_provision_libvirt(os, override)
-    override.vm.provision :ansible do |ansible|
-      common_ansible_provision(ansible)
-    end
-  end
-
-  def ansible_provision(n)
+  def run_ansible_provision(n)
     n.vm.provider :openstack do |os, override|
-      ansible_provision_openstack(os, override)
+      override.vm.provision :ansible do |ansible|
+        yield ansible, :openstack
+      end
     end
     n.vm.provider :virtualbox do |vb, override|
-      ansible_provision_virtualbox(vb, override)
+      override.vm.provision :ansible do |ansible|
+        yield ansible, :virtualbox
+      end
     end
     n.vm.provider :libvirt do |lv, override|
-      ansible_provision_libvirt(lv, override)
+      override.vm.provision :ansible do |ansible|
+        yield ansible, :libvirt
+      end
     end
   end
 
@@ -163,15 +168,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     set_provider(n)
 
     if $ansible_tags.nil?
-      # This set up the vagrant hosts before we run the main playbook
-      # Today this just creates /etc/hosts so machines can talk via their
-      # 'internal' IPs instead of the openstack public ip.
-      n.vm.provision :ansible do |ansible|
-        common_ansible_provision(ansible)
-        ansible.playbook = "./vagrant-ansible.yml"
+      run_ansible_provision n do |ansible, provider|
+        vagrant_ansible_provision(ansible, provider)
       end
     end
 
-    ansible_provision(n)
+    run_ansible_provision n do |ansible, provider|
+      cluster_ansible_provision(ansible, provider)
+    end
   end
 end

--- a/ansible/vagrant/vagrant-ansible.yml
+++ b/ansible/vagrant/vagrant-ansible.yml
@@ -1,19 +1,45 @@
 - hosts: all
   sudo: yes
   tasks:
+    - name: "Set host public IP addresses fact"
+      set_fact:
+        hosts_public_ips: |-
+          {
+            {% for host in groups['all'] %}
+              {% if hostvars[host].ansible_default_ipv4.address is defined %}
+                "{{ host }}": "{{ hostvars[host].ansible_default_ipv4.address }}",
+              {% endif %}
+            {% endfor %}
+          }
+
+    # On VirtualBox eth0 is used for NAT-ed internet connection, and actual connectivity
+    # with the host and other VMs is done using eth1 interface.
+    - name: "Set host public IP addresses fact on Virtualbox"
+      set_fact:
+        hosts_public_ips: |-
+          {
+            {% for host in groups['all'] %}
+              {% if hostvars[host].ansible_eth1.ipv4.address is defined %}
+                "{{ host }}": "{{ hostvars[host].ansible_eth1.ipv4.address }}",
+              {% endif %}
+            {% endfor %}
+          }
+      when: vagrant_provider == "virtualbox"
+
     - name: "Build hosts file"
       lineinfile:
         dest=/etc/hosts
         regexp=".*{{ item }}$"
-        line="{{ hostvars[item].ansible_default_ipv4.address }} {{item}}"
+        line="{{ hosts_public_ips[item] }} {{item}}"
         state=present
-      when: hostvars[item].ansible_default_ipv4.address is defined
+      when: item in hosts_public_ips
       with_items: groups['all']
+
     - name: "Remove hostname from localhost line"
       replace:
         dest=/etc/hosts
         regexp="{{ item }} localhost?"
         replace="localhost"
-      when: hostvars[item].ansible_default_ipv4.address is defined
+      when: item in hosts_public_ips
       with_items: groups['all']
 

--- a/ansible/vagrant/vagrant-ansible.yml
+++ b/ansible/vagrant/vagrant-ansible.yml
@@ -1,7 +1,7 @@
 - hosts: all
   sudo: yes
   vars:
-    - public_iface: eth0
+    - public_iface: "{{ ansible_default_ipv4.interface }}"
   tasks:
     - name: "Build hosts file"
       lineinfile:

--- a/ansible/vagrant/vagrant-ansible.yml
+++ b/ansible/vagrant/vagrant-ansible.yml
@@ -1,45 +1,20 @@
 - hosts: all
   sudo: yes
+  vars:
+    - public_iface: eth0
   tasks:
-    - name: "Set host public IP addresses fact"
-      set_fact:
-        hosts_public_ips: |-
-          {
-            {% for host in groups['all'] %}
-              {% if hostvars[host].ansible_default_ipv4.address is defined %}
-                "{{ host }}": "{{ hostvars[host].ansible_default_ipv4.address }}",
-              {% endif %}
-            {% endfor %}
-          }
-
-    # On VirtualBox eth0 is used for NAT-ed internet connection, and actual connectivity
-    # with the host and other VMs is done using eth1 interface.
-    - name: "Set host public IP addresses fact on Virtualbox"
-      set_fact:
-        hosts_public_ips: |-
-          {
-            {% for host in groups['all'] %}
-              {% if hostvars[host].ansible_eth1.ipv4.address is defined %}
-                "{{ host }}": "{{ hostvars[host].ansible_eth1.ipv4.address }}",
-              {% endif %}
-            {% endfor %}
-          }
-      when: vagrant_provider == "virtualbox"
-
     - name: "Build hosts file"
       lineinfile:
         dest=/etc/hosts
         regexp=".*{{ item }}$"
-        line="{{ hosts_public_ips[item] }} {{item}}"
+        line="{{ hostvars[item]['ansible_' + public_iface].ipv4.address }} {{item}}"
         state=present
-      when: item in hosts_public_ips
+      when: hostvars[item]['ansible_' + public_iface].ipv4.address is defined
       with_items: groups['all']
-
     - name: "Remove hostname from localhost line"
       replace:
         dest=/etc/hosts
         regexp="{{ item }} localhost?"
         replace="localhost"
-      when: item in hosts_public_ips
+      when: hostvars[item]['ansible_' + public_iface].ipv4.address is defined
       with_items: groups['all']
-


### PR DESCRIPTION
Changes in Ansible + Vagrant configuration:

* By default on VirtualBox public interface is not `eth0`, but `eth1`: I automatically use proper interface for flannel and when generating `/etc/hosts`.

  This should fix #586 .

* Fix `bin_dir` on CentOS with K8S installed from packages.

These changes are *almost* enough to start K8S cluster in Vagrant on VirtualBox + CentOS 7.
Unfortunately CentOS 7 yet have only [1.2.0alpha1](https://git.centos.org/summary/rpms!kubernetes.git) which doesn't include [commit with `successThreshold` and `failureThreshold` liveness probe parameter](https://github.com/kubernetes/kubernetes/commit/1e88a682da871a4a7f811dc5efcfe3890be8bbf8). This leads to errors in `kube-addons` like following one:

```
мар 24 09:43:38 kube-master kube-addons.sh[30042]: error validating "/etc/kubernetes/addons/dns/skydns-rc.yaml": error validating data: [found invalid field successThreshold for v1.Probe, found invalid field failureThreshold for v1.Probe]; if you choose to ignore these errors, turn validation off with --validate=false
```

To bypass this issue I locally patched kube-addons scripts to include `--validate=false` in `kubectl` invocations:

```
diff --git a/ansible/roles/kubernetes-addons/files/kube-addon-update.sh b/ansible/roles/kubernetes-addons/files/kube-addon-update.sh
index ede2832..ab0e023 100755
--- a/ansible/roles/kubernetes-addons/files/kube-addon-update.sh
+++ b/ansible/roles/kubernetes-addons/files/kube-addon-update.sh
@@ -259,7 +259,7 @@ function create-object() {
     log INFO "Creating new ${obj_type} from file ${file_path} in namespace ${namespace}, name: ${obj_name}"
     # this will keep on failing if the ${file_path} disappeared in the meantime.
     # Do not use too many retries.
-    run-until-success "${KUBECTL} create --namespace=${namespace} -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+    run-until-success "${KUBECTL} create --validate=false --namespace=${namespace} -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
 }
 
 function update-object() {
diff --git a/ansible/roles/kubernetes-addons/files/kube-addons.sh b/ansible/roles/kubernetes-addons/files/kube-addons.sh
index db555fe..916f4e4 100644
--- a/ansible/roles/kubernetes-addons/files/kube-addons.sh
+++ b/ansible/roles/kubernetes-addons/files/kube-addons.sh
@@ -118,7 +118,7 @@ function create-resource-from-string() {
   local -r config_name=$4;
   local -r namespace=$5;
   while [ ${tries} -gt 0 ]; do
-    echo "${config_string}" | ${KUBECTL} --namespace="${namespace}" create -f - && \
+    echo "${config_string}" | ${KUBECTL} --validate=false --namespace="${namespace}" create -f - && \
         echo "== Successfully started ${config_name} in namespace ${namespace} at $(date -Is)" && \
         return 0;
     let tries=tries-1;
```

Note that I tested with `source_type: packageManager` in `group_vars/all.yml`.

Cluster starts with:

```
$ vagrant up --provider virtualbox
[...]
PLAY RECAP *********************************************************************
kube-master                : ok=260  changed=78   unreachable=0    failed=0   
kube-node-1                : ok=125  changed=39   unreachable=0    failed=0   
kube-node-2                : ok=124  changed=39   unreachable=0    failed=0 
```

On kube-master:

```
[root@kube-master ~]# kubectl get nodes
NAME          LABELS                               STATUS    AGE
kube-node-1   kubernetes.io/hostname=kube-node-1   Ready     8m
kube-node-2   kubernetes.io/hostname=kube-node-2   Ready     8m
[root@kube-master ~]# kubectl get pods --all-namespaces
NAMESPACE     NAME                                   READY     STATUS             RESTARTS   AGE
kube-system   elasticsearch-logging-v1-dq4kh         1/1       Running            0          9m
kube-system   elasticsearch-logging-v1-hkymz         1/1       Running            0          9m
kube-system   fluentd-elasticsearch-kube-node-1      1/1       Running            0          7m
kube-system   fluentd-elasticsearch-kube-node-2      1/1       Running            0          6m
kube-system   kibana-logging-v1-irn4b                0/1       CrashLoopBackOff   5          9m
kube-system   kube-dns-v11-0u775                     3/4       Running            3          9m
kube-system   monitoring-influxdb-grafana-v3-clyo8   2/2       Running            0          9m
```

I haven't tested that configured cluster is actually working (see failing kibana-logging above), but at least it looks like properly configured.

My goal is to setup cluster on CoreOS in Vagrant and these changes are required for this anyway (e.g. proper network interface configuration).