### PR TITLE
Move task to copy kube-gen-token script

### DIFF
--- a/ansible/roles/kubernetes/tasks/gen_tokens.yml
+++ b/ansible/roles/kubernetes/tasks/gen_tokens.yml
@@ -1,10 +1,4 @@
 ---
-- name: Copy the token gen script
-  copy:
-    src=kube-gen-token.sh
-    dest={{ kube_script_dir }}
-    mode=u+x
-
 - name: Generate tokens for master components
   command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item[0] }}-{{ item[1] }}"
   environment:

--- a/ansible/roles/kubernetes/tasks/secrets.yml
+++ b/ansible/roles/kubernetes/tasks/secrets.yml
@@ -44,5 +44,11 @@
   notify:
     - restart daemons
 
+- name: Copy the token gen script
+  copy:
+    src=kube-gen-token.sh
+    dest={{ kube_script_dir }}
+    mode=u+x
+
 - include: gen_tokens.yml
   when: inventory_hostname == groups['masters'][0]


### PR DESCRIPTION
Task to copy kube-gen-token script is in secrets.yml.
However, secrets.yml is called only the first node of master.

The `kube-gen-token.sh` is also used in main.yml of kubernetes-addons.
Fail to deploy HA Cluster, in the second or later master node that does not have a script.