### PR TITLE
Fix for setting the upstart fact for ansible prior to 2.0.2

### DIFF
--- a/ansible/roles/flannel/tasks/client.yml
+++ b/ansible/roles/flannel/tasks/client.yml
@@ -13,8 +13,12 @@
         state: latest
   when: not is_atomic and flannel_source_type != "github-release"
 
+- set_fact: 
+    flannel_use_upstart: false
+
 - set_fact:
-    flannel_use_upstart: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 15 }}"
+    flannel_use_upstart: true
+  when:  "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 15 }}"
 
 - name: Install Flannel with github release
   include: github-release.yml


### PR DESCRIPTION
Addresses: #773
- Caused by some upstream ansible bugs around converting strings to booleans. Listed in the issue.

- Tested on CoreOS + VirtualBox + Vagrant and Centos + Virtualbox +Vagrant 