### PR TITLE
cherrypick: Do not use --fork-base in PR matching

### DIFF
--- a/mungegithub/Dockerfile-cherrypick
+++ b/mungegithub/Dockerfile-cherrypick
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/debian:wheezy
+FROM google/debian:jessie
 MAINTAINER Brendan Burns <bburns@google.com>
 RUN apt-get update
 RUN apt-get install -y -qq ca-certificates git

--- a/mungegithub/Dockerfile-shame-mailer
+++ b/mungegithub/Dockerfile-shame-mailer
@@ -34,7 +34,7 @@
 #          -e SMTP_PASS=my_super_secret_smtp_password \
 #          gcr.io/google_containers/shame-mailer:TAG
 
-FROM google/debian:wheezy
+FROM google/debian:jessie
 MAINTAINER Kris Rousey <krousey@google.com>
 RUN apt-get update
 RUN apt-get install -y -qq ca-certificates heirloom-mailx

--- a/mungegithub/Dockerfile-submit-queue
+++ b/mungegithub/Dockerfile-submit-queue
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/debian:wheezy
+FROM google/debian:jessie
 MAINTAINER Brendan Burns <bburns@google.com>
 RUN apt-get update
 RUN apt-get install -y -qq ca-certificates git

--- a/mungegithub/mungers/cherrypick-clear-after-merge.go
+++ b/mungegithub/mungers/cherrypick-clear-after-merge.go
@@ -69,14 +69,18 @@ func handleFound(obj *github.MungeObject, branch string) error {
 // foundLog will return if the given `logString` exists on the branch in question.
 // it will also return the actual logs for further processing
 func (c *ClearPickAfterMerge) foundLog(branch string, logString string) (bool, string) {
-	args := []string{"merge-base", "--fork-point", "origin/master", "origin/" + branch}
+	args := []string{"merge-base", "origin/master", "origin/" + branch}
 	out, err := c.features.Repos.GitCommand(args)
 	base := string(out)
 	if err != nil {
 		glog.Errorf("Unable to find the fork point for branch %s. %s:%v", branch, base, err)
 		return false, ""
 	}
-	base = strings.TrimSuffix(base, "\n")
+	lines := strings.Split(base, "\n")
+	if len(lines) < 1 {
+		glog.Errorf("Found 0 lines splitting the results of git merge-base")
+	}
+	base = lines[0]
 
 	// if release-1.2 branched from master at abcdef123 this should result in:
 	// abcdef123..origin/release-1.2


### PR DESCRIPTION
wheezy doesn't even have the option to `git merge-base`. And it doesn't work in jessie.