### PR TITLE
Adds Support for Kubernetes Internal Network Management

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -45,6 +45,19 @@ kube_master_api_port: 443
 # addresses do not need to be routable and must just be an unused block of space.
 kube_service_addresses: 10.254.0.0/16
 
+# Set manage_internal_kube_network: true to manage an
+# internal Kubernetes network for CoreOS deployments.
+# Internal network variables should be set in host_vars.
+# See the example at ansible/host_vars/managed_host_example
+manage_internal_kube_network: false
+
+# When manage_internal_kube_network: true
+# kube_internal_routes adds internal routes for
+# CoreOS deployments in the form of:
+# destination_network,destination_mask,next_hop_ip
+kube_internal_routes:
+#  - 192.168.0.0,/16,192.168.10.1
+
 # Network implementation (flannel|opencontrail)
 networking: flannel
 

--- a/ansible/host_vars/managed_host_example
+++ b/ansible/host_vars/managed_host_example
@@ -1,0 +1,15 @@
+# Change managed_host_example to the IP/DNS name of the
+# Kubernetes masters or nodes that you would like to manage
+# a seperate interface for an internal network.
+# Suported on CoreOS deployments. Make sure to set the
+# following in group_vars/all.yml:
+# manage_internal_kube_network: true
+---
+# Interface name for the internal network
+kube_internal_interface: eth1
+
+# IP address assigned to kube_internal_interface
+kube_internal_ip: 10.10.10.10
+
+# Network mask in cidr notation of kube_internal_ip
+kube_internal_cidr: /24

--- a/ansible/roles/kubernetes/handlers/main.yml
+++ b/ansible/roles/kubernetes/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart systemd-networkd
+  service: name=systemd-networkd state=restarted
+
+- name: restart systemd-resolved
+  service: name=systemd-resolved state=restarted

--- a/ansible/roles/kubernetes/tasks/coreos.yml
+++ b/ansible/roles/kubernetes/tasks/coreos.yml
@@ -1,5 +1,5 @@
 ---
-- name: Download tar file
+- name: CoreOS | Download Kubernetes tar file
   get_url:
     url: "{{ kube_download_url }}"
     dest: "{{ ansible_temp_dir }}"
@@ -8,14 +8,21 @@
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
 
-- name: Extract tar file
+- name: CoreOS | Extract Kubernetes tar file
   unarchive:
     src: "{{ ansible_temp_dir }}/kubernetes.tar.gz"
     dest: "{{ ansible_temp_dir }}"
     copy: no
 
-- name: Extract 2nd tar file
+- name: CoreOS | Extract 2nd Kubernetes tar file
   unarchive:
     src: "{{ ansible_temp_dir }}/kubernetes/server/kubernetes-server-linux-amd64.tar.gz"
     dest: "{{ bin_dir }}"
     copy: no
+
+- name: CoreOS | Manage Kubernetes internal networkd file
+  template: src=kube_internal_networkd.j2 dest=/etc/systemd/network/{{ kube_internal_interface }}.network
+  notify:
+    - restart systemd-networkd
+    - restart systemd-resolved
+  when: manage_internal_kube_network

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -32,7 +32,7 @@
   notify:
     - restart daemons
 
-- include: download_bins.yml
+- include: coreos.yml
   when: is_coreos
 
 - include: secrets.yml

--- a/ansible/roles/kubernetes/templates/kube_internal_networkd.j2
+++ b/ansible/roles/kubernetes/templates/kube_internal_networkd.j2
@@ -1,0 +1,17 @@
+[Match]
+Name={{ kube_internal_interface }}
+
+[Network]
+Address={{ kube_internal_ip }}{{ kube_internal_cidr }}
+
+{% if kube_internal_routes %}
+{% for route in kube_internal_routes %}
+{% set route_dest=route.split(',')[0] %}
+{% set route_mask=route.split(',')[1] %}
+{% set route_next_hop=route.split(',')[2] %}
+[Route]
+Destination={{ route_dest }}{{ route_mask }}
+Gateway={{ route_next_hop }}
+
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Previously, the Ansible project only supported managing a
single interface. It's common for production deployments to
require separating network traffic. This patch adds support
to manage an internal interface (no default gw) and associated
static routes.
1. Supports CoreOS deployments (systemd-networkd).
2. Adds static route support (including multiple routes).

The code can be used as a reference for supporting other
distros.

Note: This PR does not configure any service to specifically
bind to a particular interface.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/629)

<!-- Reviewable:end -->
