### PR TITLE
[ansible] Adds Support for Contiv

### DIFF
--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -44,6 +44,12 @@
   tags:
     - network-service-install
 
+# install contiv netmaster
+- hosts: masters
+  sudo: yes
+  roles:
+    - { role: contiv, contiv_role: netmaster, when: networking == 'contiv' }
+
 # install kube master services
 - hosts: masters
   sudo: yes
@@ -78,3 +84,9 @@
     - { role: opencontrail-provision, when: networking == 'opencontrail' }
   tags:
     - network-service-config
+
+# install contiv netplugin
+- hosts: nodes
+  sudo: yes
+  roles:
+    - { role: contiv, contiv_role: netplugin, when: networking == 'contiv' }

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -46,7 +46,7 @@ kube_master_api_port: 443
 # addresses do not need to be routable and must just be an unused block of space.
 kube_service_addresses: 10.254.0.0/16
 
-# Network implementation (flannel|opencontrail)
+# Network implementation (flannel|opencontrail|contiv)
 networking: flannel
 
 # External network
@@ -72,6 +72,12 @@ flannel_prefix: 12
 # will give to each node on your network.  With these defaults you should have
 # room for 4096 nodes with 254 pods per node.
 flannel_host_prefix: 24
+
+# Create a default Contiv network for providing connectivity among pods
+# networking: contiv must be set to use Contiv networking
+#contiv_default_network: true
+#contiv_default_subnet: 172.16.0.0/16
+#contiv_default_gw: 172.16.0.1
 
 # Set to false to disable logging with elasticsearch
 cluster_logging: true

--- a/ansible/roles/contiv/defaults/main.yaml
+++ b/ansible/roles/contiv/defaults/main.yaml
@@ -1,0 +1,68 @@
+# The version of Contiv binaries to use
+contiv_version: v0.1-04-11-2016.17-31-22.UTC
+
+# TCP port that Netmaster listens for network connections
+netmaster_port: 9999
+
+# TCP port that Netplugin listens for network connections
+netplugin_port: 6640
+
+# IP address of the interface used for control communication within the cluster
+# It needs to be reachable from all nodes in the cluster.
+netplugin_ctrl_ip: "{{ hostvars[inventory_hostname]['ansible_' + netplugin_interface].ipv4.address }}"
+
+# IP used to terminate vxlan tunnels
+netplugin_vtep_ip: "{{ hostvars[inventory_hostname]['ansible_' + netplugin_interface].ipv4.address }}"
+
+# Interface used by Netplugin for inter-host traffic when encap_mode is vlan.
+# The interface must support 802.1Q trunking.
+netplugin_interface: "{{ ansible_default_ipv4.interface }}"
+
+# Interface used to bind Netmaster service
+nemaster_interface: "{{ ansible_default_ipv4.interface }}"
+
+# Path to the contiv binaries
+bin_dir: /usr/bin
+
+# Path to the contivk8s cni binary
+cni_bin_dir: /opt/cni/bin
+
+# Contiv config directory
+contiv_config_dir: /opt/contiv/config
+
+# Directory to store downloaded Contiv releases
+contiv_releases_directory: /opt/contiv
+contiv_current_release_directory: "{{ contiv_releases_directory }}/{{ contiv_version }}"
+
+#The default url to download the Contiv tar's from
+contiv_download_url_base: "https://github.com/contiv/netplugin/releases/download"
+contiv_download_url: "{{ contiv_download_url_base }}/{{ contiv_version }}/netplugin-{{ contiv_version }}.tar.bz2"
+
+# This is where kubelet looks for plugin files
+kube_plugin_dir: /usr/libexec/kubernetes/kubelet-plugins/net/exec
+
+# Specifies routed mode vs bridged mode for networking (bridge | routing)
+# if you are using an external router for all routing, you should select bridge here
+netplugin_fwd_mode: routing
+
+# Contiv fabric mode aci|default
+contiv_fabric_mode: default
+
+# Encapsulation type vlan|vxlan to use for instantiating container networks
+contiv_encap_mode: vxlan
+
+# Backend used by Netplugin for instantiating container networks
+netplugin_driver: ovs
+
+# Create a default Contiv network for use by pods
+contiv_default_network: false
+
+# The following are aci specific parameters when contiv_fabric_mode: aci is set.
+# Otherwise, you can ignore these.
+apic_url: ""
+apic_username: ""
+apic_password: ""
+apic_leaf_nodes: ""
+apic_phys_dom: ""
+apic_contracts_unrestricted_mode: no
+apic_epg_bridge_domain: not_specified

