### PR TITLE
Update Ingress status information in nginx controller

### DIFF
--- a/ingress/controllers/nginx/README.md
+++ b/ingress/controllers/nginx/README.md
@@ -224,4 +224,4 @@ The previous behavior can be restored using `retry-non-idempotent=true` in the c
 
 ## Limitations
 
-TODO
+- Ingress rules for TLS require the definition of the field `host`

--- a/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
+++ b/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
@@ -14,6 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
+      terminationGracePeriodSeconds: 60      
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
+++ b/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
@@ -15,7 +15,7 @@ spec:
         name: nginx-ingress-lb
     spec:
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.4
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
+++ b/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
@@ -8,6 +8,7 @@ spec:
       labels:
         name: nginx-ingress-lb
     spec:
+      terminationGracePeriodSeconds: 60      
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
+++ b/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
@@ -9,7 +9,7 @@ spec:
         name: nginx-ingress-lb
     spec:
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.4
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/default-backend.yaml
+++ b/ingress/controllers/nginx/examples/default-backend.yaml
@@ -11,7 +11,7 @@ spec:
       labels:
         app: default-http-backend
     spec:
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 60      
       containers:
       - name: default-http-backend
         # Any image is permissable as long as:

--- a/ingress/controllers/nginx/examples/default/rc-default.yaml
+++ b/ingress/controllers/nginx/examples/default/rc-default.yaml
@@ -14,6 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
+      terminationGracePeriodSeconds: 60      
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/default/rc-default.yaml
+++ b/ingress/controllers/nginx/examples/default/rc-default.yaml
@@ -15,7 +15,7 @@ spec:
         name: nginx-ingress-lb
     spec:
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.4
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/full/rc-full.yaml
+++ b/ingress/controllers/nginx/examples/full/rc-full.yaml
@@ -20,7 +20,7 @@ spec:
         secret:
           secretName: dhparam-example
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.4
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/full/rc-full.yaml
+++ b/ingress/controllers/nginx/examples/full/rc-full.yaml
@@ -15,6 +15,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
+      terminationGracePeriodSeconds: 60      
       volumes:
       - name: dhparam-example
         secret:

--- a/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
+++ b/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
@@ -14,6 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
+      terminationGracePeriodSeconds: 60      
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
+++ b/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
@@ -15,7 +15,7 @@ spec:
         name: nginx-ingress-lb
     spec:
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.4
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
+++ b/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
@@ -14,6 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
+      terminationGracePeriodSeconds: 60      
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
+++ b/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
@@ -15,7 +15,7 @@ spec:
         name: nginx-ingress-lb
     spec:
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.4
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/udp/rc-udp.yaml
+++ b/ingress/controllers/nginx/examples/udp/rc-udp.yaml
@@ -14,6 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
+      terminationGracePeriodSeconds: 60      
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/udp/rc-udp.yaml
+++ b/ingress/controllers/nginx/examples/udp/rc-udp.yaml
@@ -15,7 +15,7 @@ spec:
         name: nginx-ingress-lb
     spec:
       containers:
-      - image: aledbf/nginx-third-party:0.9
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.5
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/nginx/main.go
+++ b/ingress/controllers/nginx/nginx/main.go
@@ -77,7 +77,9 @@ const (
 	// Size of the SSL shared cache between all worker processes.
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache
 	sslSessionCacheSize = "10m"
+)
 
+var (
 	// Base directory that contains the mounted secrets with SSL certificates, keys and
 	sslDirectory = "/etc/nginx-ssl"
 )

--- a/ingress/controllers/nginx/nginx/ssl.go
+++ b/ingress/controllers/nginx/nginx/ssl.go
@@ -27,21 +27,21 @@ import (
 )
 
 // AddOrUpdateCertAndKey creates a .pem file wth the cert and the key with the specified name
