### PR TITLE
Allocate and remember cluster uid 

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -96,3 +96,4 @@ vrrp-password
 watch-namespace
 weak-stable-jobs
 whitelist-override-label
+config-file-path

--- a/ingress/controllers/gce/Makefile
+++ b/ingress/controllers/gce/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG = 0.6.2
+TAG = 0.6.3
 PREFIX = gcr.io/google_containers/glbc
 
 server:

--- a/ingress/controllers/gce/backends/backends.go
+++ b/ingress/controllers/gce/backends/backends.go
@@ -38,11 +38,11 @@ type Backends struct {
 	nodePool      instances.NodePool
 	healthChecker healthchecks.HealthChecker
 	snapshotter   storage.Snapshotter
-	namer         utils.Namer
 	// ignoredPorts are a set of ports excluded from GC, even
 	// after the Ingress has been deleted. Note that invoking
 	// a Delete() on these ports will still delete the backend.
 	ignoredPorts sets.String
+	namer        *utils.Namer
 }
 
 func portKey(port int64) string {
@@ -60,7 +60,7 @@ func NewBackendPool(
 	cloud BackendServices,
 	healthChecker healthchecks.HealthChecker,
 	nodePool instances.NodePool,
-	namer utils.Namer,
+	namer *utils.Namer,
 	ignorePorts []int64,
 	resyncWithCloud bool) *Backends {
 

--- a/ingress/controllers/gce/backends/backends_test.go
+++ b/ingress/controllers/gce/backends/backends_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func newBackendPool(f BackendServices, fakeIGs instances.InstanceGroups, syncWithCloud bool) BackendPool {
-	namer := utils.Namer{}
+	namer := &utils.Namer{}
 	return NewBackendPool(
 		f,
 		healthchecks.NewHealthChecker(healthchecks.NewFakeHealthChecks(), "/", namer),

--- a/ingress/controllers/gce/controller/cluster_manager.go
+++ b/ingress/controllers/gce/controller/cluster_manager.go
@@ -18,7 +18,9 @@ package controller
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"time"
 
 	"k8s.io/contrib/ingress/controllers/gce/backends"
@@ -184,13 +186,13 @@ func defaultInstanceGroupName(clusterName string) string {
 	return fmt.Sprintf("%v-%v", instanceGroupPrefix, clusterName)
 }
 
-func getGCEClient() *gce.GCECloud {
+func getGCEClient(config io.Reader) *gce.GCECloud {
 	// Creating the cloud interface involves resolving the metadata server to get
 	// an oauth token. If this fails, the token provider assumes it's not on GCE.
 	// No errors are thrown. So we need to keep retrying till it works because
 	// we know we're on GCE.
 	for {
-		cloudInterface, err := cloudprovider.GetCloudProvider("gce", nil)
+		cloudInterface, err := cloudprovider.GetCloudProvider("gce", config)
 		if err == nil {
 			cloud := cloudInterface.(*gce.GCECloud)
 
@@ -217,15 +219,28 @@ func getGCEClient() *gce.GCECloud {
 //	 the kubernetes Service that serves the 404 page if no urls match.
 // - defaultHealthCheckPath: is the default path used for L7 health checks, eg: "/healthz"
 func NewClusterManager(
+	configFilePath string,
 	name string,
 	defaultBackendNodePort int64,
 	defaultHealthCheckPath string) (*ClusterManager, error) {
+
+	var config *os.File
+	var err error
+	if configFilePath != "" {
+		glog.Infof("Reading config from path %v", configFilePath)
+		config, err = os.Open(configFilePath)
+		if err != nil {
+			return nil, err
+		}
+		defer config.Close()
+	}
 
 	// TODO: Make this more resilient. Currently we create the cloud client
 	// and pass it through to all the pools. This makes unittesting easier.
 	// However if the cloud client suddenly fails, we should try to re-create it
 	// and continue.
-	cloud := getGCEClient()
+	cloud := getGCEClient(config)
+	glog.Infof("Successfully loaded cloudprovider using config %q", configFilePath)
 
 	// Names are fundamental to the cluster, the uid allocator makes sure names don't collide.
 	cluster := ClusterManager{ClusterNamer: &utils.Namer{name}}

--- a/ingress/controllers/gce/controller/controller.go
+++ b/ingress/controllers/gce/controller/controller.go
@@ -301,7 +301,7 @@ func (lbc *LoadBalancerController) sync(key string) {
 	} else if err := l7.UpdateUrlMap(urlMap); err != nil {
 		lbc.recorder.Eventf(&ing, api.EventTypeWarning, "UrlMap", err.Error())
 		syncError = fmt.Errorf("%v, update url map error: %v", syncError, err)
-	} else if lbc.updateIngressStatus(l7, ing); err != nil {
+	} else if err := lbc.updateIngressStatus(l7, ing); err != nil {
 		lbc.recorder.Eventf(&ing, api.EventTypeWarning, "Status", err.Error())
 		syncError = fmt.Errorf("%v, update ingress error: %v", syncError, err)
 	}

--- a/ingress/controllers/gce/controller/fakes.go
+++ b/ingress/controllers/gce/controller/fakes.go
@@ -17,14 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"k8s.io/kubernetes/pkg/util/intstr"
+	"k8s.io/kubernetes/pkg/util/sets"
+
 	"k8s.io/contrib/ingress/controllers/gce/backends"
 	"k8s.io/contrib/ingress/controllers/gce/firewalls"
 	"k8s.io/contrib/ingress/controllers/gce/healthchecks"
 	"k8s.io/contrib/ingress/controllers/gce/instances"
 	"k8s.io/contrib/ingress/controllers/gce/loadbalancers"
 	"k8s.io/contrib/ingress/controllers/gce/utils"
-	"k8s.io/kubernetes/pkg/util/intstr"
-	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 const (
@@ -48,7 +49,7 @@ func NewFakeClusterManager(clusterName string) *fakeClusterManager {
 	fakeBackends := backends.NewFakeBackendServices()
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString())
 	fakeHCs := healthchecks.NewFakeHealthChecks()
-	namer := utils.Namer{clusterName}
+	namer := &utils.Namer{clusterName}
 	nodePool := instances.NewNodePool(fakeIGs, defaultZone)
 	healthChecker := healthchecks.NewHealthChecker(fakeHCs, "/", namer)
 	backendPool := backends.NewBackendPool(

--- a/ingress/controllers/gce/firewalls/firewalls.go
+++ b/ingress/controllers/gce/firewalls/firewalls.go
@@ -30,14 +30,14 @@ const l7SrcRange = "130.211.0.0/22"
 // FirewallRules manages firewall rules.
 type FirewallRules struct {
 	cloud    Firewall
-	namer    utils.Namer
+	namer    *utils.Namer
 	srcRange netset.IPNet
 }
 
 // NewFirewallPool creates a new firewall rule manager.
 // cloud: the cloud object implementing Firewall.
 // namer: cluster namer.
-func NewFirewallPool(cloud Firewall, namer utils.Namer) SingleFirewallPool {
+func NewFirewallPool(cloud Firewall, namer *utils.Namer) SingleFirewallPool {
 	srcNetSet, err := netset.ParseIPNets(l7SrcRange)
 	if err != nil {
 		glog.Fatalf("Could not parse L7 src range %v for firewall rule: %v", l7SrcRange, err)

--- a/ingress/controllers/gce/healthchecks/healthchecks.go
+++ b/ingress/controllers/gce/healthchecks/healthchecks.go
@@ -28,13 +28,13 @@ import (
 type HealthChecks struct {
 	cloud       SingleHealthCheck
 	defaultPath string
-	namer       utils.Namer
+	namer       *utils.Namer
 }
 
 // NewHealthChecker creates a new health checker.
 // cloud: the cloud object implementing SingleHealthCheck.
 // defaultHealthCheckPath: is the HTTP path to use for health checks.
-func NewHealthChecker(cloud SingleHealthCheck, defaultHealthCheckPath string, namer utils.Namer) HealthChecker {
+func NewHealthChecker(cloud SingleHealthCheck, defaultHealthCheckPath string, namer *utils.Namer) HealthChecker {
 	return &HealthChecks{cloud, defaultHealthCheckPath, namer}
 }
 

--- a/ingress/controllers/gce/loadbalancers/loadbalancers.go
+++ b/ingress/controllers/gce/loadbalancers/loadbalancers.go
@@ -67,7 +67,7 @@ type L7s struct {
 	glbcDefaultBackend     *compute.BackendService
 	defaultBackendPool     backends.BackendPool
 	defaultBackendNodePort int64
-	namer                  utils.Namer
+	namer                  *utils.Namer
 }
 
 // NewLoadBalancerPool returns a new loadbalancer pool.
@@ -80,7 +80,7 @@ type L7s struct {
 func NewLoadBalancerPool(
 	cloud LoadBalancers,
 	defaultBackendPool backends.BackendPool,
-	defaultBackendNodePort int64, namer utils.Namer) LoadBalancerPool {
+	defaultBackendNodePort int64, namer *utils.Namer) LoadBalancerPool {
 	return &L7s{cloud, storage.NewInMemoryPool(), nil, defaultBackendPool, defaultBackendNodePort, namer}
 }
 
@@ -284,7 +284,7 @@ type L7 struct {
 	// TODO: Expose this to users.
 	glbcDefaultBackend *compute.BackendService
 	// namer is used to compute names of the various sub-components of an L7.
-	namer utils.Namer
+	namer *utils.Namer
 }
 
 func (l *L7) checkUrlMap(backend *compute.BackendService) (err error) {

--- a/ingress/controllers/gce/loadbalancers/loadbalancers_test.go
+++ b/ingress/controllers/gce/loadbalancers/loadbalancers_test.go
@@ -36,7 +36,7 @@ func newFakeLoadBalancerPool(f LoadBalancers, t *testing.T) LoadBalancerPool {
 	fakeBackends := backends.NewFakeBackendServices()
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString())
 	fakeHCs := healthchecks.NewFakeHealthChecks()
-	namer := utils.Namer{}
+	namer := &utils.Namer{}
 	healthChecker := healthchecks.NewHealthChecker(fakeHCs, "/", namer)
 	backendPool := backends.NewBackendPool(
 		fakeBackends, healthChecker, instances.NewNodePool(fakeIGs, defaultZone), namer, []int64{}, false)

--- a/ingress/controllers/gce/main.go
+++ b/ingress/controllers/gce/main.go
@@ -110,6 +110,13 @@ var (
 
 	verbose = flags.Bool("verbose", false,
 		`If true, logs are displayed at V(4), otherwise V(2).`)
+
+	configFilePath = flags.String("config-file-path", "",
+		`Path to a file containing the gce config. If left unspecified this
+		controller only works with default zones.`)
+
+	healthzPort = flags.Int("healthz-port", lbApiPort,
+		`Port to run healthz server. Must match the health check port in yaml.`)
 )
 
 func registerHandlers(lbc *controller.LoadBalancerController) {
@@ -127,7 +134,7 @@ func registerHandlers(lbc *controller.LoadBalancerController) {
 		lbc.Stop(true)
 	})
 
-	glog.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", lbApiPort), nil))
+	glog.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", *healthzPort), nil))
 }
 
 func handleSigterm(lbc *controller.LoadBalancerController, deleteAll bool) {
@@ -196,7 +203,7 @@ func main() {
 		if err != nil {
 			glog.Fatalf("%v", err)
 		}
-		clusterManager, err = controller.NewClusterManager(name, defaultBackendNodePort, *healthCheckPath)
+		clusterManager, err = controller.NewClusterManager(*configFilePath, name, defaultBackendNodePort, *healthCheckPath)
 		if err != nil {
 			glog.Fatalf("%v", err)
 		}

--- a/ingress/controllers/gce/main.go
+++ b/ingress/controllers/gce/main.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	kubectl_util "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	"github.com/golang/glog"
@@ -191,8 +192,11 @@ func main() {
 
 	if *inCluster || *useRealCloud {
 		// Create cluster manager
-		clusterManager, err = controller.NewClusterManager(
-			*clusterName, defaultBackendNodePort, *healthCheckPath, storage.NewConfigMapVault(kubeClient, api.NamespaceSystem, uidConfigMapName))
+		name, err := getClusterUID(kubeClient, *clusterName)
+		if err != nil {
+			glog.Fatalf("%v", err)
+		}
+		clusterManager, err = controller.NewClusterManager(name, defaultBackendNodePort, *healthCheckPath)
 		if err != nil {
 			glog.Fatalf("%v", err)
 		}
@@ -217,6 +221,60 @@ func main() {
 		glog.Infof("Handled quit, awaiting pod deletion.")
 		time.Sleep(30 * time.Second)
 	}
+}
+
+// getClusterUID returns the cluster UID. Rules for UID generation:
+// If the user specifies a --cluster-uid param it overwrites everything
+// else, check UID config map for a previously recorded uid
+// else, check if there are any working Ingresses
+//	- remember that "" is the cluster uid
+// else, allocate a new uid
+func getClusterUID(kubeClient *client.Client, name string) (string, error) {
+	cfgVault := storage.NewConfigMapVault(kubeClient, api.NamespaceSystem, uidConfigMapName)
+	if name != "" {
+		glog.Infof("Using user provided cluster uid %v", name)
+		// Don't save the uid in the vault, so users can rollback through
+		// --cluster-uid=""
+		return name, nil
+	}
+
+	existingUID, found, err := cfgVault.Get()
+	if found {
+		glog.Infof("Using saved cluster uid %q", name)
+		return existingUID, nil
+	} else if err != nil {
+		// This can fail because of:
+		// 1. No such config map - found=false, err=nil
+		// 2. No such key in config map - found=false, err=nil
+		// 3. Apiserver flake - found=false, err!=nil
+		// It is not safe to proceed in 3.
+		return "", fmt.Errorf("Failed to retrieve current uid: %v, using %q as name", err, name)
+	}
+
+	// Check if the cluster has an Ingress with ip
+	ings, err := kubeClient.Extensions().Ingress(api.NamespaceAll).List(api.ListOptions{LabelSelector: labels.Everything()})
+	if err != nil {
+		return "", err
+	}
+	for _, ing := range ings.Items {
+		if len(ing.Status.LoadBalancer.Ingress) != 0 {
+			glog.Infof("Found a working Ingress, assuming uid is empty string")
+			return "", cfgVault.Put("")
+		}
+	}
+
+	// Allocate new uid
+	f, err := os.Open("/dev/urandom")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	b := make([]byte, 8)
+	if _, err := f.Read(b); err != nil {
+		return "", err
+	}
+	uid := fmt.Sprintf("%x", b)
+	return uid, cfgVault.Put(uid)
 }
 
 // getNodePort waits for the Service, and returns it's first node port.

--- a/ingress/controllers/gce/storage/configmaps.go
+++ b/ingress/controllers/gce/storage/configmaps.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/client/cache"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// UIDVault stores UIDs.
+type UIDVault interface {
+	Get() (string, bool, error)
+	Put(string) error
+	Delete() error
+}
+
+// uidDataKey is the key used in config maps to store the UID.
+const uidDataKey = "uid"
+
+// ConfigMapVault stores cluster UIDs in config maps.
+// It's a layer on top of ConfigMapStore that just implements the utils.uidVault
+// interface.
+type ConfigMapVault struct {
+	ConfigMapStore cache.Store
+	namespace      string
+	name           string
+}
+
+// Get retrieves the cluster UID from the cluster config map.
+// If this method returns an error, it's guaranteed to be apiserver flake.
+// If the error is a not found error it sets the boolean to false and
+// returns and error of nil instead.
+func (c *ConfigMapVault) Get() (string, bool, error) {
+	key := fmt.Sprintf("%v/%v", c.namespace, c.name)
+	item, found, err := c.ConfigMapStore.GetByKey(key)
+	if err != nil || !found {
+		return "", found, err
+	}
+	cfg := item.(*api.ConfigMap)
+	if k, ok := cfg.Data[uidDataKey]; ok {
+		return k, false, nil
+	}
+	return "", found, fmt.Errorf("Found config map %v but it doesn't contain uid key: %+v", key, cfg.Data)
+}
+
+// Put stores the given UID in the cluster config map.
+func (c *ConfigMapVault) Put(uid string) error {
+	apiObj := &api.ConfigMap{
+		ObjectMeta: api.ObjectMeta{
+			Name:      c.name,
+			Namespace: c.namespace,
+		},
+		Data: map[string]string{uidDataKey: uid},
+	}
+	cfgMapKey := fmt.Sprintf("%v/%v", c.namespace, c.name)
+
+	item, exists, err := c.ConfigMapStore.GetByKey(cfgMapKey)
+	if err == nil && exists {
+		data := item.(*api.ConfigMap).Data
+		if k, ok := data[uidDataKey]; ok && k == uid {
+			return nil
+		} else if ok {
+			glog.Infof("Configmap %v has key %v but wrong value %v, updating", cfgMapKey, k, uid)
+		}
+
+		if err := c.ConfigMapStore.Update(apiObj); err != nil {
+			return fmt.Errorf("Failed to update %v: %v", cfgMapKey, err)
+		}
+	} else if err := c.ConfigMapStore.Add(apiObj); err != nil {
+		return fmt.Errorf("Failed to add %v: %v", cfgMapKey, err)
+	}
+	glog.Infof("Successfully stored uid %v in config map %v", uid, cfgMapKey)
+	return nil
+}
+
+// Delete deletes the cluster UID storing config map.
+func (c *ConfigMapVault) Delete() error {
+	cfgMapKey := fmt.Sprintf("%v/%v", c.namespace, c.name)
+	item, _, err := c.ConfigMapStore.GetByKey(cfgMapKey)
+	if err == nil {
+		return c.ConfigMapStore.Delete(item)
+	}
+	glog.Warningf("Couldn't find item %v in vault, unable to delete", cfgMapKey)
+	return nil
+}
+
+// NewConfigMapVault creates a config map client.
+// This client is essentially meant to abstract out the details of
+// configmaps and the API, and just store/retrieve a single value, the cluster uid.
+func NewConfigMapVault(c *client.Client, uidNs, uidConfigMapName string) *ConfigMapVault {
+	return &ConfigMapVault{NewConfigMapStore(c), uidNs, uidConfigMapName}
+}
+
+// FakeConfigMapStore is an implementation of the ConfigMapStore that doesn't
+// persist configmaps. Only used in testing.
+func NewFakeConfigMapVault(ns, name string) *ConfigMapVault {
+	return &ConfigMapVault{cache.NewStore(cache.MetaNamespaceKeyFunc), ns, name}
+}
+
+// ConfigMapStore wraps the store interface. Implementations usually persist
+// contents of the store transparently.
+type ConfigMapStore interface {
+	cache.Store
+}
+
+// ApiServerConfigMapStore only services Add and GetByKey from apiserver.
+// TODO: Implement all the other store methods and make this a write
+// through cache.
+type ApiServerConfigMapStore struct {
+	ConfigMapStore
+	client *client.Client
+}
+
+// Add adds the given config map to the apiserver's store.
+func (a *ApiServerConfigMapStore) Add(obj interface{}) error {
+	cfg := obj.(*api.ConfigMap)
+	_, err := a.client.ConfigMaps(cfg.Namespace).Create(cfg)
+	return err
+}
+
+// Update updates the existing config map object.
+func (a *ApiServerConfigMapStore) Update(obj interface{}) error {
+	cfg := obj.(*api.ConfigMap)
+	_, err := a.client.ConfigMaps(cfg.Namespace).Update(cfg)
+	return err
+}
+
+// Delete deletes the existing config map object.
+func (a *ApiServerConfigMapStore) Delete(obj interface{}) error {
+	cfg := obj.(*api.ConfigMap)
+	return a.client.ConfigMaps(cfg.Namespace).Delete(cfg.Name)
+}
+
+// GetByKey returns the config map for a given key.
+// The key must take the form namespace/name.
+func (a *ApiServerConfigMapStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	nsName := strings.Split(key, "/")
+	if len(nsName) != 2 {
+		return nil, false, fmt.Errorf("Failed to get key %v, unexpecte format, expecting ns/name", key)
+	}
+	ns, name := nsName[0], nsName[1]
+	cfg, err := a.client.ConfigMaps(ns).Get(name)
+	if err != nil {
+		// Translate not found errors to found=false, err=nil
+		if errors.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return cfg, true, nil
+}
+
+// NewConfigMapStore returns a config map store capable of persisting updates
+// to apiserver.
+func NewConfigMapStore(c *client.Client) ConfigMapStore {
+	return &ApiServerConfigMapStore{ConfigMapStore: cache.NewStore(cache.MetaNamespaceKeyFunc), client: c}
+}

--- a/ingress/controllers/gce/storage/configmaps_test.go
+++ b/ingress/controllers/gce/storage/configmaps_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestConfigMapUID(t *testing.T) {
+	vault := NewFakeConfigMapVault(api.NamespaceSystem, "ingress-uid")
+	uid := ""
+	k, exists, err := vault.Get()
+	if exists {
+		t.Errorf("Got a key from an empyt vault")
+	}
+	vault.Put(uid)
+	k, exists, err = vault.Get()
+	if !exists || err != nil {
+		t.Errorf("Failed to retrieve value from vault")
+	}
+	if k != "" {
+		t.Errorf("Failed to store empty string as a key in the vault")
+	}
+	vault.Put("newuid")
+	k, exists, err = vault.Get()
+	if !exists || err != nil {
+		t.Errorf("Failed to retrieve value from vault")
+	}
+	if k != "newuid" {
+		t.Errorf("Failed to modify uid")
+	}
+	if err := vault.Delete(); err != nil {
+		t.Errorf("Failed to delete uid %v", err)
+	}
+	if uid, exists, _ := vault.Get(); exists {
+		t.Errorf("Found uid %v, expected none", uid)
+	}
+}


### PR DESCRIPTION
Remembers existing cluster uids in a config map so even if it changes we don't delete/re-create working loadbalancers. This means once a cluster is up and running with a uid, it doesn't change no matter how many time the controller is restarted with a different uid, unless someone deletes the uid config map in kube-system. 

This is needed so we can rollout a change that auto-assigns uids to controllers, which in turn is required before we start running the controller on the master.