--- a/ansible/roles/contiv/files/contiv_cni.conf
+++ b/ansible/roles/contiv/files/contiv_cni.conf
@@ -1,0 +1,5 @@
+{
+  "cniVersion": "0.1.0",
+  "name": "contiv-poc",
+  "type": "contivk8s"
+}

--- a/ansible/roles/contiv/files/netmaster.env
+++ b/ansible/roles/contiv/files/netmaster.env
@@ -1,0 +1,1 @@
+NETMASTER_ARGS="--cluster-mode=kubernetes"

--- a/ansible/roles/contiv/handlers/main.yml
+++ b/ansible/roles/contiv/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+- name: reload systemd
+  command: systemctl --system daemon-reload
+
+- name: restart netmaster
+  service: name=netmaster state=restarted
+  when: netmaster_started.changed == false
+
+- name: restart netplugin
+  service: name=netplugin state=restarted
+  when: netplugin_started.changed == false
+
+- name: restart kubelet
+  service: name=kubelet state=restarted
+
+- name: Save iptables rules
+  command: service iptables save

--- a/ansible/roles/contiv/meta/main.yml
+++ b/ansible/roles/contiv/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+    - { role: etcd }
+    - { role: kubernetes }

--- a/ansible/roles/contiv/tasks/aci.yml
+++ b/ansible/roles/contiv/tasks/aci.yml
@@ -1,0 +1,22 @@
+- name: ACI | Check aci-gw container image
+  shell: docker inspect contiv/aci-gw
+  register: docker_aci_inspect_result
+  ignore_errors: yes
+
+- name: ACI | Pull aci-gw container
+  shell: docker pull contiv/aci-gw
+  when: "'No such image' in docker_aci_inspect_result.stderr"
+
+- name: ACI | Copy shell script used by aci-gw service
+  template: src=aci_gw.j2 dest="{{ bin_dir }}/aci_gw.sh" mode=u=rwx,g=rx,o=rx
+
+- name: ACI | Copy systemd units for aci-gw
+  template: src=aci-gw.service dest=/etc/systemd/system/aci-gw.service
+  notify: reload systemd
+
+- name: ACI | Enable aci-gw service
+  service: name=aci-gw enabled=yes
+
+- name: ACI | Start aci-gw service
+  service: name=aci-gw state=started
+  register: aci-gw_started

--- a/ansible/roles/contiv/tasks/default_network.yml
+++ b/ansible/roles/contiv/tasks/default_network.yml
@@ -1,0 +1,11 @@
+# Required until the following PR is merged:
+# https://github.com/contiv/netplugin/pull/325
+- name: Contiv | wait for netmaster
+  pause: seconds=10
+
+- name: Contiv | Delete default network
+  raw: netctl net delete default-net
+  ignore_errors: yes
+
+- name: Contiv | Configure network
+  raw: netctl net create default-net --subnet={{contiv_default_subnet}} --gateway={{contiv_default_gw}}

--- a/ansible/roles/contiv/tasks/download_bins.yml
+++ b/ansible/roles/contiv/tasks/download_bins.yml
@@ -1,0 +1,19 @@
+- name: Download Bins | Create directory for current Contiv release
+  file: path={{ contiv_current_release_directory }} state=directory
+
+- name: Download Bins | Download Contiv tar file
+  get_url:
+    url: "{{ contiv_download_url }}"
+    dest: "{{ contiv_current_release_directory }}"
+    mode: 0755
+    validate_certs: False
+  environment:
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
+
+- name: Download Bins | Extract Contiv tar file
+  unarchive:
+    src: "{{ contiv_current_release_directory }}/netplugin-{{ contiv_version }}.tar.bz2"
+    dest: "{{ contiv_current_release_directory }}"
+    copy: no

