### PR TITLE
removed etcd from flannel requirements

### DIFF
--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -28,7 +28,6 @@
 
 # install flannel
 - hosts:
-    - etcd
     - masters
     - nodes
   sudo: yes


### PR DESCRIPTION
- Fixes: #763 
- Single etcd machines can now be deployed, tested and confirmed single etcd, HA etcd on CoreOS and CentOS