### PR TITLE
deploy to ubuntu 15.10 [WIP

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -2,3 +2,5 @@ myinventory
 inventory
 *.swp
 *~
+binaries
+host_vars

--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -3,6 +3,15 @@
 # with the default addons.
 
 - hosts: all
+  sudo: yes
+  gather_facts: true
+  tasks: 
+
+    - lineinfile: dest=/etc/hosts line="{{hostvars[groups['masters'][0]].static_lan_ip}}    {{groups['masters'][0]}}"
+
+    - apt: name=util-linux state=installed
+
+- hosts: all
   gather_facts: false
   sudo: yes
   roles:

--- a/ansible/download-release.sh
+++ b/ansible/download-release.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+mkdir -p binaries
+
+SCRIPT_URL=https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/ubuntu/download-release.sh
+
+curl $SCRIPT_URL | bash

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -35,7 +35,7 @@ insecure_registrys:
 # Kubernetes services will get fake IP addresses from this range.
 # This range must not conflict with anything in your infrastructure. These
 # addresses do not need to be routable and must just be an unused block of space.
-kube_service_addresses: 10.254.0.0/16
+kube_service_addresses: 172.30.0.0/16
 
 # Network implementation (flannel|opencontrail)
 networking: flannel
@@ -57,12 +57,15 @@ flannel_subnet: 172.16.0.0
 # Flannel internal network total size (optional). This is the prefix of the
 # entire flannel overlay network.  So the entirety of 172.16.0.0/12 must be
 # unused in your environment.
-flannel_prefix: 12
+flannel_prefix: 16
 
 # Flannel internal network (optional). This is the size allocation that flannel
 # will give to each node on your network.  With these defaults you should have
 # room for 4096 nodes with 254 pods per node.
 flannel_host_prefix: 24
+
+# the interface/ip to use for flannel inter-node communication
+flannel_iface: eth1
 
 # Set to false to disable logging with elasticsearch
 cluster_logging: true

--- a/ansible/roles/docker/tasks/apt-docker-install.yml
+++ b/ansible/roles/docker/tasks/apt-docker-install.yml
@@ -7,7 +7,7 @@
   register: add_apt_source_docker
 
 - name: Update repository information
-  command: apt-get update
+  apt: update_cache=yes cache_valid_time=1
   when: add_apt_source_docker.changed
 
 - name: Install docker engine

--- a/ansible/roles/etcd/files/etcd.service
+++ b/ansible/roles/etcd/files/etcd.service
@@ -6,8 +6,8 @@ After=network.target
 Type=simple
 WorkingDirectory=/var/lib/etcd/
 EnvironmentFile=-/etc/etcd/etcd.conf
-User=etcd
-ExecStart=/usr/bin/etcd
+User=root
+ExecStart=/usr/local/bin/etcd
 Restart=on-failure
 LimitNOFILE=65536
 

--- a/ansible/roles/etcd/tasks/main.yml
+++ b/ansible/roles/etcd/tasks/main.yml
@@ -22,12 +22,15 @@
   notify:
     - restart etcd
 
+- name: create /var/lib/etcd/
+  file: path=/var/lib/etcd state=directory
+  
 - name: Write etcd systemd unit file for Debian
   copy: src=etcd.service dest=/etc/systemd/system
   notify:
     - reload systemd
     - restart etcd
-  when: ansible_distribution == "Debian"
+  when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu" 
 
 - name: Enable etcd
   service: name=etcd enabled=yes

--- a/ansible/roles/flannel/handlers/main.yml
+++ b/ansible/roles/flannel/handlers/main.yml
@@ -41,6 +41,7 @@
   register: docker_driver
   when: has_docker.rc|int != 2
   changed_when: false
+  failed_when: false
 
   # TODO: fail if no --selinux-enabled in 'OPTIONS'
 - name: docker fix start on btrfs

--- a/ansible/roles/flannel/tasks/client.yml
+++ b/ansible/roles/flannel/tasks/client.yml
@@ -1,17 +1,28 @@
 ---
+
 - name: Install flannel
-  action: "{{ ansible_pkg_mgr }}"
-  args:
-        name: flannel
-        state: latest
-  when: not is_atomic
-
+#  action: "{{ ansible_pkg_mgr }}"
+#  args:
+#        name: flannel
+#        state: latest
+#  when: not is_atomic
+  copy: src=binaries/flannel-0.5.5/flanneld dest=/usr/bin/flanneld mode=755
+  
 - name: Install Flannel config file
-  template: src=flanneld.j2 dest=/etc/sysconfig/flanneld
+#  template: src=flanneld.j2 dest=/etc/sysconfig/flanneld
+  template: src=flanneld.j2 dest=/etc/default/flanneld
+
+- name: Install Flannel systemd file
+  template: src=flanneld.service dest=/etc/systemd/system/flanneld.service
   notify:
     - restart flannel
 
+- name: install Docker systemd file, referring to flannel generated docker network specs
+  template: src=docker.service dest=/etc/systemd/system/docker.service
+  
 - name: Launch Flannel
-  service: name=flanneld state=started enabled=yes
+  service: name=flanneld state=restarted enabled=yes
   notify:
     - restart flannel
+    
+

--- a/ansible/roles/flannel/tasks/config.yml
+++ b/ansible/roles/flannel/tasks/config.yml
@@ -7,13 +7,25 @@
   run_once: true
   delegate_to: "{{ groups['etcd'][0] }}"
 
+
+# flannel docker opts script
+- name: create dir 
+  file: path=/usr/libexec/flannel state=directory
+- name: place mk-docker-opts.sh
+  copy: src=binaries/flannel-0.5.5/mk-docker-opts.sh dest=/usr/libexec/flannel/ mode=755
+
+- name: Create flannel service file
+  template: src=flanneld.service dest=/etc/systemd/system/flanneld.service
+  run_once: true
+  delegate_to: "{{ groups['etcd'][0] }}"
+
 - name: Create flannel config file to go in etcd
   template: src=flannel-conf.json.j2 dest={{ conf_file }}
   run_once: true
   delegate_to: "{{ groups['etcd'][0] }}"
 
 - name: Load the flannel config file into etcd
-  shell: "/usr/bin/etcdctl --no-sync --peers={{ peers }} set {{ conf_loc }} < {{ conf_file }}"
+  shell: "etcdctl --no-sync --peers={{ peers }} set {{ conf_loc }} < {{ conf_file }}"
   run_once: true
   delegate_to: "{{ groups['etcd'][0] }}"
 

--- a/ansible/roles/flannel/templates/docker.service
+++ b/ansible/roles/flannel/templates/docker.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+EnvironmentFile=-/run/flannel/docker
+Type=notify
+ExecStart=/usr/bin/docker daemon -H fd:// \
+	$DOCKER_OPT_BIP \
+	$DOCKER_OPT_IPMASQ \
+	$DOCKER_OPT_MTU \
+	$DOCKER_NETWORK_OPTIONS
+
+MountFlags=slave
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target
+

--- a/ansible/roles/flannel/templates/flanneld-upstart.conf.j2
+++ b/ansible/roles/flannel/templates/flanneld-upstart.conf.j2
@@ -1,0 +1,31 @@
+  description "Flannel service"
+  author "@chenxingyu"
+
+  start on (net-device-up
+    and local-filesystems
+    and runlevel [2345])
+  stop on runlevel [016]
+
+  respawn
+  respawn limit 10 5
+
+  pre-start script
+      FLANNEL=/usr/bin/$UPSTART_JOB
+      if [ -f /etc/default/$UPSTART_JOB ]; then
+          . /etc/default/$UPSTART_JOB
+      fi
+      if [ -f $FLANNEL ]; then
+          exit 0
+      fi
+  exit 22
+  end script
+
+  script
+      # modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
+      FLANNEL=/usr/bin/$UPSTART_JOB
+      FLANNEL_OPTS=""
+      if [ -f /etc/default/$UPSTART_JOB ]; then
+          . /etc/default/$UPSTART_JOB
+      fi
+      exec "$FLANNEL" $FLANNEL_OPTS
+  end script

--- a/ansible/roles/flannel/templates/flanneld.j2
+++ b/ansible/roles/flannel/templates/flanneld.j2
@@ -10,3 +10,5 @@ FLANNEL_ETCD_KEY="/{{ cluster_name }}/network"
 # Any additional options that you want to pass
 # By default, we just add a good guess for the network interface on Vbox.  Otherwise, Flannel will probably make the right guess.
 FLANNEL_OPTIONS="{{ flannel_opts | default('') }}"
+
+FLANNEL_IFACE="{{flannel_iface}}"

--- a/ansible/roles/flannel/templates/flanneld.service
+++ b/ansible/roles/flannel/templates/flanneld.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Flanneld overlay address etcd agent
+After=network.target
+After=etcd.service
+
+[Service]
+Type=notify
+Restart=always
+RestartSec=3
+
+EnvironmentFile=/etc/default/flanneld
+EnvironmentFile=-/etc/default/docker-network
+ExecStart=/usr/bin/flanneld -iface=${FLANNEL_IFACE} -etcd-endpoints=${FLANNEL_ETCD} -etcd-prefix=${FLANNEL_ETCD_KEY} $FLANNEL_OPTIONS
+ExecStartPost=/usr/libexec/flannel/mk-docker-opts.sh -k DOCKER_NETWORK_OPTIONS -d /run/flannel/docker
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
I have recently been working to deploy to Ubuntu 15.10 (preparing for systemd in the 16.04 LTS release). I would like to contribute, but am new to the k8s community. I like to have some alignment that assures me we will push the same direction. This PR is intended to gather some insight on how to make the ansible module more portable, as I think that is nontrivial. 

I see multiple people are using the contrib/ansible repo ( #428 #619 #586 #508 #406, a simple search: https://github.com/kubernetes/contrib/search?utf8=%E2%9C%93&q=ansible&type=Issues ). Some nice people like @eparis @rsmitty @danehans @rutsky have been working on improving it. 

I see that we attempt to make a number of things flexible: 
- k8s version, and binary/source distribution (i see the source_type variable is used). 
- OS distribution (the `when: ansible_distribution != "CoreOS"` is used in roles/tasks/flannel/client). I am afraid this when: thingy is tricky to use for all kinds of different OS's. 
- the ip addresses of the peers, and the way in which to define this (`ansible_hostname` or `ansible_fqdn`, but what about if we want to use an internal network?)
- the users that are assumed to be present on the system (e.g. 'etcd' was a user not present on ubuntu; maybe no assumptions should be made at all)
- the location where `etcdctl` turns out to be installed (`usr/bin/etcdctl` didn't hold after installing on ubuntu)

Some choice to make things more portable: 
- standardize on certain choices (e.g. no matter the OS, the implementation of the etcdctl installer _must_ create a binary in /usr/bin ; but I think a better standard would be: no matter the OS, the binaries must end up in $PATH and we don't use a full path in calling the binary);
- be configurable (e.g. the IP address of the peers). You can configure in group_vars/all, but you can also split this into separate groups. Currently i see ansible_fqdn and ansible_hostnames used, but this is pretty big assumption (imagine eth1 is your internal net you which to use -- not external eth0)
- be modular (e.g. the tool that configures the network for ubuntu). 

Tools that create flexibility: 
- use of `group_vars`
- use of `host_vars`
- indirect variables (you can set `i_am_kubelet_with_name: {{ansible_hostname}}` in group_vars/nodes and it will be defined for all hosts in `nodes` group, but have a different value)
- modularity 1: dynamic filename of  `include: install_flannel_on_{{ansible_distribution}}.yml`
- modularity 2: running things conditionally with `when: ansible_distribution == "CoreOS"`

I happen to have quite some experience with Ansible and have made significant effort with group_vars, host_vars, and levels of indirection to make things highly configurable. Ansible is super-liberal in how to approach such issues, making things very much a matter of taste.
It is certainly possible do do it more robust/portable, but I also figured it is not trivial (especially since you don't easily test on all environments). I think it requires a well chosen set of best practices. Is there a philosophy on how to these portability issues? How feels/is in the lead?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/620)

<!-- Reviewable:end -->