--- a/ansible/roles/contiv/tasks/main.yml
+++ b/ansible/roles/contiv/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: Ensure bin_dir exists
+  file: path={{ bin_dir }} recurse=yes state=directory
+
+- include: download_bins.yml
+
+- include: netmaster.yml
+  when: contiv_role == "netmaster"
+
+- include: netplugin.yml
+  when: contiv_role == "netplugin"

--- a/ansible/roles/contiv/tasks/netmaster.yml
+++ b/ansible/roles/contiv/tasks/netmaster.yml
@@ -1,0 +1,52 @@
+- include: netmaster_firewalld.yml
+  when: has_firewalld
+
+- include: netmaster_iptables.yml
+  when: not has_firewalld and has_iptables
+
+- name: Netmaster | Check is /etc/hosts file exists
+  stat: path=/etc/hosts
+  register: hosts
+
+- name: Netmaster | Create hosts file if it is not present
+  file: path=/etc/hosts state=touch
+  when: not hosts.stat.exists
+
+- name: Netmaster | Build hosts file
+  lineinfile:
+    dest=/etc/hosts
+    regexp=.*netmaster$
+    line="{{ hostvars[item]['ansible_' + nemaster_interface].ipv4.address }} netmaster"
+    state=present
+  when: hostvars[item]['ansible_' + nemaster_interface].ipv4.address is defined
+  with_items: groups['masters']
+
+- name: Netmaster | Create netmaster symlinks
+  file:
+    src: "{{ contiv_current_release_directory }}/{{ item }}"
+    dest: "{{ bin_dir }}/{{ item }}"
+    state: link
+  with_items:
+    - netmaster
+    - netctl
+
+- name: Netmaster | Copy environment file for netmaster
+  copy: src=netmaster.env dest=/etc/default/netmaster
+  notify: restart netmaster
+
+- name: Netmaster | Copy systemd units for netmaster
+  template: src=netmaster.service dest=/etc/systemd/system/netmaster.service
+  notify: reload systemd
+
+- name: Netmaster | Enable Netmaster
+  service: name=netmaster enabled=yes
+
+- name: Netmaster | Start Netmaster
+  service: name=netmaster state=started
+  register: netmaster_started
+
+- include: aci.yml
+  when: contiv_fabric_mode == "aci"
+
+- include: default_network.yml
+  when: contiv_default_network == true

--- a/ansible/roles/contiv/tasks/netmaster_firewalld.yml
+++ b/ansible/roles/contiv/tasks/netmaster_firewalld.yml
@@ -1,0 +1,10 @@
+---
+- name: Netmaster Firewalld | Open Netmaster port
+  firewalld: port={{ netmaster_port }}/tcp permanent=false state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+
+- name: Netmaster Firewalld | Save Netmaster port
+  firewalld: port={{ netmaster_port }}/tcp permanent=true state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes

--- a/ansible/roles/contiv/tasks/netmaster_iptables.yml
+++ b/ansible/roles/contiv/tasks/netmaster_iptables.yml
@@ -1,0 +1,14 @@
+---
+- name: Netmaster IPtables | Get iptables rules
+  command: iptables -L --wait
+  register: iptablesrules
+  always_run: yes
+
+- name: Netmaster IPtables | Enable iptables at boot
+  service: name=iptables enabled=yes state=started
+
+- name: Netmaster IPtables | Open Netmaster with iptables
+  command: /sbin/iptables -I INPUT 1 -p tcp --dport {{ netmaster_port }} -j ACCEPT -m comment --comment "contiv"
+  when: "'contiv' not in iptablesrules.stdout"
+  notify:
+    - Save iptables rules

