### PR TITLE
Fixes Ansible Vagrant for CoreOS

### DIFF
--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.box_version = $coreos_image_version
       end
       config.vm.box_url = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant.json" %
-        [$update_channel, $image_version]
+        [$coreos_update_channel, $coreos_image_version]
     end
   end
 


### PR DESCRIPTION
Previously, Vagrant would not properly set the box download
url:

kube-node-1: Downloading: https://storage.googleapis.com/\
.release.core-os.net/amd64-usr//coreos_production_vagrant.json

An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and
try again.

The requested URL returned error: 400 Bad Request

This commit properly sets the coreos update_channel
and image_version variables.