### PR TITLE
Bump K8s version to 1.2.0 on Core OS + download k8s binaries one by one

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -18,7 +18,7 @@ kube_script_dir: /usr/libexec/kubernetes
 kube_config_dir: /etc/kubernetes
 
 # The URL to download Kubernetes binaries from.
-kube_download_url: https://github.com/kubernetes/kubernetes/releases/download/v{{ kube_version }}/kubernetes.tar.gz
+kube_download_url_base: https://storage.googleapis.com/kubernetes-release/release/v{{ kube_version }}/bin/linux/amd64/
 
 # This is where all the cert scripts and certs will be located
 kube_cert_dir: "{{ kube_config_dir }}/certs"

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of Kubernetes binaries
-kube_version: 1.1.4
+kube_version: 1.2.0
 
 # The port that the Kubernetes apiserver component listens on.
 kube_master_api_port: 443

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -20,6 +20,19 @@ kube_config_dir: /etc/kubernetes
 # The URL to download Kubernetes binaries from.
 kube_download_url_base: https://storage.googleapis.com/kubernetes-release/release/v{{ kube_version }}/bin/linux/amd64/
 
+# List of Kubernetes binaries to download and install.
+kube_binaries:
+  - kube-apiserver
+  - kube-controller-manager
+  - kube-proxy
+  - kube-scheduler
+  - kubectl
+  - kubelet
+
+# Directory to store downloaded Kubernetes releases
+kube_releases_directory: /opt/kubernetes
+kube_current_release_directory: "{{ kube_releases_directory }}/{{ kube_version }}"
+
 # This is where all the cert scripts and certs will be located
 kube_cert_dir: "{{ kube_config_dir }}/certs"
 

--- a/ansible/roles/kubernetes/tasks/download_bins.yml
+++ b/ansible/roles/kubernetes/tasks/download_bins.yml
@@ -1,22 +1,18 @@
 ---
-- name: Download tar file
+- name: Download Kubernetes binaries
   get_url:
-    url: "{{ kube_download_url }}"
-    dest: "{{ ansible_temp_dir }}"
+    url: "{{ kube_download_url_base }}{{ item }}"
+    dest: "{{ bin_dir }}/{{ item }}"
+    mode: 0755
     validate_certs: False
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
     https_proxy: "{{ https_proxy|default('') }}"
     no_proxy: "{{ no_proxy|default('') }}"
-
-- name: Extract tar file
-  unarchive:
-    src: "{{ ansible_temp_dir }}/kubernetes.tar.gz"
-    dest: "{{ ansible_temp_dir }}"
-    copy: no
-
-- name: Extract 2nd tar file
-  unarchive:
-    src: "{{ ansible_temp_dir }}/kubernetes/server/kubernetes-server-linux-amd64.tar.gz"
-    dest: "{{ bin_dir }}"
-    copy: no
+  with_items:
+    - kube-apiserver
+    - kube-controller-manager
+    - kube-proxy
+    - kube-scheduler
+    - kubectl
+    - kubelet

--- a/ansible/roles/kubernetes/tasks/download_bins.yml
+++ b/ansible/roles/kubernetes/tasks/download_bins.yml
@@ -1,8 +1,11 @@
 ---
+- name: Create directory for current Kubernetes release
+  file: path={{ kube_current_release_directory }} state=directory
+
 - name: Download Kubernetes binaries
   get_url:
     url: "{{ kube_download_url_base }}{{ item }}"
-    dest: "{{ bin_dir }}/{{ item }}"
+    dest: "{{ kube_current_release_directory }}/{{ item }}"
     mode: 0755
     validate_certs: False
   environment:
@@ -10,9 +13,12 @@
     https_proxy: "{{ https_proxy|default('') }}"
     no_proxy: "{{ no_proxy|default('') }}"
   with_items:
-    - kube-apiserver
-    - kube-controller-manager
-    - kube-proxy
-    - kube-scheduler
-    - kubectl
-    - kubelet
+    - "{{ kube_binaries }}"
+
+- name: Create symlinks
+  file:
+    src: "{{ kube_current_release_directory }}/{{ item }}"
+    dest: "{{ bin_dir }}/{{ item }}"
+    state: link
+  with_items:
+    - "{{ kube_binaries }}"

--- a/ansible/roles/master/tasks/coreos.yml
+++ b/ansible/roles/master/tasks/coreos.yml
@@ -3,17 +3,6 @@
   set_fact:
     source_type: "github-release"
 
-- name: CoreOS | Create symlinks
-  file:
-    src: "{{ bin_dir }}/kubernetes/server/bin/{{ item }}"
-    dest: "{{ bin_dir }}/{{ item }}"
-    state: link
-  with_items:
-    - kube-apiserver
-    - kube-controller-manager
-    - kube-scheduler
-    - kubectl
-
 - name: CoreOS | Get Systemd Unit Files from Kubernetes repository
   get_url:
     url=https://raw.githubusercontent.com/kubernetes/contrib/master/init/systemd/{{ item }}.service

--- a/ansible/roles/node/tasks/coreos.yml
+++ b/ansible/roles/node/tasks/coreos.yml
@@ -3,16 +3,6 @@
   set_fact:
     source_type: "github-release"
 
-- name: CoreOS | Create symlinks
-  file:
-    src: "{{ bin_dir }}/kubernetes/server/bin/{{ item }}"
-    dest: "{{ bin_dir }}/{{ item }}"
-    state: link
-  with_items:
-    - kubelet
-    - kube-proxy
-    - kubectl
-
 - name: CoreOS | Get Systemd Unit Files from Kubernetes repository
   get_url:
     url=https://raw.githubusercontent.com/kubernetes/contrib/master/init/systemd/{{ item }}.service


### PR DESCRIPTION
Kubernetes GitHub release tarball has size of about 400+ MB.
Previously it's being downloaded, extracted, and inner tarball extracted
one more time (on each host).
This took roughly 400+ MB * NUM_NODES traffic and about 1 GB of space in
/tmp/ (on each host).

Starting from 1.2.0 it takes more than 1 GB of space in /tmp by Ansible,
which fails for example on Core OS, where /tmp is 1 GB ramdisk.

With these changes only required binaries are downloaded (not
compressed, but it's still significantly less than whole release tarball size).

/cc: @danehans @stephenrlouie @eparis 