--- a/ansible/roles/contiv/tasks/netplugin.yml
+++ b/ansible/roles/contiv/tasks/netplugin.yml
@@ -1,0 +1,54 @@
+- include: netplugin_firewalld.yml
+  when: has_firewalld
+
+- include: netplugin_iptables.yml
+  when: not has_firewalld and has_iptables
+
+- include: ovs.yml
+  when: netplugin_driver == "ovs"
+
+- name: Netplugin | Create Netplugin bin symlink
+  file:
+    src: "{{ contiv_current_release_directory }}/netplugin"
+    dest: "{{ bin_dir }}/netplugin"
+    state: link
+
+
+- name: Netplugin | Ensure cni_bin_dir exists
+  file: path={{ cni_bin_dir }} recurse=yes state=directory
+
+- name: Netplugin | Create CNI bin symlink
+  file:
+    src: "{{ contiv_current_release_directory }}/contivk8s"
+    dest: "{{ cni_bin_dir }}/contivk8s"
+    state: link
+
+- name: Netplugin | Ensure kube_plugin_dir exists
+  file: path={{ kube_plugin_dir }} recurse=yes state=directory
+
+- name: Netplugin | Ensure contiv_config_dir exists
+  file: path="{{ contiv_config_dir }}" recurse=yes state=directory
+
+- name: Netplugin | Copy contiv_cni.conf file
+  copy: src=contiv_cni.conf dest={{ kube_plugin_dir }}/contiv_cni.conf
+  notify: restart kubelet
+
+- name: Netplugin | Setup contiv.json config for the cni plugin
+  template: src=contiv.cfg.j2 dest="{{ contiv_config_dir }}/contiv.json"
+  notify: restart netplugin
+
+- name: Netplugin | Copy environment file for netplugin
+  template: src=netplugin.j2 dest=/etc/default/netplugin mode=0644
+  notify: restart netplugin
+
+- name: Netplugin | Copy systemd unit for netplugin
+  template: src=netplugin.service dest=/etc/systemd/system/netplugin.service
+  notify: reload systemd
+
+- name: Netplugin | Enable Netplugin
+  service: name=netplugin enabled=yes
+
+- name: Netplugin | Start Netplugin
+  service: name=netplugin state=started
+  register: netplugin_started
+  notify: restart kubelet

--- a/ansible/roles/contiv/tasks/netplugin_firewalld.yml
+++ b/ansible/roles/contiv/tasks/netplugin_firewalld.yml
@@ -1,0 +1,22 @@
+---
+- name: Netplugin Firewalld | Open Netplugin port
+  firewalld: port={{ netplugin_port }}/tcp permanent=false state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+
+- name: Netplugin Firewalld | Save Netplugin port
+  firewalld: port={{ netplugin_port }}/tcp permanent=true state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+
+- name: Netplugin Firewalld | Open vxlan port
+  firewalld: port=8472/udp permanent=false state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+  when: contiv_encap_mode == "vxlan"
+
+- name: Netplugin Firewalld | Save firewalld vxlan port for flanneld
+  firewalld: port=8472/udp permanent=true state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+  when: contiv_encap_mode == "vxlan"

--- a/ansible/roles/contiv/tasks/netplugin_iptables.yml
+++ b/ansible/roles/contiv/tasks/netplugin_iptables.yml
@@ -1,0 +1,18 @@
+---
+- name: Netplugin IPtables | Get iptables rules
+  command: iptables -L --wait
+  register: iptablesrules
+  always_run: yes
+
+- name: Netplugin IPtables | Enable iptables at boot
+  service: name=iptables enabled=yes state=started
+
+- name: Netplugin IPtables | Open Netmaster with iptables
+  command: /sbin/iptables -I INPUT 1 -p tcp --dport {{ netmaster_port }} -j ACCEPT -m comment --comment "contiv"
+  when: "'contiv' not in iptablesrules.stdout"
+  notify:
+    - Save iptables rules
+
+- name: Netplugin IPtables | Open vxlan port with iptables
+  command: /sbin/iptables -I INPUT 1 -p udp --dport 8472 -j ACCEPT -m comment --comment "vxlan"
+  when: contiv_encap_mode == "vxlan"

