### PR TITLE
Add contiv networking support (https://github.com/kubernetes/contrib/issues/577)

### DIFF
--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -45,6 +45,12 @@
   tags:
     - network-service-install
 
+# install contiv netmaster
+- hosts: masters
+  sudo: yes
+  roles:
+    - { role: contiv, contiv_role: netmaster, when: networking == 'contiv' }
+
 # install kube master services
 - hosts: masters
   sudo: yes
@@ -79,3 +85,9 @@
     - { role: opencontrail-provision, when: networking == 'opencontrail' }
   tags:
     - network-service-config
+
+# install contiv netplugin
+- hosts: nodes
+  sudo: yes
+  roles:
+    - { role: contiv, contiv_role: netplugin, when: networking == 'contiv' }

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -96,3 +96,21 @@ dns_replicas: 1
 
 # See kube documentation for apiserver runtime config options.  Example below enables HPA, deployments features.
 # apiserver_extra_args: "--runtime-config=extensions/v1beta1/deployments=true"
+
+# The port that the Kubernetes apiserver component listens on.
+kube_master_api_port: 443
+
+# This directory is where all the additional config stuff goes
+# the kubernetes normally puts in /srv/kubernets.
+# This puts them in a sane location.
+# Editting this value will almost surely break something. Don't
+# change it. Things like the systemd scripts are hard coded to
+# look in here. Don't do it.
+kube_config_dir: /etc/kubernetes
+
+# This is where all the cert scripts and certs will be located
+kube_cert_dir: "{{ kube_config_dir }}/certs"
+
+# This is the IP where the contiv netmaster can be accessed.
+# Usually, comes via environment or command line
+# contiv_service_vip: 10.6.3.101

--- a/ansible/roles/contiv/defaults/main.yaml
+++ b/ansible/roles/contiv/defaults/main.yaml
@@ -1,0 +1,40 @@
+# This is the ip address of the interface used for control communication within the cluster. It
+# needs to be reachable from all nodes.
+# Defaults to the address used by ansible to reach the node.
+# If using vagrant, this will need to be overriden or edited here.
+contiv_control_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+
+# This is the host interface that contiv uses for all inter-host tenant traffic. Typically set
+# in the inventory file.
+#contiv_network_if: ethX
+
+# Generic way to specify the bin path
+bin_dir: ~/go/bin
+
+# This is the path where contiv build output is kept
+contiv_bin_path: {{ bin_dir }}
+
+# This is the path where contiv binaries are placed on the target
+contiv_bin_dest: /usr/bin
+
+# This is where kubelet looks for plugin files
+kube_plugin_dir: /usr/libexec/kubernetes/kubelet-plugins/net/exec
+
+# Specifies routed mode vs bridged mode for networking (bridge | routing)
+# if you are using an external router for all routing, you should select bridge here
+contiv_fwd_mode: routing
+
+# contiv_def_subnet is the subnet pods will be assigned by default (i.e. pod spec does not
+# specify a network)
+contiv_def_subnet: "20.1.1.0/24"
+contiv_defnet_gw: 20.1.1.254
+
+# The following are aci specific parameters. These must be set only if aci integration
+# is desired. Otherwise, you can ignore these.
+apic_url: ""
+apic_username: ""
+apic_password: ""
+apic_leaf_nodes: ""
+apic_phys_dom: ""
+apic_contracts_unrestricted_mode: no
+apic_epg_bridge_domain: not_specified

--- a/ansible/roles/contiv/files/aci-gw.service
+++ b/ansible/roles/contiv/files/aci-gw.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Contiv ACI gw
+After=auditd.service systemd-user-sessions.service time-sync.target docker.service
+
+[Service]
+ExecStart=/usr/bin/aci_gw.sh start
+ExecStop=/usr/bin/aci_gw.sh stop
+KillMode=control-group
+Restart=on-failure
+RestartSec=10

--- a/ansible/roles/contiv/files/contiv_cni.conf
+++ b/ansible/roles/contiv/files/contiv_cni.conf
@@ -1,0 +1,5 @@
+{
+  "cniVersion": "0.1.0",
+  "name": "contiv-poc",
+  "type": "contivk8s.bin"
+}

--- a/ansible/roles/contiv/files/netmaster.env
+++ b/ansible/roles/contiv/files/netmaster.env
@@ -1,0 +1,1 @@
+NETMASTER_ARGS="--cluster-mode=kubernetes"

--- a/ansible/roles/contiv/files/netmaster.service
+++ b/ansible/roles/contiv/files/netmaster.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Netmaster
+After=auditd.service systemd-user-sessions.service time-sync.target etcd.service
+
+[Service]
+EnvironmentFile=/etc/default/netmaster
+ExecStart=/usr/bin/netmaster $NETMASTER_ARGS
+KillMode=control-group

--- a/ansible/roles/contiv/files/netplugin.service
+++ b/ansible/roles/contiv/files/netplugin.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Netplugin
+After=auditd.service systemd-user-sessions.service time-sync.target etcd.service
+
+[Service]
+EnvironmentFile=/etc/default/netplugin
+ExecStart=/usr/bin/netplugin $NETPLUGIN_ARGS
+KillMode=control-group
+

--- a/ansible/roles/contiv/files/netplugin_clean.sh
+++ b/ansible/roles/contiv/files/netplugin_clean.sh
@@ -1,0 +1,19 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+ovs-vsctl del-br contivVxlanBridge
+ovs-vsctl del-br contivVlanBridge
+for p in `ifconfig  | grep vport | awk '{print $1}'`; do sudo ip link delete $p type veth; done
+

--- a/ansible/roles/contiv/tasks/aci.yml
+++ b/ansible/roles/contiv/tasks/aci.yml
@@ -1,0 +1,23 @@
+- name: check aci-gw container image
+  shell: docker inspect contiv/aci-gw
+  register: docker_aci_inspect_result
+  ignore_errors: yes
+  run_once: true
+
+- name: pull aci-gw container
+  shell: docker pull contiv/aci-gw
+  when: "'No such image' in docker_aci_inspect_result.stderr"
+  run_once: true
+
+- name: copy shell script for starting aci-gw
+  template: src=aci_gw.j2 dest=/usr/bin/aci_gw.sh mode=u=rwx,g=rx,o=rx
+  run_once: true
+
+- name: copy systemd units for aci-gw
+  copy: src=aci-gw.service dest=/etc/systemd/system/aci-gw.service
+  run_once: true
+
+- name: start aci-gw container
+  service: name=aci-gw state=started
+  run_once: true
+

--- a/ansible/roles/contiv/tasks/main.yml
+++ b/ansible/roles/contiv/tasks/main.yml
@@ -1,0 +1,15 @@
+# initial set up of netmaster
+- include: netmaster.yml
+  when: contiv_role == "netmaster"
+
+# clean restart of netmaster
+- include: restart_netmaster.yml tags=contiv_restart
+  when: contiv_role == "netmaster"
+
+# initial set up of netplugin
+- include: netplugin.yml
+  when: contiv_role == "netplugin"
+
+# clean restart of netplugin
+- include: restart_netplugin.yml tags=contiv_restart
+  when: contiv_role == "netplugin"

--- a/ansible/roles/contiv/tasks/netmaster.yml
+++ b/ansible/roles/contiv/tasks/netmaster.yml
@@ -1,0 +1,31 @@
+- name: ensure contiv_bin_dest exists
+  file: path={{ contiv_bin_dest }} recurse=yes state=directory
+
+- name: copy netmaster exec file
+  copy: src={{ contiv_bin_path }}/netmaster dest={{ contiv_bin_dest }}/netmaster mode=0755
+
+- name: copy netctl exec file
+  copy: src={{ contiv_bin_path }}/netctl dest={{ contiv_bin_dest }}/netctl mode=0755
+
+- name: copy netmaster setup script
+  template: src=nw_setup.j2 dest={{ contiv_bin_dest }}/nw_setup.sh mode=0755
+
+- name: copy environment file for netmaster
+  copy: src=netmaster.env dest=/etc/default/netmaster
+
+- name: copy systemd units for netmaster
+  copy: src=netmaster.service dest=/etc/systemd/system/netmaster.service
+
+- name: setup netmaster host alias
+  lineinfile: dest=/etc/hosts line="{{ contiv_service_vip }} netmaster"
+
+- name: restart netmaster
+  service: name=netmaster state=restarted
+
+- name: wait for netmaster
+  pause: seconds=60
+
+- include: aci.yml
+
+- name: configure network
+  shell: {{ contiv_bin_dest }}/nw_setup.sh

--- a/ansible/roles/contiv/tasks/netplugin.yml
+++ b/ansible/roles/contiv/tasks/netplugin.yml
@@ -1,0 +1,86 @@
+- name: ensure pluginDir exists
+  file: path={{ kube_plugin_dir }} recurse=yes state=directory
+
+- name: copy contiv cni conf file
+  copy: src=contiv_cni.conf dest={{ kube_plugin_dir }}/contiv_cni.conf
+
+- name: ensure cni bin dir exists
+  file: path=/opt/cni/bin recurse=yes state=directory
+
+- name: copy contiv cni exec file
+  copy: src={{ contiv_bin_path }}/contivk8s dest=/opt/cni/bin/contivk8s.bin mode=0755
+
+- name: ensure contiv config directory exists
+  file: path=/opt/contiv/config recurse=yes state=directory
+
+- name: setup config for the contiv cni plugin
+  template: src=contiv.cfg.j2 dest=/opt/contiv/config/contiv.json
+
+- name: ensure contiv_bin_dest exists
+  file: path={{ contiv_bin_dest }} recurse=yes state=directory
+
+- name: copy netplugin exec file
+  copy: src={{ contiv_bin_path }}/netplugin dest={{ contiv_bin_dest }}/netplugin mode=0755
+
+- name: get openstack kilo rpm
+  get_url:
+    url: https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm
+    dest: /tmp/rdo-release-kilo-1.noarch.rpm
+    validate_certs: False
+  environment:
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
+  when: ansible_distribution == "CentOS"
+  tags:
+       - ovs_install
+
+- name: install openstack kilo
+  yum: name=/tmp/rdo-release-kilo-1.noarch.rpm state=present
+  when: ansible_distribution == "CentOS"
+  tags:
+       - ovs_install
+
+- name: install ovs
+  environment:
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
+  yum: name=openvswitch state=present
+  when: ansible_distribution == "CentOS"
+  tags:
+       - ovs_install
+
+- name: install ntp
+  yum: name=ntp state=present
+  when: ansible_distribution == "CentOS"
+
+- name: start ntp
+  shell: systemctl enable ntpd
+  when: ansible_distribution == "CentOS"
+
+- name: start ovs service
+  service: "name=openvswitch enabled=yes state=started"
+  when: ansible_distribution == "CentOS"
+
+- name: setup ovs
+  shell: "ovs-vsctl set-manager {{ item }}"
+  with_items:
+    - "tcp:127.0.0.1:6640"
+    - "ptcp:6640"
+
+- name: copy environment file for netplugin
+  template: src=netplugin.j2 dest=/etc/default/netplugin mode=0644
+
+- name: copy systemd units for netplugin
+  copy: src=netplugin.service dest=/etc/systemd/system/netplugin.service
+
+- name: setup netmaster host alias
+  lineinfile: dest=/etc/hosts line="{{ contiv_service_vip }} netmaster"
+
+- name: restart netplugin
+  service: name=netplugin state=restarted
+
+- name: restart kubelet
+  service: name=kubelet state=restarted
+

--- a/ansible/roles/contiv/tasks/restart_netmaster.yml
+++ b/ansible/roles/contiv/tasks/restart_netmaster.yml
@@ -1,0 +1,35 @@
+- name: stop netmaster
+  service: name=netmaster state=stopped
+
+- name: stop aci-gw
+  service: name=aci-gw state=stopped
+  ignore_errors: yes
+
+- name: clean netmaster state
+  shell: etcdctl rm --recursive /contiv.io || true
+
+- name: copy netmaster exec file
+  copy: src={{ contiv_bin_path }}/netmaster dest={{ contiv_bin_dest }}/netmaster mode=0755
+
+- name: copy netctl exec file
+  copy: src={{ contiv_bin_path }}/netctl dest={{ contiv_bin_dest }}/netctl mode=0755
+
+- name: copy n/w setup script
+  template: src=nw_setup.j2 dest={{ contiv_bin_dest }}/nw_setup.sh mode=0755
+
+- name: copy environment file for netmaster
+  copy: src=netmaster.env dest=/etc/default/netmaster
+
+- name: copy systemd units for netmaster
+  copy: src=netmaster.service dest=/etc/systemd/system/netmaster.service
+
+- name: start netmaster
+  service: name=netmaster state=started
+
+- name: wait for netmaster
+  pause: seconds=60
+
+- include: aci.yml
+
+- name: setup network
+  shell: {{ contiv_bin_dest }}/nw_setup.sh

--- a/ansible/roles/contiv/tasks/restart_netplugin.yml
+++ b/ansible/roles/contiv/tasks/restart_netplugin.yml
@@ -1,0 +1,71 @@
+# stop services
+- name: stop kubelet
+  service: name=kubelet state=stopped
+
+- name: stop docker
+  service: name=docker state=stopped
+
+- name: stop netplugin
+  service: name=netplugin state=stopped
+
+# perform clean up
+- name: delete contivk8s log file
+  file: path=/var/log/contivk8s.log state=absent
+
+- name: copy clean up script
+  copy: src=netplugin_clean.sh dest={{ contiv_bin_dest }}/netplugin_clean.sh mode=0755
+
+- name: clean up
+  shell: {{ contiv_bin_dest }}/netplugin_clean.sh || true
+
+# set up services
+- name: ensure pluginDir exists
+  file: path={{ kube_plugin_dir }} recurse=yes state=directory
+
+- name: copy contiv cni conf file
+  copy: src=contiv_cni.conf dest={{ kube_plugin_dir }}/contiv_cni.conf
+
+- name: ensure cni bin dir exists
+  file: path=/opt/cni/bin recurse=yes state=directory
+
+- name: copy contiv cni exec file
+  copy: src={{ contiv_bin_path }}/contivk8s dest=/opt/cni/bin/contivk8s.bin mode=0755
+
+- name: ensure contiv config directory exists
+  file: path=/opt/contiv/config recurse=yes state=directory
+
+- name: setup config for the contiv cni plugin
+  template: src=contiv.cfg.j2 dest=/opt/contiv/config/contiv.json
+
+- name: copy netplugin exec file
+  copy: src={{ contiv_bin_path }}/netplugin dest={{ contiv_bin_dest }}/netplugin mode=0755
+
+- name: copy environment file for netplugin
+  template: src=netplugin.j2 dest=/etc/default/netplugin mode=0644
+
+- name: copy systemd units for netplugin
+  copy: src=netplugin.service dest=/etc/systemd/system/netplugin.service
+
+# start services
+- name: start ovs service
+  service: "name=openvswitch enabled=yes state=started"
+  when: ansible_distribution == "CentOS"
+
+- name: setup ovs
+  shell: "ovs-vsctl set-manager {{ item }}"
+  with_items:
+    - "tcp:127.0.0.1:6640"
+    - "ptcp:6640"
+
+- name: start docker
+  service: name=docker state=started
+
+- name: start netplugin
+  service: name=netplugin state=started
+
+- name: wait for netplugin
+  pause: seconds=45
+
+- name: start kubelet
+  service: name=kubelet state=started
+

--- a/ansible/roles/contiv/templates/aci_gw.j2
+++ b/ansible/roles/contiv/templates/aci_gw.j2
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+usage="$0 start"
+if [ $# -ne 1 ]; then
+    echo USAGE: $usage
+    exit 1
+fi
+
+case $1 in
+start)
+    set -e
+
+    /usr/bin/docker run --net=host \
+    -e "APIC_URL={{ apic_url }}" \
+    -e "APIC_USERNAME={{ apic_username }}" \
+    -e "APIC_PASSWORD={{ apic_password }}" \
+    -e "APIC_LEAF_NODE={{ apic_leaf_nodes }}" \
+    -e "APIC_PHYS_DOMAIN={{ apic_phys_dom }}" \
+    -e "APIC_EPG_BRIDGE_DOMAIN={{ apic_epg_bridge_domain }}" \
+    -e "APIC_CONTRACTS_UNRESTRICTED_MODE={{ apic_contracts_unrestricted_mode }}" \
+    --name=contiv-aci-gw \
+    contiv/aci-gw
+    ;;
+
+stop)
+    # don't stop on error
+    /usr/bin/docker stop contiv-aci-gw
+    /usr/bin/docker rm contiv-aci-gw
+    ;;
+
+*)
+    echo USAGE: $usage
+    exit 1
+    ;;
+esac

