### PR TITLE
Add more logging to GCS stable check

### DIFF
--- a/mungegithub/mungers/e2e/e2e.go
+++ b/mungegithub/mungers/e2e/e2e.go
@@ -108,6 +108,8 @@ func (e *E2ETester) GCSBasedStable() bool {
 			continue
 		}
 		if stable, err := utils.CheckFinishedStatus(job, lastBuildNumber); !stable || err != nil {
+			// TODO: decrese verbosity when we feel comfortable with this check.
+			glog.Infof("Found unstable job: %v, build number: %v", job, lastBuildNumber)
 			return false
 		}
 	}

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -240,7 +240,7 @@ func (sq *SubmitQueue) e2eStable() bool {
 	gcsStable := sq.e2e.GCSBasedStable()
 
 	if stable != gcsStable {
-		glog.Errorf("GCS stable check returned different value than Jenkins.")
+		glog.Errorf("GCS stable check returned different value than Jenkins: %v vs %v.", stable, gcsStable)
 	}
 
 	sq.Lock()

--- a/test-utils/utils/utils.go
+++ b/test-utils/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/golang/glog"
 )
@@ -30,6 +31,7 @@ const (
 	urlPrefix     = "https://storage.googleapis.com/kubernetes-jenkins/logs"
 	successString = "SUCCESS"
 	retries       = 3
+	retryWait     = 100 * time.Millisecond
 )
 
 func getResponseWithRetry(url string) (*http.Response, error) {
@@ -43,6 +45,7 @@ func getResponseWithRetry(url string) (*http.Response, error) {
 		if response.StatusCode == http.StatusOK {
 			return response, nil
 		}
+		time.Sleep(retryWait)
 	}
 	return response, nil
 }


### PR DESCRIPTION
Additional log in e2e.go will probably be quite verbose, so we need to fix this problem after changing to GCS as source of truth. #602

cc @wojtek-t 
