### PR TITLE
pre-ansible tasks: avoid python to probe for Atomic

### DIFF
--- a/ansible/roles/pre-ansible/tasks/main.yml
+++ b/ansible/roles/pre-ansible/tasks/main.yml
@@ -27,14 +27,15 @@
   when: is_coreos
 
 - name: Determine if Atomic
-  stat: path=/run/ostree-booted
+  raw: "test -f /run/ostree-booted"
   register: s
   changed_when: false
+  failed_when: false
 
 - name: Set the is_atomic fact
   set_fact:
     is_atomic: true
-  when: s.stat.exists
+  when: s.rc == 0
 
 - include: fedora-dnf.yml
   when: os_version.stdout|int >= 22 and 'Fedora' in distro.stdout and is_atomic is not defined


### PR DESCRIPTION
It might not be installed yet. The following task will install it.