### PR TITLE
Fixes python_bin path for Kube Addons in Ansible

### DIFF
--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: Set default python_bin
-  set_fact:
-    python_bin: "python"
-
-- name: Set python_bin fact for CoreOS
-  set_fact:
-    python_bin: "/opt/bin/python"
-  when: is_coreos
-  set_fact:
-    python_bin: "python"
-  when: python_bin is not defined
-
 - name: Assures addons dir exists
   file: path={{ kube_addons_dir }} state=directory
 

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -7,11 +7,16 @@
     kube_script_dir: "/usr/local/libexec/kubernetes"
   when: is_atomic and kube_script_dir == "/usr/libexec/kubernetes"
 
-- name: Update Kubernetes directories if this is CoreOS
+- name: Initialize the python_bin fact
+  set_fact:
+    python_bin: "python"
+
+- name: Update facts if this is CoreOS
   set_fact:
     bin_dir: "/opt/bin"
     kube_script_dir: "/opt/bin/kubernetes"
-  when: is_coreos and kube_script_dir == "/usr/libexec/kubernetes"
+    python_bin: "/opt/bin/python"
+  when: is_coreos
 
 - name: Create kubernetes config directory
   file: path={{ kube_config_dir }} state=directory


### PR DESCRIPTION
Previously, the python_path was not being properly updated for
CoreOS systems. This patch moves python_bin fact management
from the kubernetes-addons role to the kubernetes role.

Fixes Issue: https://github.com/kubernetes/contrib/issues/623