--- a/ansible/roles/contiv/templates/contiv.cfg.j2
+++ b/ansible/roles/contiv/templates/contiv.cfg.j2
@@ -1,0 +1,6 @@
+{
+  "K8S_API_SERVER": "https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}",
+  "K8S_CA": "{{ kube_cert_dir }}/ca.crt",
+  "K8S_KEY": "{{ kube_cert_dir }}/kubecfg.key",
+  "K8S_CERT": "{{ kube_cert_dir }}/kubecfg.crt"
+}

--- a/ansible/roles/contiv/templates/netplugin.j2
+++ b/ansible/roles/contiv/templates/netplugin.j2
@@ -1,0 +1,2 @@
+{# If an interface is specified for netplugin, use it #}
+NETPLUGIN_ARGS='-vlan-if {{contiv_network_if}} -vtep-ip {{contiv_control_ip}} -ctrl-ip {{contiv_control_ip}} -plugin-mode kubernetes -fwd-mode {{contiv_fwd_mode}}'

--- a/ansible/roles/contiv/templates/nw_setup.j2
+++ b/ansible/roles/contiv/templates/nw_setup.j2
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#create default nw and epg
+netctl net create default-net --subnet={{contiv_def_subnet}} --gateway={{contiv_defnet_gw}}

--- a/ansible/roles/etcd/defaults/main.yaml
+++ b/ansible/roles/etcd/defaults/main.yaml
@@ -3,6 +3,7 @@
 etcd_source_type: package
 
 etcd_client_port: 2379
+etcd_client_extra: 4001
 etcd_peer_port: 2380
 etcd_peers_group: etcd
 etcd_url_scheme: http
@@ -32,3 +33,4 @@ etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ etcd_machine_address }}:
 etcd_listen_client_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port }}"
 
 etcd_data_dir: /var/lib/etcd
