### PR TITLE
Include the title and first comment in submit queue merges

### DIFF
--- a/mungegithub/mungers/rebuild.go
+++ b/mungegithub/mungers/rebuild.go
@@ -72,7 +72,7 @@ func (r *RebuildMunger) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	comments, err := obj.ListComments(*obj.Issue.Number)
+	comments, err := obj.ListComments()
 	if err != nil {
 		glog.Errorf("unexpected error getting comments: %v", err)
 	}


### PR DESCRIPTION
This allows us to find that information in the git logs for later
processing.