-func (nginx *Manager) AddOrUpdateCertAndKey(name string, cert string, key string) string {
+func (nginx *Manager) AddOrUpdateCertAndKey(name string, cert string, key string) (string, error) {
 	pemFileName := sslDirectory + "/" + name + ".pem"
 
 	pem, err := os.Create(pemFileName)
 	if err != nil {
-		glog.Fatalf("Couldn't create pem file %v: %v", pemFileName, err)
+		return "", fmt.Errorf("Couldn't create pem file %v: %v", pemFileName, err)
 	}
 	defer pem.Close()
 
-	_, err = pem.WriteString(fmt.Sprintf("%v\n%v", key, cert))
+	_, err = pem.WriteString(fmt.Sprintf("%v\n%v", cert, key))
 	if err != nil {
-		glog.Fatalf("Couldn't write to pem file %v: %v", pemFileName, err)
+		return "", fmt.Errorf("Couldn't write to pem file %v: %v", pemFileName, err)
 	}
 
-	return pemFileName
+	return pemFileName, nil
 }
 
 // CheckSSLCertificate checks if the certificate and key file are valid

--- a/ingress/controllers/nginx/nginx/ssl_test.go
+++ b/ingress/controllers/nginx/nginx/ssl_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nginx
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestAddOrUpdateCertAndKey(t *testing.T) {
+	sslDirectory = os.TempDir()
+	// openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=echoheaders/O=echoheaders"
+	tlsCrt := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURhakNDQWxLZ0F3SUJBZ0lKQUxHUXR5VVBKTFhYTUEwR0NTcUdTSWIzRFFFQkJRVUFNQ3d4RkRBU0JnTlYKQkFNVEMyVmphRzlvWldGa1pYSnpNUlF3RWdZRFZRUUtFd3RsWTJodmFHVmhaR1Z5Y3pBZUZ3MHhOakF6TXpFeQpNekU1TkRoYUZ3MHhOekF6TXpFeU16RTVORGhhTUN3eEZEQVNCZ05WQkFNVEMyVmphRzlvWldGa1pYSnpNUlF3CkVnWURWUVFLRXd0bFkyaHZhR1ZoWkdWeWN6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0MKZ2dFQkFONzVmS0N5RWwxanFpMjUxTlNabDYzeGQweG5HMHZTVjdYL0xxTHJveVNraW5nbnI0NDZZWlE4UEJWOAo5TUZzdW5RRGt1QVoyZzA3NHM1YWhLSm9BRGJOMzhld053RXNsVDJkRzhRTUw0TktrTUNxL1hWbzRQMDFlWG1PCmkxR2txZFA1ZUExUHlPZCtHM3gzZmxPN2xOdmtJdHVHYXFyc0tvMEhtMHhqTDVtRUpwWUlOa0tGSVhsWWVLZS8KeHRDR25CU2tLVHFMTG0yeExKSGFFcnJpaDZRdkx4NXF5U2gzZTU2QVpEcTlkTERvcWdmVHV3Z2IzekhQekc2NwppZ0E0dkYrc2FRNHpZUE1NMHQyU1NiVkx1M2pScWNvL3lxZysrOVJBTTV4bjRubnorL0hUWFhHKzZ0RDBaeGI1CmVVRDNQakVhTnlXaUV2dTN6UFJmdysyNURMY0NBd0VBQWFPQmpqQ0JpekFkQmdOVkhRNEVGZ1FVcktMZFhHeUUKNUlEOGRvd2lZNkdzK3dNMHFKc3dYQVlEVlIwakJGVXdVNEFVcktMZFhHeUU1SUQ4ZG93aVk2R3Mrd00wcUp1aApNS1F1TUN3eEZEQVNCZ05WQkFNVEMyVmphRzlvWldGa1pYSnpNUlF3RWdZRFZRUUtFd3RsWTJodmFHVmhaR1Z5CmM0SUpBTEdRdHlVUEpMWFhNQXdHQTFVZEV3UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUZCUUFEZ2dFQkFNZVMKMHFia3VZa3Z1enlSWmtBeE1PdUFaSDJCK0Evb3N4ODhFRHB1ckV0ZWN5RXVxdnRvMmpCSVdCZ2RkR3VBYU5jVQorUUZDRm9NakJOUDVWVUxIWVhTQ3VaczN2Y25WRDU4N3NHNlBaLzhzbXJuYUhTUjg1ZVpZVS80bmFyNUErdWErClIvMHJrSkZnOTlQSmNJd3JmcWlYOHdRcWdJVVlLNE9nWEJZcUJRL0VZS2YvdXl6UFN3UVZYRnVJTTZTeDBXcTYKTUNML3d2RlhLS0FaWDBqb3J4cHRjcldkUXNCcmYzWVRnYmx4TE1sN20zL2VuR1drcEhDUHdYeVRCOC9rRkw3SApLL2ZHTU1NWGswUkVSbGFPM1hTSUhrZUQ2SXJiRnRNV3R1RlJwZms2ZFA2TXlMOHRmTmZ6a3VvUHVEWUFaWllWCnR1NnZ0c0FRS0xWb0pGaGV0b1k9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+	tlsKey := "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBM3ZsOG9MSVNYV09xTGJuVTFKbVhyZkYzVEdjYlM5Slh0Zjh1b3V1akpLU0tlQ2V2CmpqcGhsRHc4Rlh6MHdXeTZkQU9TNEJuYURUdml6bHFFb21nQU5zM2Z4N0EzQVN5VlBaMGJ4QXd2ZzBxUXdLcjkKZFdqZy9UVjVlWTZMVWFTcDAvbDREVS9JNTM0YmZIZCtVN3VVMitRaTI0WnFxdXdxalFlYlRHTXZtWVFtbGdnMgpRb1VoZVZoNHA3L0cwSWFjRktRcE9vc3ViYkVza2RvU3V1S0hwQzh2SG1ySktIZDdub0JrT3IxMHNPaXFCOU83CkNCdmZNYy9NYnJ1S0FEaThYNnhwRGpOZzh3elMzWkpKdFV1N2VOR3B5ai9LcUQ3NzFFQXpuR2ZpZWZQNzhkTmQKY2I3cTBQUm5Gdmw1UVBjK01SbzNKYUlTKzdmTTlGL0Q3YmtNdHdJREFRQUJBb0lCQUViNmFEL0hMNjFtMG45bgp6bVkyMWwvYW83MUFmU0h2dlZnRCtWYUhhQkY4QjFBa1lmQUdpWlZrYjBQdjJRSFJtTERoaWxtb0lROWhadHVGCldQOVIxKythTFlnbGdmenZzanBBenR2amZTUndFaEFpM2pnSHdNY1p4S2Q3UnNJZ2hxY2huS093S0NYNHNNczQKUnBCbEFBZlhZWGs4R3F4NkxUbGptSDRDZk42QzZHM1EwTTlLMUxBN2lsck1Na3hwcngxMnBlVTNkczZMVmNpOQptOFdBL21YZ2I0c3pEbVNaWVpYRmNZMEhYNTgyS3JKRHpQWEVJdGQwZk5wd3I0eFIybzdzMEwvK2RnZCtqWERjCkh2SDBKZ3NqODJJaTIxWGZGM2tST3FxR3BKNmhVcncxTUZzVWRyZ29GL3pFck0vNWZKMDdVNEhodGFlalVzWTIKMFJuNXdpRUNnWUVBKzVUTVRiV084Wkg5K2pIdVQwc0NhZFBYcW50WTZYdTZmYU04Tm5CZWNoeTFoWGdlQVN5agpSWERlZGFWM1c0SjU5eWxIQ3FoOVdseVh4cDVTWWtyQU41RnQ3elFGYi91YmorUFIyWWhMTWZpYlBSYlYvZW1MCm5YaGF6MmtlNUUxT1JLY0x6QUVwSmpuZGQwZlZMZjdmQzFHeStnS2YyK3hTY1hjMHJqRE5iNGtDZ1lFQTR1UVEKQk91TlJQS3FKcDZUZS9zUzZrZitHbEpjQSs3RmVOMVlxM0E2WEVZVm9ydXhnZXQ4a2E2ZEo1QjZDOWtITGtNcQpwdnFwMzkxeTN3YW5uWC9ONC9KQlU2M2RxZEcyd1BWRUQ0REduaE54Qm1oaWZpQ1I0R0c2ZnE4MUV6ZE1vcTZ4CklTNHA2RVJaQnZkb1RqNk9pTHl6aUJMckpxeUhIMWR6c0hGRlNqOENnWUVBOWlSSEgyQ2JVazU4SnVYak8wRXcKUTBvNG4xdS9TZkQ4TFNBZ01VTVBwS1hpRTR2S0Qyd1U4a1BUNDFiWXlIZUh6UUpkdDFmU0RTNjZjR0ZHU1ZUSgphNVNsOG5yN051ejg3bkwvUmMzTGhFQ3Y0YjBOOFRjbW1oSy9CbDdiRXBOd0dFczNoNGs3TVdNOEF4QU15c3VxCmZmQ1pJM0tkNVJYNk0zbGwyV2QyRjhFQ2dZQlQ5RU9oTG0vVmhWMUVjUVR0cVZlMGJQTXZWaTVLSGozZm5UZkUKS0FEUVIvYVZncElLR3RLN0xUdGxlbVpPbi8yeU5wUS91UnpHZ3pDUUtldzNzU1RFSmMzYVlzbFVudzdhazJhZAp2ZTdBYXowMU84YkdHTk1oamNmdVBIS05LN2Nsc3pKRHJzcys4SnRvb245c0JHWEZYdDJuaWlpTTVPWVN5TTg4CkNJMjFEUUtCZ0hEQVRZbE84UWlDVWFBQlVqOFBsb1BtMDhwa3cyc1VmQW0xMzJCY00wQk9BN1hqYjhtNm1ManQKOUlteU5kZ2ZiM080UjlKVUxTb1pZSTc1dUxIL3k2SDhQOVlpWHZOdzMrTXl6VFU2b2d1YU8xSTNya2pna29NeAo5cU5pYlJFeGswS1A5MVZkckVLSEdHZEFwT05ES1N4VzF3ektvbUxHdmtYSTVKV05KRXFkCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg=="
+
+	dCrt, err := base64.StdEncoding.DecodeString(tlsCrt)
+	if err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+		return
+	}
+
+	dKey, err := base64.StdEncoding.DecodeString(tlsKey)
+	if err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+	}
+
+	ngx := &Manager{}
+
+	name := fmt.Sprintf("test-%v", time.Now().UnixNano())
+	pemPath, err := ngx.AddOrUpdateCertAndKey(name, string(dCrt), string(dKey))
+	if err != nil {
+		t.Fatalf("unexpected error checking SSL certificate: %v", err)
+	}
+
+	if pemPath == "" {
+		t.Fatalf("expected path to pem file but returned empty")
+	}
+
+	cnames, err := ngx.CheckSSLCertificate(pemPath)
+	if err != nil {
+		t.Fatalf("unexpected error checking SSL certificate: %v", err)
+	}
+
+	if len(cnames) == 0 {
+		t.Fatalf("expected at least one cname but none returned")
+	}
+
+	if cnames[0] != "echoheaders" {
+		t.Fatalf("expected cname echoheaders but %v returned", cnames[0])
+	}
+}


