### PR TITLE
flannel/tasks/upstart-service.yml: fix indentation

### DIFF
--- a/ansible/roles/flannel/tasks/upstart-service.yml
+++ b/ansible/roles/flannel/tasks/upstart-service.yml
@@ -3,8 +3,8 @@
 
 # On non-github-release service files must be provided by flannel package.
 - assert:
-  that:
-    - flannel_source_type == "github-release"
+    that:
+      - flannel_source_type == "github-release"
 
 - name: Create Upstart Script
   template: src=flanneld.upstart dest=/etc/init/flanneld.conf


### PR DESCRIPTION
Otherwise ansible crashes with the singular cryptic message:

> ERROR: that is not a legal parameter in an Ansible task or handler