### PR TITLE
Fix broken links in fluentd-sidecar-* docs

### DIFF
--- a/logging/fluentd-sidecar-es/README.md
+++ b/logging/fluentd-sidecar-es/README.md
@@ -1,5 +1,5 @@
 # Collecting log files from within containers with Fluentd and sending them to Elasticsearch.
-*Note that this only works for clusters with an ElasticSearch service. If your cluster is logging to Google Cloud Logging instead (e.g. if you're using Container Engine), see [this guide](/contrib/logging/fluentd-sidecar-gcp/) instead.*
+*Note that this only works for clusters with an ElasticSearch service. If your cluster is logging to Google Cloud Logging instead (e.g. if you're using Container Engine), see [this guide](/logging/fluentd-sidecar-gcp/README.md) instead.*
 
 This directory contains the source files needed to make a Docker image that collects log files from arbitrary files within a container using [Fluentd](http://www.fluentd.org/) and sends them to the cluster's Elasticsearch service.
 The image is designed to be used as a sidecar container as part of a pod.


### PR DESCRIPTION
That pr fixes two broken links in the logging/fluentd-sidecar-[gcp | es]/README.md by removing a superflous "/contrib/"  in the path.

