### PR TITLE
Resilience fixes for the Ingress controller

### DIFF
--- a/ingress/controllers/gce/Makefile
+++ b/ingress/controllers/gce/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG = 0.6.0
+TAG = 0.6.1
 PREFIX = gcr.io/google_containers/glbc
 
 server:

--- a/ingress/controllers/gce/backends/backends.go
+++ b/ingress/controllers/gce/backends/backends.go
@@ -59,7 +59,11 @@ func portKey(port int64) string {
 func NewBackendPool(
 	cloud BackendServices,
 	healthChecker healthchecks.HealthChecker,
-	nodePool instances.NodePool, namer utils.Namer, ignorePorts []int64, resyncWithCloud bool) *Backends {
+	nodePool instances.NodePool,
+	namer utils.Namer,
+	ignorePorts []int64,
+	resyncWithCloud bool) *Backends {
+
 	ignored := []string{}
 	for _, p := range ignorePorts {
 		ignored = append(ignored, portKey(p))

--- a/ingress/controllers/gce/backends/backends_test.go
+++ b/ingress/controllers/gce/backends/backends_test.go
@@ -137,7 +137,7 @@ func TestBackendPoolSync(t *testing.T) {
 	// Repopulate the pool with a cloud list, which now includes the 82 port
 	// backend. This would happen if, say, an ingress backend is removed
 	// while the controller is restarting.
-	pool.(*Backends).snapshotter.(*storage.CloudListingPool).ReplinishPool()
+	pool.(*Backends).snapshotter.(*storage.CloudListingPool).ReplenishPool()
 
 	pool.GC(svcNodePorts)
 

--- a/ingress/controllers/gce/backends/interfaces.go
+++ b/ingress/controllers/gce/backends/interfaces.go
@@ -30,7 +30,7 @@ type BackendPool interface {
 	GC(ports []int64) error
 	Shutdown() error
 	Status(name string) string
-	List() (*compute.BackendServiceList, error)
+	List() ([]interface{}, error)
 }
 
 // BackendServices is an interface for managing gce backend services.

--- a/ingress/controllers/gce/controller/cluster_manager.go
+++ b/ingress/controllers/gce/controller/cluster_manager.go
@@ -161,13 +161,16 @@ func NewClusterManager(
 	}
 	cluster.instancePool = instances.NewNodePool(cloud, zone.FailureDomain)
 	healthChecker := healthchecks.NewHealthChecker(cloud, defaultHealthCheckPath, cluster.ClusterNamer)
+
+	// TODO: This needs to change to a consolidated management of the default backend.
 	cluster.backendPool = backends.NewBackendPool(
-		cloud, healthChecker, cluster.instancePool, cluster.ClusterNamer)
+		cloud, healthChecker, cluster.instancePool, cluster.ClusterNamer, []int64{defaultBackendNodePort}, true)
 	defaultBackendHealthChecker := healthchecks.NewHealthChecker(cloud, "/healthz", cluster.ClusterNamer)
 	defaultBackendPool := backends.NewBackendPool(
-		cloud, defaultBackendHealthChecker, cluster.instancePool, cluster.ClusterNamer)
+		cloud, defaultBackendHealthChecker, cluster.instancePool, cluster.ClusterNamer, []int64{}, false)
 	cluster.defaultBackendNodePort = defaultBackendNodePort
 	cluster.l7Pool = loadbalancers.NewLoadBalancerPool(
 		cloud, defaultBackendPool, defaultBackendNodePort, cluster.ClusterNamer)
+
 	return &cluster, nil
 }

--- a/ingress/controllers/gce/controller/fakes.go
+++ b/ingress/controllers/gce/controller/fakes.go
@@ -52,7 +52,7 @@ func NewFakeClusterManager(clusterName string) *fakeClusterManager {
 	healthChecker := healthchecks.NewHealthChecker(fakeHCs, "/", namer)
 	backendPool := backends.NewBackendPool(
 		fakeBackends,
-		healthChecker, nodePool, namer)
+		healthChecker, nodePool, namer, []int64{}, false)
 	l7Pool := loadbalancers.NewLoadBalancerPool(
 		fakeLbs,
 		// TODO: change this

--- a/ingress/controllers/gce/loadbalancers/loadbalancers.go
+++ b/ingress/controllers/gce/loadbalancers/loadbalancers.go
@@ -174,7 +174,7 @@ func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
 
 	// The default backend is completely managed by the l7 pool.
 	// This includes recreating it if it's deleted, or fixing broken links.
-	if err := l.defaultBackendPool.Sync([]int64{l.defaultBackendNodePort}); err != nil {
+	if err := l.defaultBackendPool.Add(l.defaultBackendNodePort); err != nil {
 		return err
 	}
 	// create new loadbalancers, perform an edge hop for existing

--- a/ingress/controllers/gce/loadbalancers/loadbalancers_test.go
+++ b/ingress/controllers/gce/loadbalancers/loadbalancers_test.go
@@ -39,7 +39,7 @@ func newFakeLoadBalancerPool(f LoadBalancers, t *testing.T) LoadBalancerPool {
 	namer := utils.Namer{}
 	healthChecker := healthchecks.NewHealthChecker(fakeHCs, "/", namer)
 	backendPool := backends.NewBackendPool(
-		fakeBackends, healthChecker, instances.NewNodePool(fakeIGs, defaultZone), namer)
+		fakeBackends, healthChecker, instances.NewNodePool(fakeIGs, defaultZone), namer, []int64{}, false)
 	return NewLoadBalancerPool(f, backendPool, testDefaultBeNodePort, namer)
 }
 

--- a/ingress/controllers/gce/main.go
+++ b/ingress/controllers/gce/main.go
@@ -58,7 +58,7 @@ const (
 	alphaNumericChar = "0"
 
 	// Current docker image version. Only used in debug logging.
-	imageVersion = "glbc:0.6.0"
+	imageVersion = "glbc:0.6.1"
 )
 
 var (

--- a/ingress/controllers/gce/rc.yaml
+++ b/ingress/controllers/gce/rc.yaml
@@ -24,18 +24,18 @@ metadata:
   name: l7-lb-controller
   labels:
     k8s-app: glbc
-    version: v0.6.0
+    version: v0.6.1
 spec:
   # There should never be more than 1 controller alive simultaneously.
   replicas: 1
   selector:
     k8s-app: glbc
-    version: v0.6.0
+    version: v0.6.1
   template:
     metadata:
       labels:
         k8s-app: glbc
-        version: v0.6.0
+        version: v0.6.1
         name: glbc
     spec:
       terminationGracePeriodSeconds: 600
@@ -61,7 +61,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      - image: gcr.io/google_containers/glbc:0.6.0
+      - image: gcr.io/google_containers/glbc:0.6.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/ingress/controllers/gce/storage/pools.go
+++ b/ingress/controllers/gce/storage/pools.go
@@ -78,11 +78,11 @@ type CloudListingPool struct {
 	keyGetter keyFunc
 }
 
-// ReplinishPool lists through the cloudLister and inserts into the pool.
-func (c *CloudListingPool) ReplinishPool() {
+// ReplenishPool lists through the cloudLister and inserts into the pool.
+func (c *CloudListingPool) ReplenishPool() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	glog.V(4).Infof("Replinishing pool")
+	glog.V(4).Infof("Replenishing pool")
 	items, err := c.lister.List()
 	if err != nil {
 		glog.Warningf("Failed to list: %v", err)
@@ -119,7 +119,7 @@ func (c *CloudListingPool) Delete(key string) {
 	c.InMemoryPool.Delete(key)
 }
 
-// NewCloudListingPool replinishes the InMemoryPool through a background
+// NewCloudListingPool replenishes the InMemoryPool through a background
 // goroutine that lists from the given cloudLister.
 func NewCloudListingPool(k keyFunc, lister cloudLister, relistPeriod time.Duration) *CloudListingPool {
 	cl := &CloudListingPool{
@@ -127,7 +127,7 @@ func NewCloudListingPool(k keyFunc, lister cloudLister, relistPeriod time.Durati
 		lister:       lister,
 		keyGetter:    k,
 	}
-	glog.V(4).Infof("Starting pool replinish goroutine")
-	go wait.Until(cl.ReplinishPool, relistPeriod, make(chan struct{}))
+	glog.V(4).Infof("Starting pool replenish goroutine")
+	go wait.Until(cl.ReplenishPool, relistPeriod, make(chan struct{}))
 	return cl
 }


### PR DESCRIPTION
Reasoning for each commit:
1. UrlMap updating logic was too complicated, because it accounted for "joining" which we don't care about right now.
2. Errors at the beginning of the sync() function would prevent cloud urlmaps from getting cleaned up
3. The controller would silently forget about resources if it was restarted, and while down someone modified an Ingress
4. Retry creating GCE client since it can fail if we don't resolve metadata server
