### PR TITLE
Flannel URL base to contain everything except tar

### DIFF
--- a/ansible/roles/flannel/defaults/main.yaml
+++ b/ansible/roles/flannel/defaults/main.yaml
@@ -9,5 +9,5 @@ flannel_source_type: package
 flannel_releases_dir: /opt
 
 #The default url to download the flannel tar from
-flannel_download_url_base: "https://github.com/coreos/flannel/releases/download"
-flannel_download_url: "{{ flannel_download_url_base }}/v{{ flannel_version }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz"
+flannel_download_url_base: "https://github.com/coreos/flannel/releases/download/v{{ flannel_version }}"
+flannel_download_url: "{{ flannel_download_url_base }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz"


### PR DESCRIPTION
- To match how kube_download_url_base is handled.
- Similar to #723

- Base URL = path up to the final tar.