### PR TITLE
Perfdash: Add version support in perfdash

### DIFF
--- a/perfdash/Godeps/Godeps.json
+++ b/perfdash/Godeps/Godeps.json
@@ -16,8 +16,8 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e/perftype",
-			"Comment": "v1.3.0-alpha.0-427-gdac367f",
-			"Rev": "dac367f5eaeb9f703d6658f09fb6255a6df20e52"
+			"Comment": "v1.3.0-alpha.2-402-g2cd65f7",
+			"Rev": "2cd65f7153e78e270ddb23e962e5e4ab6608a33a"
 		}
 	]
 }

--- a/perfdash/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/perftype/perftype.go
+++ b/perfdash/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/perftype/perftype.go
@@ -36,9 +36,16 @@ type DataItem struct {
 
 // PerfData contains all data items generated in current test.
 type PerfData struct {
+	// Version is the version of the metrics. The metrics consumer could use the version
+	// to detect metrics version change and decide what version to support.
+	Version   string     `json:"version"`
 	DataItems []DataItem `json:"dataItems"`
 }
 
 // PerfResultTag is the prefix of generated perfdata. Analyzing tools can find the perf result
 // with this tag.
 const PerfResultTag = "[Result:Performance]"
+
+// PerfResultEnd is the end of generated perfdata. Analyzing tools can find the end of the perf
+// result with this tag.
+const PerfResultEnd = "[Finish:Performance]"

--- a/perfdash/downloader.go
+++ b/perfdash/downloader.go
@@ -31,8 +31,9 @@ type Downloader interface {
 
 // BuildData contains job name and a map from build number to perf data
 type BuildData struct {
-	Builds map[string][]perftype.DataItem `json:"builds"`
-	Job    string                         `json:"job"`
+	Builds  map[string][]perftype.DataItem `json:"builds"`
+	Job     string                         `json:"job"`
+	Version string                         `json:"version"`
 }
 
 // TestToBuildData is a map from test name to BuildData


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/pull/24542

This PR makes the perfdash aware of the metrics version.
Now, perfdash will only show the result with the newest version.

@gmarek Could you help me take a look? The change is minor. :)

/cc @yujuhong @vishh 