### PR DESCRIPTION
```
old-mbp:~ aledbf$ kubectl get ing
NAME      RULE          BACKEND   ADDRESS
echomap   -                       172.17.4.99
          foo.bar.com
          /foo          echoheaders-x:80
          bar.baz.com
          /bar          echoheaders-y:80
          /foo          echoheaders-x:80
old-mbp:~ aledbf$ kubectl describe  ing
Name:     echomap
Namespace:    default
Address:    172.17.4.99
Default backend:  default-http-backend:80 (<none>)
Rules:
  Host    Path  Backends
  ----    ----  --------
  foo.bar.com
        /foo  echoheaders-x:80 (10.2.68.4:8080)
  bar.baz.com
        /bar  echoheaders-y:80 (10.2.68.4:8080)
        /foo  echoheaders-x:80 (10.2.68.4:8080)
Annotations:
Events:
  FirstSeen LastSeen  Count From        SubobjectPath Type    Reason  Message
  --------- --------  ----- ----        ------------- --------  ------  -------
  38s   38s   1 {loadbalancer-controller }      Normal    CREATE  default/echomap
  38s   38s   1 {loadbalancer-controller }      Normal    CREATE  ip: 172.17.4.99
  38s   38s   1 {loadbalancer-controller }      Normal    UPDATE  default/echomap

```

