### PR TITLE
Updates Vagrant README

### DIFF
--- a/ansible/vagrant/README.md
+++ b/ansible/vagrant/README.md
@@ -20,7 +20,7 @@ vagrant plugin install vagrant-openstack-provider --plugin-version ">= 0.6.1"
 Vagrant uses Ansible to automate the Kubernetes deployment. Install Ansible (Mac OSX example):
 ```
 sudo easy_install pip
-sudo pip install ansible
+sudo pip install ansible==2.0.0.2
 ```
 
 Reference [Ansible installation](http://docs.ansible.com/ansible/intro_installation.html) for additional installation instructions.
@@ -49,7 +49,7 @@ Note that these variables should be set for all vagrant commands invocations,
 
 If you export an env variable such as
 ```
-export NUM_MINIONS=4
+export NUM_NODES=4
 ```
 
 The system will create that number of nodes. Default is 2.


### PR DESCRIPTION
1. Adds Ansible 1.9.4 for pip install
2. Updated NUM_MINIONS to NUM_NODES

The default version of Ansible for Mac OSX is 2.x. This version
does not work with CoreOS. Vagrantfile was updated in a
previous commit to go from NUM_MINIONS > NUM_NODES but the README
was not updated.