### PR TITLE
Fixes Insecure Docker Registry for CoreOS

### DIFF
--- a/ansible/roles/docker/tasks/coreos.yml
+++ b/ansible/roles/docker/tasks/coreos.yml
@@ -7,3 +7,9 @@
   register: docker_dropin
   notify:
     - reload systemd
+
+- name: CoreOS | Add any insecure registries to docker config
+  lineinfile: dest={{ docker_config_dir }}/docker regexp=^DOCKER_OPTS= line=DOCKER_OPTS="'{% for reg in insecure_registrys %}--insecure-registry={{ reg }}{% endfor %}'"
+  when: insecure_registrys is defined and insecure_registrys > 0
+  notify:
+    - restart docker

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -61,7 +61,7 @@
 
 - name: Add any insecure registrys to docker config
   lineinfile: dest={{ docker_config_dir }}/docker regexp=^INSECURE_REGISTRY= line=INSECURE_REGISTRY="'{% for reg in insecure_registrys %}--insecure-registry={{ reg }} {% endfor %}'"
-  when: insecure_registrys is defined and insecure_registrys > 0
+  when: not is_coreos and insecure_registrys is defined and insecure_registrys > 0
   notify:
     - restart docker
 


### PR DESCRIPTION
Previously, CoreOS would not read the INSECURE_REGISTRY key
in the docker config file. This commit adds --insecure-registry
entries to DOCKER_OPT in the docker config file for CoreOS.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/641)

<!-- Reviewable:end -->
