### PR TITLE
Updated with correction for Ingress TLS spec

### DIFF
--- a/ingress/controllers/gce/README.md
+++ b/ingress/controllers/gce/README.md
@@ -390,7 +390,7 @@ metadata:
   name: no-rules-map
 spec:
   tls:
-    secretName: testsecret
+  - secretName: testsecret
   backend:
     serviceName: s1
     servicePort: 80


### PR DESCRIPTION
Documentation fix for `error validating data: expected type array, for field spec.tls, got map; if you choose to ignore these errors, turn validation off with --validate=false`