### PR TITLE
add CoreOS support to Ansible+Vagrant+VirtualBox + fix initial vagrant-ansible.yml playbook

### DIFF
--- a/ansible/vagrant/README.md
+++ b/ansible/vagrant/README.md
@@ -41,6 +41,36 @@ Vagrant (1.7.x) does not properly select a provider. You will need to manually s
 
 ## Usage
 
+You can change some aspects of configuration using environment variables.
+Note that these variables should be set for all vagrant commands invocations,
+`vagrant up`, `vagrant provision`, `vagrant destroy`, etc.
+
+### Configure number of nodes
+
+If you export an env variable such as
+```
+export NUM_MINIONS=4
+```
+
+The system will create that number of nodes. Default is 2.
+
+### Configure OS to use
+
+You can specify which OS image to use on hosts:
+
+```
+export OS_IMAGE=coreos7
+```
+
+By default CoreOS 7 image is used.
+
+Supported images:
+
+* `centos7` (default) - Core OS 7 supported on OpenStack, VirtualBox, Libvirt providers.
+* `coreos` - Core OS supported on VirtualBox provider.
+
+### Start your cluster
+
 Update ~/contrib/ansible/group_vars/all.yml with the following:
 ```
 source_type: packageManager
@@ -52,12 +82,6 @@ If you are not running Vagrant 1.7.x or older, then change to the vagrant direct
 vagrant up
 ```
 
