### PR TITLE
Adds support for no_proxy

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -35,6 +35,7 @@ insecure_registrys:
 # If you need a proxy for the docker daemon define these here
 #http_proxy: "http://proxy.example.com:3128"
 #https_proxy: "http://proxy.example.com:3128"
+#no_proxy: "127.0.0.1,localhost,docker-registry.somecorporation.com"
 
 # The port that the Kubernetes apiserver component listens on.
 kube_master_api_port: 443

--- a/ansible/roles/etcd/tasks/github-release.yml
+++ b/ansible/roles/etcd/tasks/github-release.yml
@@ -14,6 +14,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
 
 - name: Extract tar file
   unarchive:

--- a/ansible/roles/flannel/tasks/github-release.yml
+++ b/ansible/roles/flannel/tasks/github-release.yml
@@ -11,6 +11,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
 
 - name: Extract tar file
   unarchive:

--- a/ansible/roles/kubernetes-addons/tasks/cluster-logging.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-logging.yml
@@ -11,6 +11,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
   with_items:
     - es-controller.yaml
     - es-service.yaml

--- a/ansible/roles/kubernetes-addons/tasks/kube-dash.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-dash.yml
@@ -11,6 +11,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
   with_items:
     - kube-dash-rc.yaml
     - kube-dash-svc.yaml

--- a/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
@@ -11,6 +11,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
   with_items:
     - kube-ui-rc.yaml
     - kube-ui-svc.yaml

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -20,6 +20,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
 
 - include: dns.yml
   when: dns_setup

--- a/ansible/roles/kubernetes/tasks/download_bins.yml
+++ b/ansible/roles/kubernetes/tasks/download_bins.yml
@@ -7,6 +7,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
 
 - name: Extract tar file
   unarchive:

--- a/ansible/roles/master/tasks/coreos.yml
+++ b/ansible/roles/master/tasks/coreos.yml
@@ -29,6 +29,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
 
 - name: CoreOS | Create dropin directories for Kubernetes Master services
   file: path=/etc/systemd/system/{{ item }}.service.d state=directory mode=0755

--- a/ansible/roles/node/tasks/coreos.yml
+++ b/ansible/roles/node/tasks/coreos.yml
@@ -27,6 +27,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
 
 - name: CoreOS | Create dropin directories for Kubernetes Node services
   file: path=/etc/systemd/system/{{ item }}.service.d state=directory mode=0755

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -28,6 +28,7 @@
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
   when: cluster_logging
 
 - name: Get the node token values

--- a/ansible/roles/pre-ansible/tasks/coreos.yml
+++ b/ansible/roles/pre-ansible/tasks/coreos.yml
@@ -9,4 +9,5 @@
     BOOTSTRAP_SCRIPT_DIR: "{{ bootstrap_script_dir }}"
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
   when: need_bootstrap | failed


### PR DESCRIPTION
Previously, the Ansible project supported setting http/https proxy
settings, but not no_proxy. Bypassing the http/https proxy is
common in production deployments. For example, a deployment may
need to bypass the http/https proxy to pull images from a local
Docker registry.