### PR TITLE
Add a fake e2e tester.

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -8,3 +8,5 @@ ingress/controllers/nginx/nginx.tmpl:    error_page 501 = @custom_501;
 ingress/controllers/nginx/nginx.tmpl:    error_page 502 = @custom_502;
 ingress/controllers/nginx/nginx.tmpl:    error_page 503 = @custom_503;
 ingress/controllers/nginx/nginx.tmpl:    error_page 504 = @custom_504;
+mungegithub/mungers/submit-queue.go:		sq.e2e = &fake_e2e.FakeE2ETester{
+mungegithub/mungers/submit-queue.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -23,6 +23,7 @@ etcd-servers
 extra-cpu
 extra-memory
 extra-storage
+fake-e2e
 forward-services
 generated-files-config
 health-check-path

--- a/mungegithub/mungers/e2e/e2e_test.go
+++ b/mungegithub/mungers/e2e/e2e_test.go
@@ -111,7 +111,7 @@ func TestCheckBuilds(t *testing.T) {
 				res.Write(data)
 			},
 		})
-		e2e := &E2ETester{
+		e2e := &RealE2ETester{
 			JenkinsHost: server.URL,
 			JobNames: []string{
 				"foo",

--- a/mungegithub/mungers/e2e/fake/fake.go
+++ b/mungegithub/mungers/e2e/fake/fake.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import "k8s.io/contrib/mungegithub/mungers/e2e"
+
+// FakeE2ETester always reports builds as stable.
+type FakeE2ETester struct {
+	JobNames           []string
+	WeakStableJobNames []string
+}
+
+// GCSBasedStable is always true.
+func (e *FakeE2ETester) GCSBasedStable() bool { return true }
+
+// GCSWeakStable is always true.
+func (e *FakeE2ETester) GCSWeakStable() bool { return true }
+
+// Stable is always true.
+func (e *FakeE2ETester) Stable() bool { return true }
+
+// GetBuildStatus reports "Stable" and a latest build of "1" for each build.
+func (e *FakeE2ETester) GetBuildStatus() map[string]e2e.BuildInfo {
+	out := map[string]e2e.BuildInfo{}
+	for _, name := range e.JobNames {
+		out[name] = e2e.BuildInfo{"Stable", "1"}
+	}
+	for _, name := range e.WeakStableJobNames {
+		out[name] = e2e.BuildInfo{"Stable", "1"}
+	}
+	return out
+}


### PR DESCRIPTION
Pass in `--fake-e2e` and all jobs will be stable. I'm really not sure if this is the idiomatic way of doing this in go, but it seems reasonable.

It's probably a good idea to switch the submit-queue_test to use this, but that can wait.

ref #713