### PR TITLE
submit-queue: Give information about how long the queue has been blocked

### DIFF
--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/kubernetes/pkg/util"
+
 	github_util "k8s.io/contrib/mungegithub/github"
 	github_test "k8s.io/contrib/mungegithub/github/testing"
 	"k8s.io/contrib/mungegithub/mungers/jenkins"
@@ -169,11 +171,20 @@ func getTestSQ(startThreads bool, config *github_util.Config, server *httptest.S
 	sq.RequiredStatusContexts = []string{jenkinsUnitContext}
 	sq.E2EStatusContext = jenkinsE2EContext
 	sq.UnitStatusContext = jenkinsUnitContext
-	sq.JenkinsHost = server.URL
+	if server != nil {
+		sq.JenkinsHost = server.URL
+	}
 	sq.JobNames = []string{"foo"}
 	sq.WhitelistOverride = "ok-to-merge"
 	sq.githubE2EQueue = map[int]*github_util.MungeObject{}
 	sq.githubE2EPollTime = 50 * time.Millisecond
+
+	sq.clock = util.NewFakeClock(time.Time{})
+	sq.lastMergeTime = sq.clock.Now()
+	sq.lastE2EStable = true
+	sq.prStatus = map[string]submitStatus{}
+	sq.lastPRStatus = map[string]submitStatus{}
+
 	if startThreads {
 		sq.internalInitialize(config, nil, server.URL)
 		sq.EachLoop()
@@ -850,6 +861,178 @@ func TestSubmitQueue(t *testing.T) {
 
 		if test.state != "" && test.state != stateSet {
 			t.Errorf("%d:%q state set to %q but expected %q", testNum, test.name, stateSet, test.state)
+		}
+	}
+}
+
+func TestCalcMergeRate(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	tests := []struct {
+		name     string // because when it fails, counting is hard
+		preRate  float64
+		interval time.Duration
+		expected func(float64) bool
+	}{
+		{
+			name:     "0One",
+			preRate:  0,
+			interval: time.Duration(time.Hour),
+			expected: func(rate float64) bool {
+				return rate > 10 && rate < 11
+			},
+		},
+		{
+			name:     "24One",
+			preRate:  24,
+			interval: time.Duration(time.Hour),
+			expected: func(rate float64) bool {
+				return rate == float64(24)
+			},
+		},
+		{
+			name:     "24Two",
+			preRate:  24,
+			interval: time.Duration(2 * time.Hour),
+			expected: func(rate float64) bool {
+				return rate > 17 && rate < 18
+			},
+		},
+		{
+			name:     "24HalfHour",
+			preRate:  24,
+			interval: time.Duration(time.Hour) / 2,
+			expected: func(rate float64) bool {
+				return rate > 31 && rate < 32
+			},
+		},
+		{
+			name:     "24Three",
+			preRate:  24,
+			interval: time.Duration(3 * time.Hour),
+			expected: func(rate float64) bool {
+				return rate > 14 && rate < 15
+			},
+		},
+		{
+			name:     "24Then24",
+			preRate:  24,
+			interval: time.Duration(24 * time.Hour),
+			expected: func(rate float64) bool {
+				return rate > 2 && rate < 3
+			},
+		},
+	}
+	for testNum, test := range tests {
+		sq := getTestSQ(false, nil, nil)
+		clock := sq.clock.(*util.FakeClock)
+		sq.mergeRate = test.preRate
+		clock.Step(test.interval)
+		sq.updateMergeRate()
+		if !test.expected(sq.mergeRate) {
+			t.Errorf("%d:%s: expected() failed: rate:%v", testNum, test.name, sq.mergeRate)
+		}
+	}
+}
+
+func TestCalcMergeRateWithTail(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	tests := []struct {
+		name     string // because when it fails, counting is hard
+		preRate  float64
+		interval time.Duration
+		expected func(float64) bool
+	}{
+		{
+			name:     "ZeroPlusZero",
+			preRate:  0,
+			interval: time.Duration(0),
+			expected: func(rate float64) bool {
+				return rate == float64(0)
+			},
+		},
+		{
+			name:     "0OneHour",
+			preRate:  0,
+			interval: time.Duration(time.Hour),
+			expected: func(rate float64) bool {
+				return rate == 0
+			},
+		},
+		{
+			name:     "TinyOneHour",
+			preRate:  .001,
+			interval: time.Duration(time.Hour),
+			expected: func(rate float64) bool {
+				return rate == .001
+			},
+		},
+		{
+			name:     "TwentyFourPlusHalfHour",
+			preRate:  24,
+			interval: time.Duration(time.Hour) / 2,
+			expected: func(rate float64) bool {
+				return rate == 24
+			},
+		},
+		{
+			name:     "TwentyFourPlusOneHour",
+			preRate:  24,
+			interval: time.Duration(time.Hour),
+			expected: func(rate float64) bool {
+				return rate == 24
+			},
+		},
+		{
+			name:     "TwentyFourPlusTwoHour",
+			preRate:  24,
+			interval: time.Duration(2 * time.Hour),
+			expected: func(rate float64) bool {
+				return rate > 17 && rate < 18
+			},
+		},
+		{
+			name:     "TwentyFourPlusFourHour",
+			preRate:  24,
+			interval: time.Duration(4 * time.Hour),
+			expected: func(rate float64) bool {
+				return rate > 12 && rate < 13
+			},
+		},
+		{
+			name:     "TwentyFourPlusTwentyFourHour",
+			preRate:  24,
+			interval: time.Duration(24 * time.Hour),
+			expected: func(rate float64) bool {
+				return rate > 2 && rate < 3
+			},
+		},
+		{
+			name:     "TwentyFourPlusTiny",
+			preRate:  24,
+			interval: time.Duration(time.Nanosecond),
+			expected: func(rate float64) bool {
+				return rate == 24
+			},
+		},
+		{
+			name:     "TwentyFourPlusHuge",
+			preRate:  24,
+			interval: time.Duration(1024 * time.Hour),
+			expected: func(rate float64) bool {
+				return rate > 0 && rate < 1
+			},
+		},
+	}
+	for testNum, test := range tests {
+		sq := getTestSQ(false, nil, nil)
+		sq.mergeRate = test.preRate
+		clock := sq.clock.(*util.FakeClock)
+		clock.Step(test.interval)
+		rate := sq.calcMergeRateWithTail()
+		if !test.expected(rate) {
+			t.Errorf("%d:%s: %v", testNum, test.name, rate)
 		}
 	}
 }

--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -19,10 +19,10 @@
     <md-content class="md-whiteframe-z2">
       <md-toolbar layout="row" layout-align="space-around center">
         <h1 class="md-display-2">Submit Queue Status</h1>
-        <a ng-href="https://k8s.io"><img src="https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png" class="titleLogo"></a>
+        <a ng-href="https://k8s.io"><img src="https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png" alt="kubernetes logo" class="titleLogo"></a>
       </md-toolbar>
       <md-toolbar class="md-warn" ng-show="cntl.failedBuild">
-        <h2 class="md-toolbar-tools">E2E Tests Failing. Entire Submit Queue Blocked.</h2>
+        <h2 class="md-toolbar-tools">E2E Tests Failing. Entire submit queue blocked. Last merge&nbsp;<span am-time-ago="cntl.lastMergeTime"></span>.</h2>
       </md-toolbar>
       <md-content class="md-padding">
         <md-tabs md-selected="cntl.selected" md-dynamic-height md-border-bottom>
@@ -61,9 +61,13 @@
           </md-tab>
 
           <md-tab label="Queue" md-on-select="cntl.selectTab('queue')">
-            <md-toolbar class="md-whiteframe-z2">
-              <h2 class="md-toolbar-tools">Queued For Retest And Merge<span id="queue-len" ng-show="cntl.e2equeue.length > 0"></span></h2>
-            </md-toolbar>
+	    <md-content class="md-whiteframe-z2">
+              <md-toolbar class="md-whiteframe-z2">
+	        <h2 class="md-toolbar-tools">Queued For Retest And Merge ({{cntl.e2equeue.length}})</h2>
+              </md-toolbar>
+	      <md-subheader class="md-primary">Estimated Merging {{cntl.sqStats.MergeRate}} PRs per day.</md-subheader>
+	    </md-content>
+	    <md-divider></md-divider>
             <section>
               <md-subheader class="md-primary">CURRENTLY RUNNING</md-subheader>
               <md-list layout-padding>
@@ -161,22 +165,18 @@
 	      <md-tabs md-dynamic-height md-border-bottom>
 
                 <md-tab label="Queue Order">
-                  <md-content class="md-whiteframe-z2">
-                    <md-toolbar>
-                      <h2 class="md-toolbar-tools">How PRs get ordered in the queue</h2>
-                    </md-toolbar>
-                  </md-content>
+                  <md-toolbar class="md-whiteframe-z2">
+                    <h2 class="md-toolbar-tools">How PRs get ordered in the queue</h2>
+                  </md-toolbar>
 	          <md-content class="md-padding">
 	            <span id="priority-info"></span>
 	          </md-content>
 	        </md-tab>
 
                 <md-tab label="Merge Requirements">
-                  <md-content class="md-whiteframe-z2">
-                    <md-toolbar>
-                      <h2 class="md-toolbar-tools">Requirements for a PR to get automatically merged </h2>
-                    </md-toolbar>
-                  </md-content>
+                  <md-toolbar class="md-whiteframe-z2">
+                    <h2 class="md-toolbar-tools">Requirements for a PR to get automatically merged </h2>
+                  </md-toolbar>
 	          <md-content class="md-padding">
 	            <span id="merge-info"></span>
 	          </md-content>
@@ -245,6 +245,8 @@
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.3/angular-animate.min.js" type="text/javascript"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.3/angular-aria.min.js" type="text/javascript"></script>
   <script src="https://cdn.gitcdn.link/cdn/angular/bower-material/v1.0.7/angular-material.min.js" type="text/javascript"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.12.0/moment.min.js" type="text/javascript"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-moment/1.0.0-beta.5/angular-moment.min.js" type="text/javascript"></script>
   <script src="md-data-table.min.js" type="text/javascript"></script>
   <script src="toArrayFilter.js" type="text/javascript"></script>
   <script src="script.js" type="text/javascript"></script>

--- a/mungegithub/submit-queue/www/script.js
+++ b/mungegithub/submit-queue/www/script.js
@@ -1,5 +1,5 @@
 "use strict";
-angular.module('SubmitQueueModule', ['ngMaterial', 'md.data.table', 'angular-toArrayFilter']);
+angular.module('SubmitQueueModule', ['ngMaterial', 'md.data.table', 'angular-toArrayFilter', 'angularMoment']);
 
 angular.module('SubmitQueueModule').controller('SQCntl', ['DataService', '$interval', '$location', SQCntl]);
 
@@ -9,6 +9,7 @@ function SQCntl(dataService, $interval, $location) {
   self.users = {};
   self.builds = {};
   self.health = {};
+  self.lastMergeTime = Date();
   self.prQuerySearch = prQuerySearch;
   self.historyQuerySearch = historyQuerySearch;
   self.goToPerson = goToPerson;
@@ -76,7 +77,6 @@ function SQCntl(dataService, $interval, $location) {
         self.e2erunning = [response.data.E2ERunning];
       }
       self.e2equeue = response.data.E2EQueue;
-      document.getElementById("queue-len").innerHTML = "&nbsp;(" + self.e2equeue.length + ")"
     });
   }
 
@@ -92,11 +92,22 @@ function SQCntl(dataService, $interval, $location) {
     });
   }
 
-  // Refresh every 10 minutes
-  refreshStats();
-  $interval(refreshStats, 600000);
+  // Refresh every 30 minutes
+  refreshSQStats();
+  $interval(refreshSQStats, 1800000);
 
-  function refreshStats() {
+  function refreshSQStats() {
+    dataService.getData('sq-stats').then(function successCallback(response) {
+      self.sqStats = response.data;
+      self.lastMergeTime = new Date(response.data.LastMergeTime)
+    });
+  }
+
+  // Refresh every 10 minutes
+  refreshBotStats();
+  $interval(refreshBotStats, 600000);
+
+  function refreshBotStats() {
     dataService.getData('stats').then(function successCallback(response) {
       var nextLoop = new Date(response.data.NextLoopTime);
       document.getElementById("next-run-time").innerHTML = nextLoop.toLocaleTimeString();


### PR DESCRIPTION
![sq](https://cloud.githubusercontent.com/assets/8093535/14441739/d462eec4-fffb-11e5-87cc-ba399124e7a6.png)

And how fast it is running...

These number ignore PRs with e2e-not-required and those merged by hand
(since both require almost nothing from the submit queue)

resolves #721 
