### PR TITLE
fix indentation

### DIFF
--- a/ansible/roles/flannel/tasks/upstart-service.yml
+++ b/ansible/roles/flannel/tasks/upstart-service.yml
@@ -3,8 +3,8 @@
 
 # On non-github-release service files must be provided by flannel package.
 - assert:
-  that:
-    - flannel_source_type == "github-release"
+    that:
+      - flannel_source_type == "github-release"
 
 - name: Create Upstart Script
   template: src=flanneld.upstart dest=/etc/init/flanneld.conf


### PR DESCRIPTION
Previously on some versions of Ansible this was reported as following error:

```
ERROR: that is not a legal parameter in an Ansible task or handler
```

(however my Ansible 2.0.0.2 was silent).

/cc @stephenrlouie 