### PR TITLE
Run nginx controller on a non-minion node

### DIFF
--- a/ingress/controllers/nginx/README.md
+++ b/ingress/controllers/nginx/README.md
@@ -18,6 +18,16 @@ This is a nginx Ingress controller that uses [ConfigMap](https://github.com/kube
 - default backend [404-server](https://github.com/kubernetes/contrib/tree/master/404-server)
 
 
+## Dry running the Ingress controller
+
+Before deploying the controller to production you might want to run it outside the cluster and observe it.
+
+```console
+$ make controller
+$ mkdir /etc/nginx-ssl
+$ ./nginx-ingress-controller --running-in-cluster=false --default-backend-service=kube-system/default-http-backend
+```
+
 
 ## Deploy the Ingress controller
 

--- a/ingress/controllers/nginx/nginx/main.go
+++ b/ingress/controllers/nginx/nginx/main.go
@@ -294,6 +294,10 @@ func NewManager(kubeClient *client.Client) *Manager {
 
 func (nginx *Manager) createCertsDir(base string) {
 	if err := os.Mkdir(base, os.ModeDir); err != nil {
+		if os.IsExist(err) {
+			glog.Infof("%v already exists", err)
+			return
+		}
 		glog.Fatalf("Couldn't create directory %v: %v", base, err)
 	}
 }

--- a/ingress/controllers/nginx/rc.yaml
+++ b/ingress/controllers/nginx/rc.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  labels:
+    k8s-app: default-http-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    k8s-app: default-http-backend
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: default-http-backend
+spec:
+  replicas: 1
+  selector:
+    k8s-app: default-http-backend
+  template:
+    metadata:
+      labels:
+        k8s-app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx-ingress-controller
+  labels:
+    k8s-app: nginx-ingress-lb
+spec:
+  replicas: 1
+  selector:
+    k8s-app: nginx-ingress-lb
+  template:
+    metadata:
+      labels:
+        k8s-app: nginx-ingress-lb
+        name: nginx-ingress-lb
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.5
+        name: nginx-ingress-lb
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10249
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        # use downward API
+        env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 4444
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=default/default-http-backend

--- a/ingress/controllers/nginx/rc.yaml
+++ b/ingress/controllers/nginx/rc.yaml
@@ -80,10 +80,6 @@ spec:
           timeoutSeconds: 5
         # use downward API
         env:
-          - name: POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
           - name: POD_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
Add a `--running-in-cluster=false` mode. This is useful for running the controller on any non-minion node (eg: edge router, kubernetes master, local desktop for development etc). 

Also adds an all-in-one rc example.
@aledbf 