--- a/ansible/roles/contiv/tasks/ovs.yml
+++ b/ansible/roles/contiv/tasks/ovs.yml
@@ -1,0 +1,17 @@
+- include: packageManagerInstall.yml
+  when: source_type == "packageManager"
+  tags:
+    - binary-update
+
+- name: OVS | Enable ovs
+  service: name=openvswitch enabled=yes
+
+- name: OVS | Start ovs
+  service: name=openvswitch state=started
+  register: ovs_started
+
+- name: OVS | Configure ovs
+  shell: "ovs-vsctl set-manager {{ item }}"
+  with_items:
+    - "tcp:127.0.0.1:6640"
+    - "ptcp:6640"

--- a/ansible/roles/contiv/tasks/packageManagerInstall.yml
+++ b/ansible/roles/contiv/tasks/packageManagerInstall.yml
@@ -1,0 +1,12 @@
+---
+- name: Package Manager | Init the did_install fact
+  set_fact:
+    did_install: false
+
+- include: pkgMgrInstallers/centos-install.yml
+  when: ansible_distribution == "CentOS" and not is_atomic
+
+- name: Package Manager | Set fact saying we did CentOS package install
+  set_fact:
+    did_install: true
+  when: ansible_distribution == "CentOS"

--- a/ansible/roles/contiv/tasks/pkgMgrInstallers/centos-install.yml
+++ b/ansible/roles/contiv/tasks/pkgMgrInstallers/centos-install.yml
@@ -1,0 +1,33 @@
+---
+- name: PkgMgr CentOS | Install net-tools pkg for route
+  yum:
+    pkg=net-tools
+    state=latest
+
+- name: PkgMgr CentOS | Get openstack kilo rpm
+  get_url:
+    url: https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm
+    dest: /tmp/rdo-release-kilo-1.noarch.rpm
+    validate_certs: False
+  environment:
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
+  tags:
+       - ovs_install
+
+- name: PkgMgr CentOS | Install openstack kilo rpm
+  yum: name=/tmp/rdo-release-kilo-1.noarch.rpm state=present
+  tags:
+       - ovs_install
+
+- name: PkgMgr CentOS | Install ovs
+  yum:
+    pkg=openvswitch
+    state=latest
+  environment:
+    http_proxy: "{{ http_proxy|default('') }}"
+    https_proxy: "{{ https_proxy|default('') }}"
+    no_proxy: "{{ no_proxy|default('') }}"
+  tags:
+       - ovs_install

--- a/ansible/roles/contiv/templates/aci-gw.service
+++ b/ansible/roles/contiv/templates/aci-gw.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Contiv ACI gw
+After=auditd.service systemd-user-sessions.service time-sync.target docker.service
+
+[Service]
+ExecStart={{ bin_dir }}/aci_gw.sh start
+ExecStop={{ bin_dir }}/aci_gw.sh stop
+KillMode=control-group
+Restart=on-failure
+RestartSec=10

--- a/ansible/roles/contiv/templates/aci_gw.j2
+++ b/ansible/roles/contiv/templates/aci_gw.j2
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+usage="$0 start"
+if [ $# -ne 1 ]; then
+    echo USAGE: $usage
+    exit 1
+fi
+
+case $1 in
+start)
+    set -e
+
+    docker run --net=host \
+    -e "APIC_URL={{ apic_url }}" \
+    -e "APIC_USERNAME={{ apic_username }}" \
+    -e "APIC_PASSWORD={{ apic_password }}" \
+    -e "APIC_LEAF_NODE={{ apic_leaf_nodes }}" \
+    -e "APIC_PHYS_DOMAIN={{ apic_phys_dom }}" \
+    -e "APIC_EPG_BRIDGE_DOMAIN={{ apic_epg_bridge_domain }}" \
+    -e "APIC_CONTRACTS_UNRESTRICTED_MODE={{ apic_contracts_unrestricted_mode }}" \
+    --name=contiv-aci-gw \
+    contiv/aci-gw
+    ;;
+
+stop)
+    # don't stop on error
+    docker stop contiv-aci-gw
+    docker rm contiv-aci-gw
+    ;;
+
+*)
+    echo USAGE: $usage
+    exit 1
+    ;;
+esac

