### PR TITLE
submit queue: Update chip links

### DIFF
--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -147,7 +147,7 @@
                 </md-toolbar>
                 <md-chips ng-model="cntl.builds" readonly="true">
                   <md-chip-template title="{{$chip.msg}}">
-                    <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="https://storage.cloud.google.com/kubernetes-jenkins/logs/{{$chip.name}}/{{$chip.id}}/">{{$chip.name}}</a>
+                    <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="https://console.cloud.google.com/storage/kubernetes-jenkins/logs/{{$chip.name}}/{{$chip.id}}/">{{$chip.name}}</a>
                     <span style="color: {{$chip.color}}">{{$chip.msg}}</span>
                   </md-chip-template>
                 </md-chips>


### PR DESCRIPTION
They used to point to
storage.cloud.google.com/
But that stopped working so point to
console.cloud.google.com/storage/