### PR TITLE
add requirement for minimal Vagrant version to use for Core OS images

### DIFF
--- a/ansible/vagrant/README.md
+++ b/ansible/vagrant/README.md
@@ -38,6 +38,7 @@ Reference the [python-netaddr documentation](https://pythonhosted.org/netaddr/in
 
 Vagrant (1.7.x) does not properly select a provider. You will need to manually specify the provider. Refer to the Provider Specific Information section for using the proper `vagrant up` command.
 
+Vagrant prior version 1.8.0 doesn't write group variables into Ansible inventory file, which is required for using Core OS images.
 
 ## Usage
 

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -206,6 +206,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
      "all_groups:children" => ["etcd","masters","nodes"],
   }
   if $os_image == :coreos
+    # Vagrant prior version 1.8.0 doesn't write group variables into inventory file:
+    # <https://github.com/mitchellh/vagrant/commit/dd4ae1a51cfb246d561bced89d3b34ee90a0a38f>
+    Vagrant.require_version ">= 1.8.0"
+
     # On CoreOS we use custom Python in Ansible.
     $groups["all_groups:vars"] = ['ansible_python_interpreter="PATH=/opt/bin:$PATH python"']
   end


### PR DESCRIPTION
Vagrant prior version 1.8.0 doesn't write group variables into inventory file:
<https://github.com/mitchellh/vagrant/commit/dd4ae1a51cfb246d561bced89d3b34ee90a0a38f>

@stephenrlouie this is a check for issue that you observed with wrong `ansible_python_path`.
