### PR TITLE
CoreOS pre-ansible: un-hardcode bin_dir

### DIFF
--- a/ansible/roles/pre-ansible/defaults/main.yml
+++ b/ansible/roles/pre-ansible/defaults/main.yml
@@ -1,3 +1,7 @@
+# The directory where binaries are stored on Ansible
+# # managed systems.
+bin_dir: /usr/bin
+
 # The directory where scripts used for bootstrapping CoreOS
 # reside.
 bootstrap_script_dir: /opt/bin

--- a/ansible/roles/pre-ansible/tasks/coreos.yml
+++ b/ansible/roles/pre-ansible/tasks/coreos.yml
@@ -34,7 +34,7 @@
   raw: >
           printf "%s\n%s"
           "#! /usr/bin/bash"
-          "PATH=\$PATH:/opt/bin"
+          "PATH=\$PATH:{{ bin_dir }}"
           > /etc/profile.d/opt-path.sh
 
 - name: CoreOS | Change permissions and ownership for opt-path.sh to run as root

--- a/ansible/roles/pre-ansible/tasks/main.yml
+++ b/ansible/roles/pre-ansible/tasks/main.yml
@@ -18,6 +18,11 @@
     is_coreos: true
   when: "'CoreOS' in distro.stdout"
 
+- name: Set the bin directory path for CoreOS
+  set_fact:
+    bin_dir: "/opt/bin"
+  when: is_coreos
+
 - include: coreos.yml
   when: is_coreos
 


### PR DESCRIPTION
Updates CoreOS pre-ansible tasks so that bin_dir isn't hardcoded in coreos.yml. 

@eparis @danehans 