### PR TITLE
Add cross-compiling support for exechealthz

### DIFF
--- a/exec-healthz/Dockerfile
+++ b/exec-healthz/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox
+FROM BASEIMAGE
 MAINTAINER Prashanth B <beeps@google.com>
-ADD exechealthz exechealthz
-ADD README.md README.md
+COPY exechealthz /
+COPY README.md /
 ENTRYPOINT ["/exechealthz"]

--- a/exec-healthz/Makefile
+++ b/exec-healthz/Makefile
@@ -1,17 +1,71 @@
-all: push
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# 0.0 shouldn't clobber any released builds
-TAG = 0.0
-PREFIX = gcr.io/google_containers/exechealthz
+# Build the exechealthz binary or image for any GOARCH
+#
+# Usage:
+# 	[TAG=1.0] [PREFIX=gcr.io/google_containers/exechealthz] [ARCH=amd64] make (server|container|push)
+
+all: container
+
+TAG?=1.0
+PREFIX?=gcr.io/google_containers/exechealthz
+ARCH?=amd64
+GOLANG_VERSION=1.6
+TEMP_DIR:=$(shell mktemp -d)
+
+# Set default base image dynamically for each arch
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=busybox
+endif
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=armel/busybox
+endif
+ifeq ($(ARCH),arm64)
+	BASEIMAGE?=aarch64/busybox
+endif
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/busybox
+endif
 
 server: exechealthz.go
-	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o exechealthz ./exechealthz.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GOARM=6 go build -a -installsuffix cgo -ldflags '-w' -o exechealthz ./exechealthz.go
 
-container: server
-	docker build -t $(PREFIX):$(TAG) .
+container:
+	# Copy the whole directory to a temporary dir and set the base image
+	cp -r ./* $(TEMP_DIR)
+	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+	# Compile the binary inside a container for reliable builds
+	docker run --rm -it -v $(TEMP_DIR):/build golang:$(GOLANG_VERSION) /bin/bash -c "make -C /build server ARCH=$(ARCH)"
+
+	docker build -t $(PREFIX)-$(ARCH):$(TAG) $(TEMP_DIR)
+
+ifeq ($(ARCH),amd64)
+	# Backward compatibility. TODO: deprecate this image tag
+	docker tag -f $(PREFIX)-$(ARCH):$(TAG) $(PREFIX):$(TAG)
+endif
+
+	sudo rm -r $(TEMP_DIR)
 
 push: container
+	gcloud docker push $(PREFIX)-$(ARCH):$(TAG)
+
+ifeq ($(ARCH),amd64)
+	# Backward compatibility. TODO: deprecate this image tag
 	gcloud docker push $(PREFIX):$(TAG)
+endif
 
 clean:
 	rm -f exechealthz

--- a/exec-healthz/README.md
+++ b/exec-healthz/README.md
@@ -2,6 +2,30 @@
 
 The exec healthz server is a sidecar container meant to serve as a liveness-exec-over-http bridge. It isolates pods from the idiosyncrasies of container runtime exec implementations.
 
+## How to release:
+
+The `exechealthz` Makefile supports multiple architecures, which means it may cross-compile and build an docker image easily.
+If you are releasing a new version, please bump the `TAG` value in the `Makefile` before building the images.
+
+How to build and push all images:
+```
+# Build for linux/amd64 (default)
+$ make push
+$ make push ARCH=amd64
+# ---> gcr.io/google_containers/exechealthz-amd64
+# ---> gcr.io/google_containers/exechealthz (backwards compatible image)
+
+$ make push ARCH=arm
+# ---> gcr.io/google_containers/exechealthz-arm
+
+$ make push ARCH=arm64
+# ---> gcr.io/google_containers/exechealthz-arm64
+
+$ make push ARCH=ppc64le
+# ---> gcr.io/google_containers/exechealthz-ppc64le
+```
+Of course, if you don't want to push the images, just run `make` or `make container`
+
 ## Examples:
 
 ### Run the healthz server directly on localhost:


### PR DESCRIPTION
Compile `exechealthz` for different architectures
Please push the generated images
Tracking issue: kubernetes/kubernetes#17981

@bprashanth @thockin @brendandburns @aledbf @eparis 