### PR TITLE
mungegithub: delete bot comments when they are no longer useful

### DIFF
--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/contrib/mungegithub/github"
 
 	"github.com/golang/glog"
-	github_api "github.com/google/go-github/github"
+	githubapi "github.com/google/go-github/github"
 	"github.com/spf13/cobra"
 )
 
@@ -70,7 +70,7 @@ func (b *BlunderbussMunger) AddFlags(cmd *cobra.Command, config *github.Config) 
 }
 
 // u may be nil.
-func describeUser(u *github_api.User) string {
+func describeUser(u *githubapi.User) string {
 	if u != nil && u.Login != nil {
 		return *u.Login
 	}

--- a/mungegithub/mungers/cherrypick-queue.go
+++ b/mungegithub/mungers/cherrypick-queue.go
@@ -195,8 +195,8 @@ func (s cpQueueSorter) Less(i, j int) bool {
 	// Sort by LGTM as humans are likely to want to approve
 	// those first. After it merges the above check will win
 	// and LGTM won't matter
-	aLGTM := a.HasLabel("lgtm")
-	bLGTM := b.HasLabel("lgtm")
+	aLGTM := a.HasLabel(lgtmLabel)
+	bLGTM := b.HasLabel(lgtmLabel)
 	if aLGTM && !bLGTM {
 		return true
 	} else if !aLGTM && bLGTM {
@@ -284,10 +284,10 @@ func (c *CherrypickQueue) getQueueData(last, current map[int]*github.MungeObject
 			cps.ExtraInfo = append(cps.ExtraInfo, milestone)
 		}
 		merged, _ := obj.IsMerged()
-		if !merged && obj.HasLabel("lgtm") {
+		if !merged && obj.HasLabel(lgtmLabel) {
 			// Don't bother showing LGTM for merged things
 			// it's just a distraction at that point
-			cps.ExtraInfo = append(cps.ExtraInfo, "lgtm")
+			cps.ExtraInfo = append(cps.ExtraInfo, lgtmLabel)
 		}
 		out = append(out, cps)
 	}
@@ -336,9 +336,9 @@ func (c *CherrypickQueue) serveQueueInfo(res http.ResponseWriter, req *http.Requ
       <li>PRs which have not merged are considered 'after' any merged PR</li>
     </ul>
   </li>
-  <li>Labeld with "lgtm"
+  <li>Labeld with "` + lgtmLabel + `"
     <ul>
-      <li>PRs with the "lgtm" label come before those without</li>
+      <li>PRs with the "` + lgtmLabel + `" label come before those without</li>
     </ul>
   <li>PR number</li>
 </ol> `))

--- a/mungegithub/mungers/comment-deleter.go
+++ b/mungegithub/mungers/comment-deleter.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"k8s.io/contrib/mungegithub/features"
+	"k8s.io/contrib/mungegithub/github"
+
+	"github.com/golang/glog"
+	githubapi "github.com/google/go-github/github"
+	"github.com/spf13/cobra"
+)
+
+const (
+	commentDeleterName = "comment-deleter"
+)
+
+var (
+	_     = glog.Infof
+	funcs = []func(*github.MungeObject, *githubapi.IssueComment) bool{}
+)
+
+// CommentDeleter looks for comments which are no longer useful
+// and deletes them
+type CommentDeleter struct{}
+
+func init() {
+	RegisterMungerOrDie(CommentDeleter{})
+}
+
+//
+func registerShouldDeleteCommentFunc(f func(*github.MungeObject, *githubapi.IssueComment) bool) {
+	funcs = append(funcs, f)
+}
+
+// Name is the name usable in --pr-mungers
+func (CommentDeleter) Name() string { return commentDeleterName }
+
+// RequiredFeatures is a slice of 'features' that must be provided
+func (CommentDeleter) RequiredFeatures() []string { return []string{} }
+
+// Initialize will initialize the munger
+func (CommentDeleter) Initialize(config *github.Config, features *features.Features) error { return nil }
+
+// EachLoop is called at the start of every munge loop
+func (CommentDeleter) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (CommentDeleter) AddFlags(cmd *cobra.Command, config *github.Config) {}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (CommentDeleter) Munge(obj *github.MungeObject) {
+	if !obj.IsPR() {
+		return
+	}
+
+	comments, err := obj.ListComments()
+	if err != nil {
+		return
+	}
+
+	for i := range comments {
+		comment := &comments[i]
+		if comment.User == nil || comment.User.Login == nil {
+			continue
+		}
+		if *comment.User.Login != botName {
+			continue
+		}
+		if comment.Body == nil {
+			continue
+		}
+		for _, f := range funcs {
+			if f(obj, comment) {
+				obj.DeleteComment(comment)
+				break
+			}
+		}
+	}
+}

--- a/mungegithub/mungers/lgtm_after_commit.go
+++ b/mungegithub/mungers/lgtm_after_commit.go
@@ -55,12 +55,12 @@ func (LGTMAfterCommitMunger) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	if !obj.HasLabel("lgtm") {
+	if !obj.HasLabel(lgtmLabel) {
 		return
 	}
 
 	lastModified := obj.LastModifiedTime()
-	lgtmTime := obj.LabelTime("lgtm")
+	lgtmTime := obj.LabelTime(lgtmLabel)
 
 	if lastModified == nil || lgtmTime == nil {
 		glog.Errorf("PR %d unable to determine lastModified or lgtmTime", *obj.Issue.Number)
@@ -73,6 +73,6 @@ func (LGTMAfterCommitMunger) Munge(obj *github.MungeObject) {
 		if err := obj.WriteComment(lgtmRemovedBody); err != nil {
 			return
 		}
-		obj.RemoveLabel("lgtm")
+		obj.RemoveLabel(lgtmLabel)
 	}
 }

--- a/mungegithub/mungers/lgtm_after_commit.go
+++ b/mungegithub/mungers/lgtm_after_commit.go
@@ -21,7 +21,12 @@ import (
 	"k8s.io/contrib/mungegithub/github"
 
 	"github.com/golang/glog"
+	githubapi "github.com/google/go-github/github"
 	"github.com/spf13/cobra"
+)
+
+const (
+	lgtmRemovedBody = "PR changed after LGTM, removing LGTM."
 )
 
 // LGTMAfterCommitMunger will remove the LGTM flag from an PR which has been
@@ -29,7 +34,9 @@ import (
 type LGTMAfterCommitMunger struct{}
 
 func init() {
-	RegisterMungerOrDie(LGTMAfterCommitMunger{})
+	l := LGTMAfterCommitMunger{}
+	RegisterMungerOrDie(l)
+	registerShouldDeleteCommentFunc(l.isStaleComment)
 }
 
 // Name is the name usable in --pr-mungers
@@ -69,10 +76,30 @@ func (LGTMAfterCommitMunger) Munge(obj *github.MungeObject) {
 
 	if lastModified.After(*lgtmTime) {
 		glog.Infof("PR: %d lgtm:%s  lastModified:%s", *obj.Issue.Number, lgtmTime.String(), lastModified.String())
-		lgtmRemovedBody := "PR changed after LGTM, removing LGTM."
 		if err := obj.WriteComment(lgtmRemovedBody); err != nil {
 			return
 		}
 		obj.RemoveLabel(lgtmLabel)
 	}
+}
+
+func (LGTMAfterCommitMunger) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+	if *comment.Body != lgtmRemovedBody {
+		return false
+	}
+	if comment.CreatedAt == nil {
+		return false
+	}
+	if !obj.HasLabel("lgtm") {
+		return false
+	}
+	lgtmTime := obj.LabelTime("lgtm")
+	if lgtmTime == nil {
+		return false
+	}
+	stale := lgtmTime.After(*comment.CreatedAt)
+	if stale {
+		glog.V(6).Infof("Found stale LGTMAfterCommitMunger comment")
+	}
+	return stale
 }

--- a/mungegithub/mungers/needs_rebase.go
+++ b/mungegithub/mungers/needs_rebase.go
@@ -30,7 +30,9 @@ import (
 // unable to be automatically merged
 type NeedsRebaseMunger struct{}
 
-const needsRebase = "needs-rebase"
+const (
+	needsRebaseLabel = "needs-rebase"
+)
 
 func init() {
 	RegisterMungerOrDie(NeedsRebaseMunger{})
@@ -64,11 +66,11 @@ func (NeedsRebaseMunger) Munge(obj *github.MungeObject) {
 		glog.V(2).Infof("Skipping %d - problem determining mergeable", *obj.Issue.Number)
 		return
 	}
-	if mergeable && obj.HasLabel(needsRebase) {
-		obj.RemoveLabel(needsRebase)
+	if mergeable && obj.HasLabel(needsRebaseLabel) {
+		obj.RemoveLabel(needsRebaseLabel)
 	}
-	if !mergeable && !obj.HasLabel(needsRebase) {
-		obj.AddLabels([]string{needsRebase})
+	if !mergeable && !obj.HasLabel(needsRebaseLabel) {
+		obj.AddLabels([]string{needsRebaseLabel})
 
 		body := fmt.Sprintf("@%s PR needs rebase", *obj.Issue.User.Login)
 		if err := obj.WriteComment(body); err != nil {

--- a/mungegithub/mungers/ok-to-test.go
+++ b/mungegithub/mungers/ok-to-test.go
@@ -21,7 +21,15 @@ import (
 	"k8s.io/contrib/mungegithub/github"
 
 	"github.com/golang/glog"
+	githubapi "github.com/google/go-github/github"
 	"github.com/spf13/cobra"
+)
+
+const (
+	okToTestBody = `@k8s-bot ok to test
+@k8s-bot test this
+
+pr builder appears to be missing, activating due to 'lgtm' label.`
 )
 
 // OkToTestMunger looks for situations where a reviewer has LGTM'd a PR, but it
@@ -29,7 +37,9 @@ import (
 type OkToTestMunger struct{}
 
 func init() {
-	RegisterMungerOrDie(OkToTestMunger{})
+	ok := OkToTestMunger{}
+	RegisterMungerOrDie(ok)
+	registerShouldDeleteCommentFunc(ok.isStaleComment)
 }
 
 // Name is the name usable in --pr-mungers
@@ -39,7 +49,9 @@ func (OkToTestMunger) Name() string { return "ok-to-test" }
 func (OkToTestMunger) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
-func (OkToTestMunger) Initialize(config *github.Config, features *features.Features) error { return nil }
+func (OkToTestMunger) Initialize(config *github.Config, features *features.Features) error {
+	return nil
+}
 
 // EachLoop is called at the start of every munge loop
 func (OkToTestMunger) EachLoop() error { return nil }
@@ -56,13 +68,20 @@ func (OkToTestMunger) Munge(obj *github.MungeObject) {
 	if !obj.HasLabel(lgtmLabel) {
 		return
 	}
-	state := obj.GetStatusState([]string{jenkinsE2EContext, jenkinsUnitContext})
+	state := obj.GetStatusState(requiredContexts)
 	if state == "incomplete" {
 		glog.V(2).Infof("status is incomplete, adding ok to test")
-		msg := `@k8s-bot ok to test
-@k8s-bot test this
-
-pr builder appears to be missing, activating due to 'lgtm' label.`
-		obj.WriteComment(msg)
+		obj.WriteComment(okToTestBody)
 	}
+}
+
+func (OkToTestMunger) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+	if *comment.Body != okToTestBody {
+		return false
+	}
+	stale := commentBeforeLastCI(obj, comment)
+	if stale {
+		glog.V(6).Infof("Found stale OkToTestMunger comment")
+	}
+	return stale
 }

--- a/mungegithub/mungers/ok-to-test.go
+++ b/mungegithub/mungers/ok-to-test.go
@@ -53,7 +53,7 @@ func (OkToTestMunger) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	if !obj.HasLabel("lgtm") {
+	if !obj.HasLabel(lgtmLabel) {
 		return
 	}
 	state := obj.GetStatusState([]string{jenkinsE2EContext, jenkinsUnitContext})

--- a/mungegithub/mungers/path_label_test.go
+++ b/mungegithub/mungers/path_label_test.go
@@ -37,7 +37,7 @@ var (
 )
 
 func docsProposalIssue() *github.Issue {
-	return github_test.Issue(botName, 1, []string{"cla: yes", "kind/design"}, true)
+	return github_test.Issue(botName, 1, []string{claYesLabel, "kind/design"}, true)
 }
 
 // Commit returns a filled out github.Commit which happened at time.Unix(t, 0)

--- a/mungegithub/mungers/ping_ci.go
+++ b/mungegithub/mungers/ping_ci.go
@@ -72,7 +72,7 @@ func (PingCIMunger) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	if !obj.HasLabel("lgtm") {
+	if !obj.HasLabel(lgtmLabel) {
 		return
 	}
 	mergeable, err := obj.IsMergeable()

--- a/mungegithub/mungers/rebuild.go
+++ b/mungegithub/mungers/rebuild.go
@@ -98,8 +98,8 @@ Here is the [list of open test flakes](https://github.com/kubernetes/kubernetes/
 				glog.Errorf("unexpected error adding comment: %v", err)
 				continue
 			}
-			if obj.HasLabel("lgtm") {
-				if err := obj.RemoveLabel("lgtm"); err != nil {
+			if obj.HasLabel(lgtmLabel) {
+				if err := obj.RemoveLabel(lgtmLabel); err != nil {
 					glog.Errorf("unexpected error removing lgtm label: %v", err)
 				}
 			}

--- a/mungegithub/mungers/rebuild.go
+++ b/mungegithub/mungers/rebuild.go
@@ -19,6 +19,7 @@ package mungers
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"k8s.io/contrib/mungegithub/features"
 	"k8s.io/contrib/mungegithub/github"
@@ -36,16 +37,26 @@ type RebuildMunger struct {
 }
 
 const (
-	issueURLRe = "(?:https?://)?github.com/kubernetes/kubernetes/issues/[0-9]+"
+	issueURLRe    = "(?:https?://)?github.com/kubernetes/kubernetes/issues/[0-9]+"
+	rebuildFormat = `@%s
+You must link to the test flake issue which caused you to request this manual re-test.
+Re-test requests should be in the form of: ` + "`" + `k8s-bot test this issue: #<number>` + "`" + `
+Here is the [list of open test flakes](https://github.com/kubernetes/kubernetes/issues?q=is:issue+label:kind/flake+is:open).`
 )
 
 var (
 	buildMatcher = regexp.MustCompile("@k8s-bot\\s+(?:e2e\\s+)?(?:unit\\s+)?test\\s+this.*")
 	issueMatcher = regexp.MustCompile("\\s+(?:github\\s+)?(issue|flake)\\:?\\s+(?:#(?:IGNORE|[0-9]+)|" + issueURLRe + ")")
+
+	// take the format and replace the %s with \S+
+	rebuildCommentREString = strings.Replace(rebuildFormat, `@%s`, `@\S+`, 1)
+	rebuildCommentRE       = regexp.MustCompile(rebuildCommentREString)
 )
 
 func init() {
-	RegisterMungerOrDie(&RebuildMunger{})
+	r := &RebuildMunger{}
+	RegisterMungerOrDie(r)
+	registerShouldDeleteCommentFunc(r.isStaleComment)
 }
 
 // Name is the name usable in --pr-mungers
@@ -89,10 +100,7 @@ func (r *RebuildMunger) Munge(obj *github.MungeObject) {
 				glog.Errorf("Error deleting comment: %v", err)
 				continue
 			}
-			body := fmt.Sprintf(`@%s
-You must link to the test flake issue which caused you to request this manual re-test.
-Re-test requests should be in the form of: `+"`"+`k8s-bot test this issue: #<number>`+"`"+`
-Here is the [list of open test flakes](https://github.com/kubernetes/kubernetes/issues?q=is:issue+label:kind/flake+is:open).`, *comment.User.Login)
+			body := fmt.Sprintf(rebuildFormat, *comment.User.Login)
 			err := obj.WriteComment(body)
 			if err != nil {
 				glog.Errorf("unexpected error adding comment: %v", err)
@@ -113,4 +121,15 @@ func isRebuildComment(comment *githubapi.IssueComment) bool {
 
 func rebuildCommentMissingIssueNumber(comment *githubapi.IssueComment) bool {
 	return !issueMatcher.MatchString(*comment.Body)
+}
+
+func (r *RebuildMunger) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+	if !rebuildCommentRE.MatchString(*comment.Body) {
+		return false
+	}
+	stale := commentBeforeLastCI(obj, comment)
+	if stale {
+		glog.V(6).Infof("Found stale RebuildMunger comment")
+	}
+	return stale
 }

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -105,7 +105,7 @@ func (r *ReleaseNoteLabel) Munge(obj *github.MungeObject) {
 		obj.AddLabel(releaseNoteLabelNeeded)
 	}
 
-	if !obj.HasLabel("lgtm") {
+	if !obj.HasLabel(lgtmLabel) {
 		return
 	}
 
@@ -114,5 +114,5 @@ One of the following labels is required %q, %q, or %q
 Please see: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes`
 	msg := fmt.Sprintf(msgFmt, releaseNote, releaseNoteNone, releaseNoteActionRequired)
 	obj.WriteComment(msg)
-	obj.RemoveLabel("lgtm")
+	obj.RemoveLabel(lgtmLabel)
 }

--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -62,7 +62,7 @@ func (StaleGreenCI) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	if !obj.HasLabels([]string{"lgtm"}) {
+	if !obj.HasLabel(lgtmLabel) {
 		return
 	}
 

--- a/mungegithub/mungers/stale-pending-ci.go
+++ b/mungegithub/mungers/stale-pending-ci.go
@@ -74,7 +74,7 @@ func (StalePendingCI) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	if !obj.HasLabel("lgtm") {
+	if !obj.HasLabel(lgtmLabel) {
 		return
 	}
 

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -72,54 +72,54 @@ func BareIssue() *github.Issue {
 }
 
 func NoOKToMergeIssue() *github.Issue {
-	return github_test.Issue(whitelistUser, 1, []string{"cla: yes", "lgtm"}, true)
+	return github_test.Issue(whitelistUser, 1, []string{claYesLabel, lgtmLabel}, true)
 }
 
 func DoNotMergeIssue() *github.Issue {
-	return github_test.Issue(whitelistUser, 1, []string{"cla: yes", "lgtm", doNotMergeLabel}, true)
+	return github_test.Issue(whitelistUser, 1, []string{claYesLabel, lgtmLabel, doNotMergeLabel}, true)
 }
 
 func NoCLAIssue() *github.Issue {
-	return github_test.Issue(whitelistUser, 1, []string{"lgtm", "ok-to-merge"}, true)
+	return github_test.Issue(whitelistUser, 1, []string{lgtmLabel, okToMergeLabel}, true)
 }
 
 func NoLGTMIssue() *github.Issue {
-	return github_test.Issue(whitelistUser, 1, []string{"cla: yes", "ok-to-merge"}, true)
+	return github_test.Issue(whitelistUser, 1, []string{claYesLabel, okToMergeLabel}, true)
 }
 
 func UserNotInWhitelistNoOKToMergeIssue() *github.Issue {
-	return github_test.Issue(noWhitelistUser, 1, []string{"cla: yes", "lgtm"}, true)
+	return github_test.Issue(noWhitelistUser, 1, []string{claYesLabel, lgtmLabel}, true)
 }
 
 func UserNotInWhitelistOKToMergeIssue() *github.Issue {
-	return github_test.Issue(noWhitelistUser, 1, []string{"lgtm", "cla: yes", "ok-to-merge"}, true)
+	return github_test.Issue(noWhitelistUser, 1, []string{lgtmLabel, claYesLabel, okToMergeLabel}, true)
 }
 
 func DontRequireGithubE2EIssue() *github.Issue {
-	return github_test.Issue(whitelistUser, 1, []string{"cla: yes", "lgtm", e2eNotRequiredLabel}, true)
+	return github_test.Issue(whitelistUser, 1, []string{claYesLabel, lgtmLabel, e2eNotRequiredLabel}, true)
 }
 
 func OldLGTMEvents() []github.IssueEvent {
 	return github_test.Events([]github_test.LabelTime{
-		{"bob", "lgtm", 6},
-		{"bob", "lgtm", 7},
-		{"bob", "lgtm", 8},
+		{"bob", lgtmLabel, 6},
+		{"bob", lgtmLabel, 7},
+		{"bob", lgtmLabel, 8},
 	})
 }
 
 func NewLGTMEvents() []github.IssueEvent {
 	return github_test.Events([]github_test.LabelTime{
-		{"bob", "lgtm", 10},
-		{"bob", "lgtm", 11},
-		{"bob", "lgtm", 12},
+		{"bob", lgtmLabel, 10},
+		{"bob", lgtmLabel, 11},
+		{"bob", lgtmLabel, 12},
 	})
 }
 
 func OverlappingLGTMEvents() []github.IssueEvent {
 	return github_test.Events([]github_test.LabelTime{
-		{"bob", "lgtm", 8},
-		{"bob", "lgtm", 9},
-		{"bob", "lgtm", 10},
+		{"bob", lgtmLabel, 8},
+		{"bob", lgtmLabel, 9},
+		{"bob", lgtmLabel, 10},
 	})
 }
 
@@ -182,7 +182,6 @@ func getTestSQ(startThreads bool, config *github_util.Config, server *httptest.S
 	}
 	sq.JobNames = []string{"foo"}
 	sq.WeakStableJobNames = []string{"bar"}
-	sq.WhitelistOverride = "ok-to-merge"
 	sq.githubE2EQueue = map[int]*github_util.MungeObject{}
 	sq.githubE2EPollTime = 50 * time.Millisecond
 
@@ -242,7 +241,7 @@ func TestQueueOrder(t *testing.T) {
 				*github_test.Issue(whitelistUser, 2, []string{"priority/P1", "priority/P0"}, true),
 				*github_test.Issue(whitelistUser, 3, []string{"priority/P1", "kind/design"}, true),
 				*github_test.Issue(whitelistUser, 4, []string{"priority/P0"}, true),
-				*github_test.Issue(whitelistUser, 5, []string{"LGTM", "kind/new-api"}, true),
+				*github_test.Issue(whitelistUser, 5, []string{lgtmLabel, "kind/new-api"}, true),
 			},
 			expected: []int{2, 4, 3, 5},
 		},
@@ -267,7 +266,7 @@ func TestQueueOrder(t *testing.T) {
 			expected: []int{4, 2, 3, 5},
 		},
 		{
-			name: "e2e-not-required counts as P-negative 1",
+			name: "e2eNotRequiredLabel counts as P-negative 1",
 			issues: []github.Issue{
 				*github_test.Issue(whitelistUser, 2, nil, true),
 				*github_test.Issue(whitelistUser, 3, []string{"priority/P3"}, true),
@@ -350,7 +349,7 @@ func TestValidateLGTMAfterPush(t *testing.T) {
 		}
 
 		lastModifiedTime := obj.LastModifiedTime()
-		lgtmTime := obj.LabelTime("lgtm")
+		lgtmTime := obj.LabelTime(lgtmLabel)
 
 		if lastModifiedTime == nil || lgtmTime == nil {
 			t.Errorf("unexpected lastModifiedTime or lgtmTime == nil")
@@ -487,7 +486,7 @@ func TestSubmitQueue(t *testing.T) {
 			reason:          merged,
 			state:           "success",
 		},
-		// Should merge even though user not in whitelist because has ok-to-merge
+		// Should merge even though user not in whitelist because has okToMergeLabel
 		{
 			name:            "Test4",
 			pr:              ValidPR(),
@@ -528,7 +527,7 @@ func TestSubmitQueue(t *testing.T) {
 			gcsResult:       SuccessGCS(),
 			weakResults:     map[int]utils.FinishedFile{LastBuildNumber(): SuccessGCS()},
 		},
-		// Fail because the "cla: yes" label was not applied
+		// Fail because the claYesLabel label was not applied
 		{
 			name:   "Test7",
 			pr:     ValidPR(),
@@ -552,7 +551,7 @@ func TestSubmitQueue(t *testing.T) {
 			gcsResult:       SuccessGCS(),
 			weakResults:     map[int]utils.FinishedFile{LastBuildNumber(): SuccessGCS()},
 		},
-		// Fail because the user is not in the whitelist and we don't have "ok-to-merge"
+		// Fail because the user is not in the whitelist and we don't have okToMergeLabel
 		{
 			name:     "Test9",
 			pr:       ValidPR(),

--- a/mungegithub/mungers/user-lists.go
+++ b/mungegithub/mungers/user-lists.go
@@ -178,7 +178,6 @@ func (sq *SubmitQueue) addWhitelistCommand(root *cobra.Command, config *github_u
 	}
 	root.PersistentFlags().StringVar(&sq.Whitelist, "user-whitelist", "./whitelist.txt", "Path to a whitelist file that contains users to auto-merge.  Required.")
 	root.PersistentFlags().StringVar(&sq.Committers, "committers", "./committers.txt", "File in which the list of authorized committers is stored; only used if this list cannot be gotten at run time.  (Merged with whitelist; separate so that it can be auto-generated)")
-	root.Flags().StringVar(&sq.WhitelistOverride, "whitelist-override-label", "ok-to-merge", "Github label, if present on a PR it will be merged even if the author isn't in the whitelist")
 
 	root.AddCommand(genCommitters)
 }

--- a/mungegithub/submit-queue/rc.yaml
+++ b/mungegithub/submit-queue/rc.yaml
@@ -23,7 +23,7 @@ spec:
       - command:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
-        - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,submit-queue
+        - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue
         - --dry-run=true
         image: gcr.io/google_containers/submit-queue:2015-10-26-2a7f8fd
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Almost all of the bot's comments serve a purpose that can be resolved.
Once they are resolved the comments no longer need to be present and
just make review more difficult.

This PR removes the comments created by this bot. It does NOT remove
comments created by the cherrypick or the k8s-bot.

Resolves: https://github.com/kubernetes/kubernetes/issues/24007