### PR TITLE
add "etcd_interface" variable 

### DIFF
--- a/ansible/roles/etcd/defaults/main.yaml
+++ b/ansible/roles/etcd/defaults/main.yaml
@@ -19,10 +19,16 @@ etcd_peer_key_file: "{{ etcd_conf_dir }}/peer.key"
 etcd_initial_cluster_state: new
 etcd_initial_cluster_token: etcd-k8-cluster
 
-etcd_initial_advertise_peer_urls: "{{ etcd_peer_url_scheme }}://{{ ansible_default_ipv4.address }}:{{ etcd_peer_port }}"
+# Interface on which etcd listens.
+# Useful on systems when default interface is not connected to other machines,
+# for example as in Vagrant+VirtualBox configuration.
+# Note that this variable can't be set in per-host manner with current implementation.
+etcd_interface: "{{ ansible_default_ipv4.interface }}"
+
+etcd_machine_address: "{{ hostvars[inventory_hostname]['ansible_' + etcd_interface].ipv4.address }}"
+etcd_initial_advertise_peer_urls: "{{ etcd_peer_url_scheme }}://{{ etcd_machine_address }}:{{ etcd_peer_port }}"
 etcd_listen_peer_urls: "{{ etcd_peer_url_scheme }}://0.0.0.0:{{ etcd_peer_port }}"
-etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ ansible_default_ipv4.address }}:{{ etcd_client_port }}"
+etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ etcd_machine_address }}:{{ etcd_client_port }}"
 etcd_listen_client_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port }}"
 
 etcd_data_dir: /var/lib/etcd
-

--- a/ansible/roles/etcd/templates/etcd.conf.j2
+++ b/ansible/roles/etcd/templates/etcd.conf.j2
@@ -1,11 +1,8 @@
 {% macro initial_cluster() -%}
 {% for host in groups[etcd_peers_group] -%}
-{% if loop.last -%}
-{{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host].ansible_default_ipv4.address }}:{{ etcd_peer_port }}
-{%- else -%}
-{{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host].ansible_default_ipv4.address }}:{{ etcd_peer_port }},
-{%- endif -%}
-{% endfor -%}
+  {{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['ansible_' + etcd_interface].ipv4.address }}:{{ etcd_peer_port }}
+  {%- if not loop.last -%},{%- endif -%}
+{%- endfor -%}
 {% endmacro -%}
 
 {% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 1 %}

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -161,7 +161,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # On VirtualBox eth0 is used for NAT-ed internet connection,
       # and actual connectivity with the host and other VMs is done
       # using eth1 interface.
-      ansible.extra_vars = { flannel_opts: "--iface=eth1" }
+      ansible.extra_vars = {
+        flannel_opts: "--iface=eth1",
+        etcd_interface: "eth1",
+      }
     end
   end
 


### PR DESCRIPTION
Allows to specify host public interface on which etcd will listen.
Used to construct default advertisement addresses.

Useful on configuration when default interface is not connected to other
machines, such as in Vagrant+VirtualBox configuration.

Commit with setting interface in Vagrant+VirtualBox configuration will conflict with #712 - lets merge any of these PRs and I'll other one.

@adamschaub I included suggested change with looping in template: https://github.com/rutsky/contrib/blob/etcd-interface/ansible/roles/etcd/templates/etcd.conf.j2#L4

/cc: @danehans @eparis 