```
old-mbp:~ aledbf$ kubectl get events -w
FIRSTSEEN                       LASTSEEN                        COUNT     NAME                             KIND                    SUBOBJECT                           TYPE      REASON             SOURCE                      MESSAGE
2016-03-31 00:03:55 -0300 CLT   2016-03-31 00:03:55 -0300 CLT   1         nginx-ingress-controller   ReplicationController             Normal    SuccessfulCreate   {replication-controller }   Created pod: nginx-ingress-controller-wdrix
2016-03-31 00:03:55 -0300 CLT   2016-03-31 00:03:55 -0300 CLT   1         nginx-ingress-controller-wdrix   Pod                 Normal    Scheduled   {default-scheduler }   Successfully assigned nginx-ingress-controller-wdrix to 172.17.4.99
2016-03-31 00:03:55 -0300 CLT   2016-03-31 00:03:55 -0300 CLT   1         nginx-ingress-controller-wdrix   Pod       spec.containers{nginx-ingress-lb}   Normal    Pulling   {kubelet 172.17.4.99}   pulling image "aledbf/nginx-third-party:0.9"
2016-03-31 00:04:08 -0300 CLT   2016-03-31 00:04:08 -0300 CLT   1         nginx-ingress-controller-wdrix   Pod       spec.containers{nginx-ingress-lb}   Normal    Pulled    {kubelet 172.17.4.99}   Successfully pulled image "aledbf/nginx-third-party:0.9"
2016-03-31 00:04:08 -0300 CLT   2016-03-31 00:04:08 -0300 CLT   1         nginx-ingress-controller-wdrix   Pod       spec.containers{nginx-ingress-lb}   Normal    Created   {kubelet 172.17.4.99}   Created container with docker id 68c6a6f8ec6d
2016-03-31 00:04:08 -0300 CLT   2016-03-31 00:04:08 -0300 CLT   1         nginx-ingress-controller-wdrix   Pod       spec.containers{nginx-ingress-lb}   Normal    Started   {kubelet 172.17.4.99}   Started container with docker id 68c6a6f8ec6d
2016-03-31 00:04:08 -0300 CLT   2016-03-31 00:04:08 -0300 CLT   1         echomap   Ingress             Normal    CREATE    {loadbalancer-controller }   default/echomap

2016-03-31 00:04:27 -0300 CLT   2016-03-31 00:04:27 -0300 CLT   1         nginx-ingress-controller   ReplicationController             Normal    SuccessfulDelete   {replication-controller }   Deleted pod: nginx-ingress-controller-wdrix
2016-03-31 00:04:27 -0300 CLT   2016-03-31 00:04:27 -0300 CLT   1         echomap   Ingress             Normal    DELETE    {loadbalancer-controller }   ip: 172.17.4.99
2016-03-31 00:04:57 -0300 CLT   2016-03-31 00:04:57 -0300 CLT   1         nginx-ingress-controller-wdrix   Pod       spec.containers{nginx-ingress-lb}   Normal    Killing   {kubelet 172.17.4.99}   Killing container with docker id 68c6a6f8ec6d: Need to kill pod.
```