### PR TITLE
fix "--v" flag description

### DIFF
--- a/ansible/roles/kubernetes/templates/config.j2
+++ b/ansible/roles/kubernetes/templates/config.j2
@@ -13,7 +13,7 @@
 # logging to stderr means we get it in the systemd journal
 KUBE_LOGTOSTDERR="--logtostderr=true"
 
-# journal message level, 0 is debug
+# journal verbosity level, the higher is the more verbose
 KUBE_LOG_LEVEL="--v=0"
 
 # Should this cluster be allowed to run privileged docker containers


### PR DESCRIPTION
It's "verbosity" flag, the higher it is, the more verbose messages will
be printed.

It should mimic glog's "--v":
<https://google-glog.googlecode.com/svn/trunk/doc/glog.html#verbose>