+etcd_proxy_mode: off

--- a/ansible/roles/etcd/templates/etcd.conf.j2
+++ b/ansible/roles/etcd/templates/etcd.conf.j2
@@ -1,13 +1,15 @@
 {% macro initial_cluster() -%}
 {% for host in groups[etcd_peers_group] -%}
+{% if loop.last -%}
   {{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['ansible_' + etcd_interface].ipv4.address }}:{{ etcd_peer_port }}
-  {%- if not loop.last -%},{%- endif -%}
-{%- endfor -%}
+{%- else -%}
+  {{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['ansible_' + etcd_interface].ipv4.address }}:{{ etcd_peer_port }},
+{%- endif -%}
+{% endfor -%}
 {% endmacro -%}
 
-{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 1 %}
+{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 0 %}
 ETCD_NAME={{ ansible_hostname }}
-ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
 {% else %}
 ETCD_NAME=default
 {% endif %}
@@ -15,23 +17,32 @@ ETCD_DATA_DIR={{ etcd_data_dir }}
 #ETCD_SNAPSHOT_COUNTER="10000"
 #ETCD_HEARTBEAT_INTERVAL="100"
 #ETCD_ELECTION_TIMEOUT="1000"
-ETCD_LISTEN_CLIENT_URLS="{{ etcd_listen_client_urls }}"
 #ETCD_MAX_SNAPSHOTS="5"
 #ETCD_MAX_WALS="5"
 #ETCD_CORS=""
 
