### PR TITLE
Add job health to the internal e2e page.

### DIFF
--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -147,9 +147,12 @@
               <md-chips ng-model="cntl.builds" readonly="true">
                 <md-chip-template title="{{$chip.msg}}">
                   <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="https://console.cloud.google.com/storage/kubernetes-jenkins/logs/{{$chip.name}}/{{$chip.id}}/">{{$chip.name}}</a>
-                  <span style="color: {{$chip.color}}">{{$chip.msg}}</span>
+                  <span style="color: {{$chip.color}}">{{$chip.msg}}</span> <span title="Job stability">{{$chip.stability}}</span>
                 </md-chip-template>
               </md-chips>
+              <br>
+              <h2 class="md-title" ng-show="cntl.OverallHealth.length > 0">Overall Health: {{ cntl.OverallHealth }}</h2>
+              <p>Health percents are the fraction of the time that a given job is stable since the submit queue restarted<span ng-show="cntl.StartTime.length > 0"> ({{ cntl.StartTime }})</span>.</p>
             </md-tab-body>
           </md-tab>
 


### PR DESCRIPTION
Every munge loop, the submit queue now tracks which jobs are stable and which aren't, and keeps a running total. The internal e2e page now displays these percents next to the job like so:

![ss](https://cloud.githubusercontent.com/assets/7368979/14333710/efa28a64-fc04-11e5-886e-ec35120b75f8.png)

I'd like to have a chart showing health as a function of time, and I would like to have it save the health data across restarts. It also won't be tough to make the color scale from green to red as the job fails more and more. Those can happen in future PRs.

cc @kubernetes/sig-testing 