-If you export an env variable such as
-```
-export NUM_MINIONS=4
-```
-
-The system will create that number of nodes. Default is 2.
 
 Vagrant up should complete with a successful Ansible playbook run:
 ```
@@ -136,7 +160,26 @@ If you just want to update the binaries on your systems (either pkgManager or lo
 ```
 ANSIBLE_TAGS="binary-update" vagrant provision
 ```
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/contrib/ansible/vagrant/README.md?pixel)]()
+
+### Running Ansible
+
+After provisioning cluster vith Vagrant you can run ansible in this directory for any additional provision -
+`ansible.cfg` provides configuration that will allow Ansible to connect to managed hosts.
+
+For example:
+
+```
+$ ansible -m setup kube-master
+kube-master | SUCCESS => {
+    "ansible_facts": {
+        "ansible_all_ipv4_addresses": [
+            "172.28.128.21",
+            "10.0.2.15"
+        ],
+...
+```
 
 ### Issues
 File an issue [here](https://github.com/kubernetes/contrib/issues) if the Vagrant Deployer does not work for you or the documentation has a bug. [Pull Requests](https://github.com/kubernetes/contrib/pulls) are always welcome :-) Please review the [contributing guidelines](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md) if you have not contributed in the past and feel free to ask questions on the [kubernetes-users Slack](http://slack.kubernetes.io) channel.
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/contrib/ansible/vagrant/README.md?pixel)]()

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -205,6 +205,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
      "nodes" => nodes,
      "all_groups:children" => ["etcd","masters","nodes"],
   }
+  if $os_image == :coreos
+    # On CoreOS we use custom Python in Ansible.
+    $groups["all_groups:vars"] = ['ansible_python_interpreter="PATH=/opt/bin:$PATH python"']
+  end
 
   config.vm.define "kube-master" do |n|
     name = "kube-master"

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -9,6 +9,13 @@ require 'vagrant-openstack-provider'
 
 $num_nodes = (ENV['NUM_NODES'] || 2).to_i
 $ansible_tags = ENV['ANSIBLE_TAGS']
+# OS image to use. Currently supported:
+# - "centos7" on openstack, libvirt, virtualbox
+# - "coreos" on virtualbox
+$os_image = (ENV['OS_IMAGE'] || "centos7").to_sym
+
+$coreos_update_channel = "stable"
+$coreos_image_version = "current"
 
 VAGRANTFILE_API_VERSION = "2"
 
@@ -27,10 +34,39 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "libvirt"
   config.vm.provider "virtualbox"
 
+  def set_openstack_box(config)
+    case $os_image
+    when :centos7
+      # common config
+      config.vm.box = "dummy"
+      config.vm.box_url = "https://github.com/cloudbau/vagrant-openstack-plugin/raw/master/dummy.box"
+    end
+  end
+
+  def set_vbox_box(config)
+    case $os_image
+    when :centos7
+      config.vm.box = "centos/7"
+    when :coreos
+      config.vm.box = "coreos-%s" % $coreos_update_channel
+      if $coreos_image_version != "current"
+        config.vm.box_version = $coreos_image_version
+      end
+      config.vm.box_url = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant.json" %
+        [$update_channel, $image_version]
+    end
+  end
+
+  def set_libvirt_box(config)
+    case $os_image
+    when :centos7
+      config.vm.box = "kube-centos-7"
+      config.vm.box_url = "http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7.LibVirt.box"
+    end
+  end
+
   def set_openstack(os, config, n)
-    # common config
-    config.vm.box = "dummy"
-    config.vm.box_url = "https://github.com/cloudbau/vagrant-openstack-plugin/raw/master/dummy.box"
+    set_openstack_box(config)
 
     # this crap is to make it not fail if the file doesn't exist (which is ok if we are using a different provisioner)
     __filename = File.join(File.dirname(__FILE__), "openstack_config.yml")
@@ -60,7 +96,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   def set_vbox(vb, config)
-    config.vm.box = "centos/7"
+    set_vbox_box(config)
+
     config.vm.network "private_network", type: "dhcp"
     vb.gui = false
     vb.memory = 2048
@@ -72,8 +109,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   def set_libvirt(lv, config)
-    config.vm.box = "kube-centos-7"
-    config.vm.box_url = "http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7.LibVirt.box"
+    set_libvirt_box(config)
+
     lv.memory = 2048
     lv.cpus = 2
     lv.nested = true
@@ -166,7 +203,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
      "etcd" => ["kube-master"],
      "masters" => ["kube-master"],
      "nodes" => nodes,
-     "all_groups:children" => ["etcd","masters","nodes"]
+     "all_groups:children" => ["etcd","masters","nodes"],
   }
 
   config.vm.define "kube-master" do |n|

--- a/ansible/vagrant/ansible.cfg
+++ b/ansible/vagrant/ansible.cfg
@@ -9,3 +9,7 @@ ansible_ssh_private_key_file: ~/.vagrant.d/insecure_private_key
 
 # Vagrant prepares inventory file with proper auth settings.
 inventory = .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory
+
+# Add main roles library to the roles path. Allows to use pre-ansible role in
+# vagrant-ansible.yml.
+roles_path = ../roles

--- a/ansible/vagrant/vagrant-ansible.yml
+++ b/ansible/vagrant/vagrant-ansible.yml
@@ -1,4 +1,11 @@
 - hosts: all
+  gather_facts: false
+  sudo: yes
+  roles:
+    # On CoreOS pre-ansible installs Python required to run further ansible steps.
+    - pre-ansible
+
+- hosts: all
   sudo: yes
   vars:
     - public_iface: "{{ ansible_default_ipv4.interface }}"

--- a/ansible/vagrant/vagrant-ansible.yml
+++ b/ansible/vagrant/vagrant-ansible.yml
@@ -10,6 +10,10 @@
   vars:
     - public_iface: "{{ ansible_default_ipv4.interface }}"
   tasks:
+    # On stock Core OS there is no /etc/hosts.
+    - name: "Create hosts file if it is not present"
+      file: path=/etc/hosts state=touch
+
     - name: "Build hosts file"
       lineinfile:
         dest=/etc/hosts
@@ -18,6 +22,7 @@
         state=present
       when: hostvars[item]['ansible_' + public_iface].ipv4.address is defined
       with_items: groups['all']
+
     - name: "Remove hostname from localhost line"
       replace:
         dest=/etc/hosts


### PR DESCRIPTION
This PR

* adds support for selecting OS images to use in Vagrant,

* adds Core OS image support,

* fixes issues with initial run of `vagrant-ansible.yml` (missing `/etc/hosts` on Core OS and configuring ansible_python_interpreter),

* update documentation.

Now you can setup K8S cluster in Vagrant+Ansible+VirtualBox using:

```
$ OS_IMAGE=coreos vagrant up --provider virtualbox
[...]
PLAY RECAP *********************************************************************
kube-master                : ok=257  changed=92   unreachable=0    failed=0   
kube-node-1                : ok=129  changed=54   unreachable=0    failed=0   
kube-node-2                : ok=128  changed=54   unreachable=0    failed=0
$ OS_IMAGE=coreos vagrant ssh kube-master                     
CoreOS stable (899.13.0)
core@kube-master ~ $ kubectl cluster-info                                                                                                         
Kubernetes master is running at http://localhost:8080
core@kube-master ~ $ kubectl get nodes
NAME          LABELS                               STATUS    AGE
kube-node-1   kubernetes.io/hostname=kube-node-1   Ready     1m
kube-node-2   kubernetes.io/hostname=kube-node-2   Ready     1m
core@kube-master ~ $ kubectl get pods --all-namespaces
NAMESPACE     NAME                                READY     STATUS    RESTARTS   AGE
kube-system   fluentd-elasticsearch-kube-node-1   1/1       Running   0          1m
kube-system   fluentd-elasticsearch-kube-node-2   1/1       Running   0          1m
core@kube-master ~ $ sudo systemctl status flanneld
● flanneld.service - flannel is an etcd backed overlay network for containers
   Loaded: loaded (/etc/systemd/system/flanneld.service; enabled; vendor preset: disabled)
   Active: active (running) since Sun 2016-03-27 12:27:43 UTC; 23min ago
 Main PID: 3126 (flanneld)
   Memory: 2.9M
      CPU: 75ms
   CGroup: /system.slice/flanneld.service
           └─3126 /opt/bin/flanneld

Mar 27 12:27:43 kube-master flanneld[3126]: I0327 12:27:43.158745 03126 main.go:130] Determining IP address of default interface
Mar 27 12:27:43 kube-master flanneld[3126]: I0327 12:27:43.158996 03126 main.go:188] Using 10.0.2.15 as external interface
Mar 27 12:27:43 kube-master flanneld[3126]: I0327 12:27:43.159057 03126 main.go:189] Using 10.0.2.15 as external endpoint
Mar 27 12:27:43 kube-master flanneld[3126]: I0327 12:27:43.162512 03126 etcd.go:129] Found lease (172.16.7.0/24) for current IP (10.0.2... reusing
Mar 27 12:27:43 kube-master flanneld[3126]: I0327 12:27:43.164223 03126 etcd.go:84] Subnet lease acquired: 172.16.7.0/24
Mar 27 12:27:43 kube-master flanneld[3126]: I0327 12:27:43.167300 03126 vxlan.go:153] Watching for L3 misses
Mar 27 12:27:43 kube-master flanneld[3126]: I0327 12:27:43.167329 03126 vxlan.go:159] Watching for new subnet leases
Mar 27 12:27:43 kube-master flanneld[3126]: I0327 12:27:43.168354 03126 vxlan.go:273] Handling initial subnet events
Mar 27 12:27:43 kube-master flanneld[3126]: I0327 12:27:43.168409 03126 device.go:159] calling GetL2List() dev.link.Index: 5
Mar 27 12:27:43 kube-master systemd[1]: Started flannel is an etcd backed overlay network for containers.
Hint: Some lines were ellipsized, use -l to show in full.
```

Core OS on other providers (OpenStask and libvirt) are not supported. It's easy to add them --- just specify proper Vagrant image --- but I don't have proper environment to test.

As you can see in the output above cluster is not properly setup --- there is at least one error with Flannel configuration in VirtualBox: wrong interface selected because Flannel settings are not properly passed to flannel.
@danehans in 7604d83e337e85af5c2ff32681067d5c7e75f127 you introduced `FLANNELD_OPTIONS` for Core OS that should mimic `FLANNEL_OPTIONS` for other configurations. However `FLANNEL_OPTIONS` value are passed to `flanneld` process as command line argument, and `FLANNELD_OPTIONS` is exposed to the Flannel as the environment variable which doesn't work for me and shouldn't according to Flannel documentation (each option from `FLANNEL_OPTIONS` like `--iface=eth1` should be converted to something like `FLANNEL_IFACE=eth1`).

I hope to fix this (and maybe other issues) next week in separate pull request.

/cc @eparis, @danehans,  @stephenrlouie 