### PR TITLE
Fix daemonset arguments to match replication controller

### DIFF
--- a/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
+++ b/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
@@ -40,5 +40,5 @@ spec:
         - containerPort: 443
           hostPort: 4444
         args:
-        - /nginx-ingress-controller-lb
+        - /nginx-ingress-controller
         - --default-backend-service=default/default-http-backend


### PR DESCRIPTION
The example DaemonSet as it exists causes the pod to crash on startup with the following:

Error syncing pod, skipping: failed to "StartContainer" for "nginx-ingress-lb" with RunContainerError: "runContainer: API error (500): Cannot start container 7eab41694a7d817665337724b5710bd17d7846f0212408aa9d6056e3211447a4: [8] System error: exec: \"/nginx-ingress-controller-lb\": stat /nginx-ingress-controller-lb: no such file or directory\n"

Modifying the arguments to match the replication controller works.