### PR TITLE
Proposed change to https load balancing template

### DIFF
--- a/service-loadbalancer/README.md
+++ b/service-loadbalancer/README.md
@@ -124,7 +124,6 @@ metadata:
   name: myservice
   annotations:
     serviceloadbalancer/lb.sslTerm: "true"
-    serviceloadbalancer/lb.aclMatch: "-i /t1 /t2"
   labels:
 ```
 

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -90,7 +90,9 @@ frontend httpsfrontend
     rspadd  Strict-Transport-Security:\ max-age=15768000
 
 {{range $i, $svc := .services.httpsTerm}}
-    acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
+    {{ if $svc.AclMatch }} acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
+    {{else}} acl url_acl_{{$svc.Name}} path_beg {{$svc.Name}}
+    {{ end }}
     {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
     use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
     {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
@@ -168,7 +170,7 @@ backend {{$svc.Name}}
     balance {{$svc.Algorithm}}
 
     #Rewrite the request back to root from the url that is used for the frontend.
-    reqrep ^([^\ :]*)\ /{{$svc.AclMatch}}[/]?(.*) \1\ /\2
+    {{if ( not $svc.AclMatch )}} reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2 {{end}}
 
 {{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
     # create a stickiness table using client IP address as key

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -167,6 +167,9 @@ backend {{$svc.Name}}
 
     balance {{$svc.Algorithm}}
 
+    #Rewrite the request back to root from the url that is used for the frontend.
+    reqrep ^([^\ :]*)\ /{{$svc.AclMatch}}[/]?(.*) \1\ /\2
+
 {{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
     # create a stickiness table using client IP address as key
     # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -169,8 +169,11 @@ backend {{$svc.Name}}
 
     balance {{$svc.Algorithm}}
 
+
+    {{if ( not $svc.AclMatch )}}
     #Rewrite the request back to root from the url that is used for the frontend.
-    {{if ( not $svc.AclMatch )}} reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2 {{end}}
+    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
+    {{end}}
 
 {{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
     # create a stickiness table using client IP address as key


### PR DESCRIPTION
This change should make https load balancing act just like http services with only the sslTerm annotation set. It still retains the option to specify an AclMatch which will not rewrite the url as we can't guarantee that the acl will be a valid path.

