### PR TITLE
SSL termination URL rewritting changes

### DIFF
--- a/service-loadbalancer/README.md
+++ b/service-loadbalancer/README.md
@@ -116,8 +116,7 @@ A couple of points to note:
 - You need to take care of ensuring there is no collision between these service ports on the node.
 
 #### SSL Termination
-
-- Annotate a service
+To terminate SSL for a service you just need to annotate the service with ``` serviceloadbalancer/lb.sslTerm: "true" ``` as seen below. This will cause your service to be served behind /{service-name} or /{service-name}:{port} if not running on port 80. This mimics the standard http functionality.
 
 ```yaml
 metadata:
@@ -146,13 +145,14 @@ metadata:
           hostPort: 1936
           protocol: TCP
         resources: {}
-        volumes:
-        - name: secret-volume
-          secret:
-            secretName: my-secret
         volumeMounts:
         - mountPath: "/ssl"
           name: secret-volume
+    volumes:
+    - name: secret-volume
+      secret:
+        secretName: my-secret
+       
 ```
 
 - Add your SSL configuration to loadbalancer pod
@@ -164,6 +164,17 @@ metadata:
       - --namespace=default
 ```
 
+##### Custom ACL
+ - Adding the aclMatch annotation will allow you to serve the service on a specific path although URLs will not be rewritten back to root. The following will cause your service to be available at /test and your web service will be passed the url with /test on the front.
+ 
+```yaml
+ metadata:
+   name: myservice
+   annotations:
+     serviceloadbalancer/lb.sslTerm: "true"
+     serviceloadbalancer/lb.aclMatch: "-i /test"
+   labels:
+```
 #### TCP
 
 ```yaml

--- a/service-loadbalancer/README.md
+++ b/service-loadbalancer/README.md
@@ -124,7 +124,6 @@ metadata:
   name: myservice
   annotations:
     serviceloadbalancer/lb.sslTerm: "true"
-    serviceloadbalancer/lb.aclMatch: "-i /t1 /t2"
   labels:
 ```
 

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -91,9 +91,9 @@ frontend httpsfrontend
 
 {{range $i, $svc := .services.httpsTerm}}
     {{ if $svc.AclMatch }} acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
-    {{else}} acl url_acl_{{$svc.Name}} path_beg {{$svc.Name}}
+    {{else}} acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
     {{ end }}
-    acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
+    
     {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
     use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
     {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -90,6 +90,9 @@ frontend httpsfrontend
     rspadd  Strict-Transport-Security:\ max-age=15768000
 
 {{range $i, $svc := .services.httpsTerm}}
+    {{ if $svc.AclMatch }} acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
+    {{else}} acl url_acl_{{$svc.Name}} path_beg {{$svc.Name}}
+    {{ end }}
     acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
     {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
     use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
@@ -166,6 +169,8 @@ backend {{$svc.Name}}
     errorfile 504 /etc/haproxy/errors/504.http
 
     balance {{$svc.Algorithm}}
+
+    {{if ( not $svc.AclMatch )}} reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2 {{end}}
 
 {{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
     # create a stickiness table using client IP address as key

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -170,7 +170,10 @@ backend {{$svc.Name}}
 
     balance {{$svc.Algorithm}}
 
-    {{if ( not $svc.AclMatch )}} reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2 {{end}}
+    {{if ( not $svc.AclMatch )}}
+    #Rewrite the request back to root from the url that is used for the frontend.
+    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
+    {{end}}
 
 {{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
     # create a stickiness table using client IP address as key


### PR DESCRIPTION
These changes will allow ssl termination to work without an AclMatch and it will act just like the http services. If the user wants they can specify an AclMatch which will make the load balancer act the same as it does currently.