--- a/ansible/roles/contiv/templates/contiv.cfg.j2
+++ b/ansible/roles/contiv/templates/contiv.cfg.j2
@@ -1,0 +1,6 @@
+{
+  "K8S_API_SERVER": "https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}",
+  "K8S_CA": "{{ kube_cert_dir }}/ca.crt",
+  "K8S_KEY": "{{ kube_cert_dir }}/kubecfg.key",
+  "K8S_CERT": "{{ kube_cert_dir }}/kubecfg.crt"
+}

--- a/ansible/roles/contiv/templates/netmaster.service
+++ b/ansible/roles/contiv/templates/netmaster.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Netmaster
+After=auditd.service systemd-user-sessions.service etcd.service
+
+[Service]
+EnvironmentFile=/etc/default/netmaster
+ExecStart={{ bin_dir }}/netmaster $NETMASTER_ARGS
+KillMode=control-group

--- a/ansible/roles/contiv/templates/netplugin.j2
+++ b/ansible/roles/contiv/templates/netplugin.j2
@@ -1,0 +1,6 @@
+{% if contiv_encap_mode == "vlan" %}
+NETPLUGIN_ARGS='-vlan-if {{ netplugin_interface }} -ctrl-ip {{ netplugin_ctrl_ip }} -fwd-mode {{netplugin_fwd_mode}} -plugin-mode kubernetes'
+{% endif %}
+{% if contiv_encap_mode == "vxlan" %}
+NETPLUGIN_ARGS='-vtep-ip {{ netplugin_vtep_ip }} -ctrl-ip {{ netplugin_ctrl_ip }} -fwd-mode {{netplugin_fwd_mode}} -plugin-mode kubernetes'
+{% endif %}

--- a/ansible/roles/contiv/templates/netplugin.service
+++ b/ansible/roles/contiv/templates/netplugin.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Netplugin
+After=auditd.service systemd-user-sessions.service etcd.service
+
+[Service]
+EnvironmentFile=/etc/default/netplugin
+ExecStart={{ bin_dir }}/netplugin $NETPLUGIN_ARGS
+KillMode=control-group

--- a/ansible/roles/etcd/defaults/main.yaml
+++ b/ansible/roles/etcd/defaults/main.yaml
@@ -4,6 +4,10 @@ etcd_source_type: package
 
 etcd_client_port: 2379
 etcd_peer_port: 2380
+# Remove etcd_client_legacy_port & etcd_peer_legacy_port
+# when https://github.com/contiv/netplugin/issues/323 is fixed
+etcd_client_legacy_port: 4001
+etcd_peer_legacy_port: 7001
 etcd_peers_group: etcd
 etcd_url_scheme: http
 etcd_peer_url_scheme: http
@@ -30,5 +34,11 @@ etcd_initial_advertise_peer_urls: "{{ etcd_peer_url_scheme }}://{{ etcd_machine_
 etcd_listen_peer_urls: "{{ etcd_peer_url_scheme }}://0.0.0.0:{{ etcd_peer_port }}"
 etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ etcd_machine_address }}:{{ etcd_client_port }}"
 etcd_listen_client_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port }}"
+
+# Remove etcd_listen_peer_legacy_urls, etcd_advertise_client_legacy_urls
+# and etcd_listen_client_legacy_url when https://github.com/contiv/netplugin/issues/323 is fixed
+etcd_listen_peer_legacy_urls: "{{ etcd_peer_url_scheme }}://0.0.0.0:{{ etcd_peer_port }},{{ etcd_peer_url_scheme }}://0.0.0.0:{{ etcd_peer_legacy_port }}"
+etcd_advertise_client_legacy_urls: "{{ etcd_url_scheme }}://{{ etcd_machine_address }}:{{ etcd_client_port }},{{ etcd_url_scheme }}://{{ etcd_machine_address }}:{{ etcd_client_legacy_port }}"
+etcd_listen_client_legacy_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port }},{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_legacy_port }}"
 
 etcd_data_dir: /var/lib/etcd

