### PR TITLE
add Docker dropin to start it after Flannel on CoreOS

### DIFF
--- a/ansible/roles/flannel/files/40-docker-depends-on-flannel.conf
+++ b/ansible/roles/flannel/files/40-docker-depends-on-flannel.conf
@@ -1,0 +1,12 @@
+# Dropin for docker.service
+
+[Unit]
+# Flannel must be started before Docker.
+# Flannel acquires subnet for the host and writes appropriate
+# configuration in /run/flannel_docker_opts.env that is being read
+# by Docker service.
+# See https://coreos.com/kubernetes/docs/latest/deploy-master.html
+# and https://github.com/coreos/flannel/issues/112#issuecomment-72708347
+# for details.
+Requires=flanneld.service
+After=flanneld.service

--- a/ansible/roles/flannel/tasks/client.yml
+++ b/ansible/roles/flannel/tasks/client.yml
@@ -14,7 +14,7 @@
   when: not is_atomic and flannel_source_type != "github-release"
 
 - set_fact:
-    flannel_use_upstart: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 15
+    flannel_use_upstart: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 15 }}"
 
 - name: Install Flannel with github release
   include: github-release.yml

--- a/ansible/roles/flannel/tasks/client.yml
+++ b/ansible/roles/flannel/tasks/client.yml
@@ -1,4 +1,6 @@
 ---
+# Install Flannel.
+
 - name: Force to use github-release when packages are not available
   set_fact:
     flannel_source_type: "github-release"
@@ -11,12 +13,12 @@
         state: latest
   when: not is_atomic and flannel_source_type != "github-release"
 
+- set_fact:
+    flannel_use_upstart: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 15
+
 - name: Install Flannel with github release
   include: github-release.yml
   when: flannel_source_type == "github-release"
-
-- set_fact:
-    flannel_use_upstart: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 15
 
 - name: Set Flannel config file directory
   set_fact:

--- a/ansible/roles/flannel/tasks/config.yml
+++ b/ansible/roles/flannel/tasks/config.yml
@@ -1,4 +1,6 @@
 ---
+# Prepare and write Flannel configuration to etcd.
+
 - name: Set facts about etcdctl command
   set_fact:
     peers: "{% for hostname in groups['etcd'] %}http://{{ hostname }}:2379{% if not loop.last %},{% endif %}{% endfor %}"

--- a/ansible/roles/flannel/tasks/coreos.yml
+++ b/ansible/roles/flannel/tasks/coreos.yml
@@ -4,3 +4,11 @@
   register: flanneld_service
   notify:
     - reload systemd
+
+- name: CoreOS | Create Docker systemd dropin directory
+  file: path=/etc/systemd/system/docker.service.d state=directory
+
+- name: CoreOS | Add Docker drop-in with dependency on Flannel
+  copy: src=40-docker-depends-on-flannel.conf dest="/etc/systemd/system/docker.service.d/40-docker-depends-on-flannel.conf"
+  notify:
+    - reload systemd

--- a/ansible/roles/flannel/tasks/github-release.yml
+++ b/ansible/roles/flannel/tasks/github-release.yml
@@ -33,3 +33,11 @@
   with_items:
     - flanneld
     - mk-docker-opts.sh
+
+- name: Setup systemd service
+  include: systemd-service.yml
+  when: not flannel_use_upstart
+
+- name: Setup upstart service
+  include: upstart-service.yml
+  when: flannel_use_upstart

--- a/ansible/roles/flannel/tasks/main.yml
+++ b/ansible/roles/flannel/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
-- include: config.yml
+- name: Prepare and write Flannel configuration to etcd
+  include: config.yml
 
-- include: client.yml
+- name: Install Flannel
+  include: client.yml
   when: inventory_hostname in groups['masters'] + groups['nodes']
-
-- include: coreos.yml
-  when: is_coreos
 
 - include: ubuntu.yml
   when: ansible_distribution == 'Ubuntu'

--- a/ansible/roles/flannel/tasks/systemd-service.yml
+++ b/ansible/roles/flannel/tasks/systemd-service.yml
@@ -1,14 +1,21 @@
 ---
-- name: CoreOS | Add Flanneld Systemd Unit File
+# Write systemd Flannel configuration.
+
+# On non-github-release service files must be provided by flannel package.
+- assert:
+    that:
+      - flannel_source_type == "github-release"
+
+- name: Add Flanneld Systemd Unit File
   template: src=flanneld.service dest=/etc/systemd/system/flanneld.service
   register: flanneld_service
   notify:
     - reload systemd
 
-- name: CoreOS | Create Docker systemd dropin directory
+- name: Create Docker systemd dropin directory
   file: path=/etc/systemd/system/docker.service.d state=directory
 
-- name: CoreOS | Add Docker drop-in with dependency on Flannel
+- name: Add Docker drop-in with dependency on Flannel
   copy: src=40-docker-depends-on-flannel.conf dest="/etc/systemd/system/docker.service.d/40-docker-depends-on-flannel.conf"
   notify:
     - reload systemd

--- a/ansible/roles/flannel/tasks/ubuntu.yml
+++ b/ansible/roles/flannel/tasks/ubuntu.yml
@@ -10,7 +10,3 @@
   when: ansible_distribution_major_version|int < 15
   notify:
     - restart flannel
-
-- name: Ubuntu | Create Upstart Script
-  template: src=flanneld.upstart dest=/etc/init/flanneld.conf
-  when: ansible_distribution_major_version|int < 15

--- a/ansible/roles/flannel/tasks/upstart-service.yml
+++ b/ansible/roles/flannel/tasks/upstart-service.yml
@@ -1,0 +1,10 @@
+---
+# Write upstart Flannel configuration.
+
+# On non-github-release service files must be provided by flannel package.
+- assert:
+  that:
+    - flannel_source_type == "github-release"
+
+- name: Create Upstart Script
+  template: src=flanneld.upstart dest=/etc/init/flanneld.conf


### PR DESCRIPTION
Without this Docker can start before Flannel which will lead to
incorrect configuration of docker0 device (since configuration for it
prepares Flannel).

This should fix issue #716.

As this issue was not reported on other configuration, I believe on
other OSes Docker already depends on Flannel.

/cc: @danehans @eparis 