### PR TITLE
set KillMode=process for kubelet

### DIFF
--- a/init/systemd/kubelet.service
+++ b/init/systemd/kubelet.service
@@ -18,6 +18,7 @@ ExecStart=/usr/bin/kubelet \
 	    $KUBE_ALLOW_PRIV \
 	    $KUBELET_ARGS
 Restart=on-failure
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When a pod requests a e.g. glusterfs, kubelet mounter will in the end invoke the glusterfs mount daemon. The daemon stays till the volume is unmounted. If systemd stops kubelet with killMode=control-group (the default), both kubelet and glusterfs daemon is killed, while the container stays alive with a broken bind mount. When systemd starts kubelet again, even though kubelet is able to re-mount the volume, the broken bind mount in the container cannot be repaired. This is what happened in Kubernetes #13511

The proposed fix is to tell systemd to just kill kubelet and leave other processes alive by setting killMode=process, the glusterfs daemon stays with the container when kubelet is stopped.