--- a/ansible/roles/etcd/tasks/firewalld.yml
+++ b/ansible/roles/etcd/tasks/firewalld.yml
@@ -14,3 +14,21 @@
   with_items:
     - "{{ etcd_client_port }}"
     - "{{ etcd_peer_port }}"
+
+- name: Open firewalld port for etcd legacy ports
+  firewalld: port={{ item }}/tcp permanent=false state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+  when: networking == contiv
+  with_items:
+    - "{{ etcd_client_legacy_port }}"
+    - "{{ etcd_peer_legacy_port }}"
+
+- name: Save firewalld port for etcd legacy ports
+  firewalld: port={{ item }}/tcp permanent=true state=enabled
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+  when: networking == contiv
+  with_items:
+    - "{{ etcd_client_legacy_port }}"
+    - "{{ etcd_peer_legacy_port }}"

--- a/ansible/roles/etcd/tasks/iptables.yml
+++ b/ansible/roles/etcd/tasks/iptables.yml
@@ -15,3 +15,12 @@
   with_items:
     - "{{ etcd_client_port }}"
     - "{{ etcd_peer_port }}"
+
+- name: Open etcd client legacy port with iptables
+  command: /sbin/iptables -I INPUT 1 -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "etcd-legacy"
+  when: "'etcd-legacy' not in iptablesrules.stdout and networking == contiv"
+  notify:
+    - Save iptables rules
+  with_items:
+    - "{{ etcd_client_legacy_port }}"
+    - "{{ etcd_peer_legacy_port }}"

--- a/ansible/roles/etcd/templates/etcd.conf.j2
+++ b/ansible/roles/etcd/templates/etcd.conf.j2
@@ -5,9 +5,8 @@
 {%- endfor -%}
 {% endmacro -%}
 
-{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 1 %}
+{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 0 %}
 ETCD_NAME={{ ansible_hostname }}
-ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
 {% else %}
 ETCD_NAME=default
 {% endif %}
@@ -15,12 +14,11 @@ ETCD_DATA_DIR={{ etcd_data_dir }}
 #ETCD_SNAPSHOT_COUNTER="10000"
 #ETCD_HEARTBEAT_INTERVAL="100"
 #ETCD_ELECTION_TIMEOUT="1000"
-ETCD_LISTEN_CLIENT_URLS="{{ etcd_listen_client_urls }}"
 #ETCD_MAX_SNAPSHOTS="5"
 #ETCD_MAX_WALS="5"
 #ETCD_CORS=""
 
-{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 1 %}
+{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 0 %}
 #[cluster]
 ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
 ETCD_INITIAL_CLUSTER={{ initial_cluster() }}
@@ -31,10 +29,27 @@ ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
 #ETCD_DISCOVERY_FALLBACK="proxy"
 #ETCD_DISCOVERY_PROXY=""
 {% endif %}
+
+{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 0 and networking == "contiv" %}
+ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_legacy_urls }}
+{% else %}
+ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
+{% endif %}
+
+{% if networking == "contiv" %}
+ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_legacy_urls }}
+ETCD_LISTEN_CLIENT_URLS={{ etcd_listen_client_legacy_urls }}
+{% else %}
 ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
+ETCD_LISTEN_CLIENT_URLS="{{ etcd_listen_client_urls }}"
+{% endif %}
 
 #[proxy]
-#ETCD_PROXY="off"
+{% if networking == "contiv" and inventory_hostname in groups['nodes'] %}
+ETCD_PROXY="on"
+{% else %}
+ETCD_PROXY="off"
+{% endif %}
 
 #[security]
 {% if etcd_url_scheme == 'https' -%}

--- a/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
@@ -13,6 +13,7 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/cluster-monitoring/influxdb/{{ item }}
     dest="{{ local_temp_addon_dir }}/cluster-monitoring/{{ item }}.j2"
     force=yes
+    validate_certs=False
   sudo: no
   with_items:
     - grafana-service.yaml

