### PR TITLE
Updated kube-ui to use new kubernetes dashboard ui

### DIFF
--- a/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
@@ -4,7 +4,7 @@
 
 - name: KUBE-UI | Download kube-ui files from Kubernetes repo
   get_url:
-    url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/kube-ui/{{ item }}
+    url=https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dashboard/{{ item }}
     dest="{{ kube_addons_dir }}/kube-ui/"
     force=yes
     validate_certs=False
@@ -13,5 +13,5 @@
     https_proxy: "{{ https_proxy|default('') }}"
     no_proxy: "{{ no_proxy|default('') }}"
   with_items:
-    - kube-ui-rc.yaml
-    - kube-ui-svc.yaml
+    - dashboard-controller.yaml
+    - dashboard-service.yaml


### PR DESCRIPTION
Updated kube-ui to use new kubernetes dashboard ui from [here](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dashboard)