### PR TITLE
Set implicit value for did install fact for node role

### DIFF
--- a/ansible/roles/node/tasks/packageManagerInstall.yml
+++ b/ansible/roles/node/tasks/packageManagerInstall.yml
@@ -1,4 +1,8 @@
 ---
+- name: Init the did_install fact
+  set_fact:
+    did_install: false
+
 - name: Set fact for Atomic Host package install
   set_fact:
     did_install: true


### PR DESCRIPTION
Init the did_install fact in packageManagerInstall.yml for node role.
Otherwise it is undefined for other distros than CoreOS or Fedora