--- a/ansible/roles/kubernetes-addons/tasks/dns.yml
+++ b/ansible/roles/kubernetes-addons/tasks/dns.yml
@@ -13,6 +13,7 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/dns/skydns-rc.yaml.in
     dest="{{ local_temp_addon_dir }}/dns/skydns-rc.yaml.j2"
     force=yes
+    validate_certs=False
   sudo: no
   changed_when: false
 
@@ -38,6 +39,7 @@
     url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/dns/skydns-svc.yaml.in
     dest="{{ local_temp_addon_dir }}/dns/skydns-svc.yaml.j2"
     force=yes
+    validate_certs=False
   sudo: no
   changed_when: false
 

--- a/ansible/roles/kubernetes/tasks/secrets.yml
+++ b/ansible/roles/kubernetes/tasks/secrets.yml
@@ -39,8 +39,36 @@
   set_fact:
     kube_ca_cert: "{{ ca_cert.content|b64decode }}"
 
-- name: Place CA certificate everywhere
+- name: Place CA certificate and kube_cfg credentials everywhere
   copy: content="{{ kube_ca_cert }}" dest="{{ kube_cert_dir }}/ca.crt"
+
+- name: Read back the kubecfg key
+  slurp:
+    src: "{{ kube_cert_dir }}/kubecfg.key"
+  register: api_key
+  run_once: true
+  delegate_to: "{{ groups['masters'][0] }}"
+
+- name: Register the cfg key as a fact so it can be used later
+  set_fact:
+    kube_api_key: "{{ api_key.content|b64decode }}"
+
+- name: Place CA certificate and kube_cfg credentials everywhere
+  copy: content="{{ kube_api_key }}" dest="{{ kube_cert_dir }}/kubecfg.key"
+
+- name: Read back the kubecfg cert
+  slurp:
+    src: "{{ kube_cert_dir }}/kubecfg.crt"
+  register: api_crt
+  run_once: true
+  delegate_to: "{{ groups['masters'][0] }}"
+
+- name: Register the cfg cert as a fact so it can be used later
+  set_fact:
+    kube_api_crt: "{{ api_crt.content|b64decode }}"
+
+- name: Place CA certificate and kube_cfg credentials everywhere
+  copy: content="{{ kube_api_crt }}" dest="{{ kube_cert_dir }}/kubecfg.crt"
   notify:
     - restart daemons
 

--- a/ansible/roles/node/templates/kubelet.j2
+++ b/ansible/roles/node/templates/kubelet.j2
@@ -21,5 +21,8 @@ KUBELET_API_SERVER="--api-servers=https://{{ groups['masters'][0] }}:{{ kube_mas
 {% if networking == "opencontrail" -%}
 {{ kubelet_options.append('--network-plugin=opencontrail')|default('', true) -}}
 {% endif -%}
+{% if networking == "contiv" -%}
+{{ kubelet_options.append('--network-plugin=cni')|default('', true) -}}
+{% endif -%}
 
 KUBELET_ARGS="--kubeconfig={{ kube_config_dir }}/kubelet.kubeconfig --config={{ kube_manifest_dir }} {{ kubelet_options|join(' ') }}"

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -170,6 +170,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.extra_vars = {
         flannel_opts: "--iface=eth1",
         etcd_interface: "eth1",
+        netplugin_interface: "eth1",
+        netmaster_interface: "eth1",
         kube_apiserver_bind_address: master_ip,
       }
     end


### PR DESCRIPTION
Supercedes https://github.com/kubernetes/contrib/pull/625

This PR brings in ansible changes needed to setup Kubernetes
with Contiv networking as outlined in:

https://github.com/kubernetes/contrib/issues/577

Change Summary:

1) Added the contiv role that holds all contiv specific config code.
2) Expose minimal contiv configuration options in group_vars/all
3) Updates ansible/cluster.yml to expose contiv role.
4) Updates etcd to support legacy (:4001/:7001) ports and adds
   proxy support.
5) Added missing "validate_certs: False" for a couple of addon
   file fetches.