### PR TITLE
download Flannel releases to /opt/

### DIFF
--- a/ansible/roles/flannel/defaults/main.yaml
+++ b/ansible/roles/flannel/defaults/main.yaml
@@ -3,3 +3,7 @@
 etcd_client_port: 2379
 # valid types: package | github-release
 flannel_source_type: package
+
+# Directory to store downloaded flannel releases
+# (in case of using github-releases).
+flannel_releases_dir: /opt

--- a/ansible/roles/flannel/tasks/github-release.yml
+++ b/ansible/roles/flannel/tasks/github-release.yml
@@ -3,7 +3,11 @@
   set_fact:
     flannel_version: 0.5.5
 
-- stat: path=/usr/local/flannel-{{ flannel_version }}
+- name: Set Flannel releases directory
+  set_fact:
+    flannel_releases_dir: /opt/
+
+- stat: path={{ flannel_releases_dir }}flannel-{{ flannel_version }}
   register: st
 
 - name: Download tar file
@@ -20,13 +24,13 @@
 - name: Extract tar file
   unarchive:
     src: "{{ ansible_temp_dir }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz"
-    dest: /usr/local
+    dest: "{{ flannel_releases_dir }}"
     copy: no
   when: st.stat.isdir is not defined
 
 - name: Create symlinks
   file:
-    src: /usr/local/flannel-{{ flannel_version }}/{{ item }}
+    src: "{{ flannel_releases_dir }}flannel-{{ flannel_version }}/{{ item }}"
     dest: "{{ bin_dir }}/{{ item }}"
     state: link
     force: yes

--- a/ansible/roles/flannel/tasks/github-release.yml
+++ b/ansible/roles/flannel/tasks/github-release.yml
@@ -3,11 +3,7 @@
   set_fact:
     flannel_version: 0.5.5
 
-- name: Set Flannel releases directory
-  set_fact:
-    flannel_releases_dir: /opt/
-
-- stat: path={{ flannel_releases_dir }}flannel-{{ flannel_version }}
+- stat: path={{ flannel_releases_dir }}/flannel-{{ flannel_version }}
   register: st
 
 - name: Download tar file
@@ -30,7 +26,7 @@
 
 - name: Create symlinks
   file:
-    src: "{{ flannel_releases_dir }}flannel-{{ flannel_version }}/{{ item }}"
+    src: "{{ flannel_releases_dir }}/flannel-{{ flannel_version }}/{{ item }}"
     dest: "{{ bin_dir }}/{{ item }}"
     state: link
     force: yes


### PR DESCRIPTION
/usr/ is readonly on Core OS, and /opt/ should work on Ubuntu too.

Intallation failure on Core OS was introduces in #588 

/cc @unicell @danehans @stephenrlouie