-{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 1 %}
+
+{% if etcd_proxy_mode == "on" %}
+ETCD_INITIAL_CLUSTER={{ initial_cluster() }}
+ETCD_PROXY="on"
+ETCD_LISTEN_CLIENT_URLS="{{ etcd_listen_client_urls }}"
+{% elif groups[etcd_peers_group] and groups[etcd_peers_group] | length > 0 %}
 #[cluster]
 ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
 ETCD_INITIAL_CLUSTER={{ initial_cluster() }}
 ETCD_INITIAL_CLUSTER_STATE={{ etcd_initial_cluster_state }}
 ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
+ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
 #ETCD_DISCOVERY=""
 #ETCD_DISCOVERY_SRV=""
 #ETCD_DISCOVERY_FALLBACK="proxy"
 #ETCD_DISCOVERY_PROXY=""
-{% endif %}
+ETCD_LISTEN_CLIENT_URLS="{{ etcd_listen_client_urls }}"
 ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
+{% else %}
+ETCD_LISTEN_CLIENT_URLS="{{ etcd_listen_client_urls }}"
+ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
+{% endif %}
 
 #[proxy]
 #ETCD_PROXY="off"

--- a/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
@@ -13,6 +13,7 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/cluster-monitoring/influxdb/{{ item }}
     dest="{{ local_temp_addon_dir }}/cluster-monitoring/{{ item }}.j2"
     force=yes
