### PR TITLE
Avoid unnecessary 'changed' for kubernetes-addons playbooks

### DIFF
--- a/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
@@ -20,6 +20,7 @@
     - heapster-service.yaml
     - influxdb-grafana-controller.yaml
     - influxdb-service.yaml
+  changed_when: false
 
 - name: MONITORING | Remove instances of getting pillar dicts
   local_action: lineinfile
@@ -33,6 +34,7 @@
     - heapster-service.yaml
     - influxdb-grafana-controller.yaml
     - influxdb-service.yaml
+  changed_when: false
 
 - name: MONITORING | Add tests for pillar vars converted to ansible vars
   local_action: lineinfile
@@ -47,6 +49,7 @@
     - heapster-service.yaml
     - influxdb-grafana-controller.yaml
     - influxdb-service.yaml
+  changed_when: false
 
 - name: MONITORING | Install template from converted saltfile
   template:

--- a/ansible/roles/kubernetes-addons/tasks/dns.yml
+++ b/ansible/roles/kubernetes-addons/tasks/dns.yml
@@ -14,6 +14,7 @@
     dest="{{ local_temp_addon_dir }}/dns/skydns-rc.yaml.j2"
     force=yes
   sudo: no
+  changed_when: false
 
 - name: DNS | Convert pillar vars to ansible vars for skydns-rc.yaml
   local_action: replace
@@ -21,6 +22,7 @@
     regexp="pillar\[\'(\w*)\'\]"
     replace="\1"
   sudo: no
+  changed_when: false
 
 - name: DNS | Install Template from converted saltfile
   template:
@@ -37,6 +39,7 @@
     dest="{{ local_temp_addon_dir }}/dns/skydns-svc.yaml.j2"
     force=yes
   sudo: no
+  changed_when: false
 
 - name: DNS | Convert pillar vars to ansible vars for skydns-rc.yaml
   local_action: replace
@@ -44,6 +47,7 @@
     regexp="pillar\[\'(\w*)\'\]"
     replace="\1"
   sudo: no
+  changed_when: false
 
 - name: DNS | Install Template from converted saltfile
   template:


### PR DESCRIPTION
Currently several addon spec file are always downloaded from Github,
each time Ansible run. Then installed to target configuration file after
inline changes.

This creates too many 'changed' noise and breaks the expectation that
Ansible run should be idempotent and only report 'changed' when really
does.

This change mute 'changed' message for downloading and inline replacing
part, and let the final install to /etc part report 'changed' or not.