### PR TITLE
Updates the Default bin_dir for Ansible

### DIFF
--- a/ansible/roles/common/defaults/main.yaml
+++ b/ansible/roles/common/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 # The directory where binaries are stored on Ansible
 # managed systems.
-bin_dir: /usr/local/bin
+bin_dir: /usr/bin
 
 # The directory used by Ansible to temporarily store
 # files on Ansible managed systems.


### PR DESCRIPTION
Previously, the default bin_dir did not work for some platforms.
The new default follows the contrib/init project settings.

Fixes Issue: https://github.com/kubernetes/contrib/pull/618