### PR TITLE
Remove single inner quotes for insecure registry option

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -60,7 +60,7 @@
     - restart docker
 
 - name: Add any insecure registrys to docker config
-  lineinfile: dest={{ docker_config_dir }}/docker regexp=^INSECURE_REGISTRY= line=INSECURE_REGISTRY="'{% for reg in insecure_registrys %}--insecure-registry={{ reg }} {% endfor %}'"
+  lineinfile: dest={{ docker_config_dir }}/docker regexp=^INSECURE_REGISTRY= line=INSECURE_REGISTRY="{% for reg in insecure_registrys %}--insecure-registry={{ reg }} {% endfor %}"
   when: insecure_registrys is defined and insecure_registrys > 0
   notify:
     - restart docker


### PR DESCRIPTION
Remove single inner quotes which prevented docker from starting in CentOS when using _insecure registry_.

When the following entry is generated in CentOS (/etc/sysconfig/docker), the Docker service won't start and complain about misconfiguration. When the single inner quotes are removed everything works fine.

Docker do not start --> INSECURE_REGISTRY="'--insecure-registry=gcr.io '"

Docker start Okay --> INSECURE_REGISTRY="--insecure-registry=gcr.io "

