### PR TITLE
Create container for mailing via remote smtp

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -51,6 +51,7 @@ right-build-number
 running-in-cluster
 shame-cc
 shame-from
+shame-reply-to
 shame-report-cmd
 source-file
 ssl-ca-cert

--- a/mungegithub/Dockerfile-shame-mailer
+++ b/mungegithub/Dockerfile-shame-mailer
@@ -1,0 +1,46 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The following environment variable need to be bound before executing
+# this containter:
+#
+#   GITHUB_API_TOKEN: An API token to use with Github's API.
+#   SHAME_FROM: The email address from which the mail is sent.
+#   SHAME_REPLY_TO: The email address to which replies will go.
+#   SHAME_CC: Email addresses that should be CC'd.
+#   SMTP_SERVER: SMTP server to use. Port may also be specified.
+#   SMTP_USER: SMTP server user login.
+#   SMTP_PASS: SMTP server password.
+#
+# An example invocation would be:
+#   docker run \
+#          -e GITHUB_API_TOKEN=A_GITHUB_API_TOKEN \
+#          -e SHAME_FROM=from@example.com \
+#          -e SHAME_REPLY_TO=replies@example.com \
+#          -e SHAME_CC=reports@example.com \
+#          -e SMTP_SERVER=smtp.example.com:1234 \
+#          -e SMTP_USER=smtp_example_user \
+#          -e SMTP_PASS=my_super_secret_smtp_password \
+#          gcr.io/google_containers/shame-mailer:TAG
+
+FROM google/debian:wheezy
+MAINTAINER Kris Rousey <krousey@google.com>
+RUN apt-get update
+RUN apt-get install -y -qq ca-certificates heirloom-mailx
+
+ADD mungegithub /mungegithub
+ADD shame_entrypoint.sh /shame_entrypoint.sh
+RUN chmod +x /shame_entrypoint.sh
+
+ENTRYPOINT ["/shame_entrypoint.sh"]

--- a/mungegithub/reports/shame.go
+++ b/mungegithub/reports/shame.go
@@ -36,6 +36,7 @@ type ShameReport struct {
 	Command string
 	From    string
 	Cc      string
+	ReplyTo string
 }
 
 func init() {
@@ -50,6 +51,7 @@ func (s *ShameReport) AddFlags(cmd *cobra.Command, config *githubhelper.Config) 
 	cmd.Flags().StringVar(&s.Command, "shame-report-cmd", "tee -a shame.txt", "command to execute, passing the report as stdin")
 	cmd.Flags().StringVar(&s.From, "shame-from", "", "From: header for shame report")
 	cmd.Flags().StringVar(&s.Cc, "shame-cc", "", "Cc: header for shame report")
+	cmd.Flags().StringVar(&s.ReplyTo, "shame-reply-to", "", "Reply-To: header for shame report")
 }
 
 type reportData struct {
@@ -213,6 +215,9 @@ func (s *ShameReport) groupReport(r *reportData) (map[string]bool, error) {
 	if s.From != "" {
 		fmt.Fprintf(dest, "From: %v\n", s.From)
 	}
+	if s.ReplyTo != "" {
+		fmt.Fprintf(dest, "Reply-To: %v\n", s.ReplyTo)
+	}
 	if s.Cc != "" {
 		fmt.Fprintf(dest, "Cc: %v\n", s.Cc)
 	}
@@ -270,6 +275,9 @@ func (s *ShameReport) individualReport(user string, r *reportData) error {
 	// Write the report
 	if s.From != "" {
 		fmt.Fprintf(dest, "From: %v\n", s.From)
+	}
+	if s.ReplyTo != "" {
+		fmt.Fprintf(dest, "Reply-To: %v\n", s.ReplyTo)
 	}
 	// No Cc on individual emails!
 	fmt.Fprintf(dest, "To: %v\n", strings.Join(to, ","))

--- a/mungegithub/shame_entrypoint.sh
+++ b/mungegithub/shame_entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+./mungegithub --token="${GITHUB_API_TOKEN}" --issue-reports=shame\
+	      --shame-from="${SHAME_FROM}" --shame-reply-to="${SHAME_REPLY_TO}"\
+	      --shame-cc="${SHAME_CC}"\
+	      --shame-report-cmd="mailx -v -t -S smtp=${SMTP_SERVER} -S smtp-auth=login -S smtp-auth-user=${SMTP_USER} -S smtp-auth-password=${SMTP_PASS}"


### PR DESCRIPTION
Note there is already a Makefile in this directory. This means that both

``` console
> APP=shame-mailer make
> APP=shame-mailer make push
```

work. I have not run `APP=shame-mailer make push` yet.

cc @lavalamp @ixdy @fejta 