+    validate_certs=False
   sudo: no
   with_items:
     - grafana-service.yaml

--- a/ansible/roles/kubernetes-addons/tasks/dns.yml
+++ b/ansible/roles/kubernetes-addons/tasks/dns.yml
@@ -13,6 +13,7 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/dns/skydns-rc.yaml.in
     dest="{{ local_temp_addon_dir }}/dns/skydns-rc.yaml.j2"
     force=yes
+    validate_certs=False
   sudo: no
   changed_when: false
 
@@ -38,6 +39,7 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/dns/skydns-svc.yaml.in
     dest="{{ local_temp_addon_dir }}/dns/skydns-svc.yaml.j2"
     force=yes
+    validate_certs=False
   sudo: no
   changed_when: false
 

--- a/ansible/roles/kubernetes/tasks/secrets.yml
+++ b/ansible/roles/kubernetes/tasks/secrets.yml
@@ -39,8 +39,40 @@
   set_fact:
     kube_ca_cert: "{{ ca_cert.content|b64decode }}"
 
-- name: Place CA certificate everywhere
+- name: Place CA certificate and kube_cfg credentials everywhere
   copy: content="{{ kube_ca_cert }}" dest="{{ kube_cert_dir }}/ca.crt"
+  notify:
+    - restart daemons
+
+- name: Read back the kubecfg key
+  slurp:
+    src: "{{ kube_cert_dir }}/kubecfg.key"
+  register: api_key
+  run_once: true
+  delegate_to: "{{ groups['masters'][0] }}"
+
+- name: Register the cfg key as a fact so it can be used later
+  set_fact:
+    kube_api_key: "{{ api_key.content|b64decode }}"
+
+- name: Place CA certificate and kube_cfg credentials everywhere
+  copy: content="{{ kube_api_key }}" dest="{{ kube_cert_dir }}/kubecfg.key"
+  notify:
+    - restart daemons
+
+- name: Read back the kubecfg cert
+  slurp:
+    src: "{{ kube_cert_dir }}/kubecfg.crt"
+  register: api_crt
+  run_once: true
+  delegate_to: "{{ groups['masters'][0] }}"
+
+- name: Register the cfg cert as a fact so it can be used later
+  set_fact:
+    kube_api_crt: "{{ api_crt.content|b64decode }}"
+
+- name: Place CA certificate and kube_cfg credentials everywhere
+  copy: content="{{ kube_api_crt }}" dest="{{ kube_cert_dir }}/kubecfg.crt"
   notify:
     - restart daemons
 

--- a/ansible/roles/node/templates/kubelet.j2
+++ b/ansible/roles/node/templates/kubelet.j2
@@ -21,5 +21,8 @@ KUBELET_API_SERVER="--api-servers=https://{{ groups['masters'][0] }}:{{ kube_mas
 {% if networking == "opencontrail" -%}
 {{ kubelet_options.append('--network-plugin=opencontrail')|default('', true) -}}
 {% endif -%}
+{% if networking == "contiv" -%}
+{{ kubelet_options.append('--network-plugin=cni')|default('', true) -}}
+{% endif -%}
 
 KUBELET_ARGS="--kubeconfig={{ kube_config_dir }}/kubelet.kubeconfig --config={{ kube_manifest_dir }} {{ kubelet_options|join(' ') }}"


### PR DESCRIPTION
This PR brings in ansible changes needed to setup kubernetes with Contiv networking as outlined in https://github.com/kubernetes/contrib/issues/577.

Summary of changes:
1) Added a new role (contiv) that holds all contiv specific config code
2) Minor tweaks to etcd setup so contiv can access etcd from any node in proxy-mode
3) Exposed a few options via variables, with default values set so the default behavior will be unchanged.
4) Added missing "validate_certs: False" for a couple of addon file fetches.