### PR TITLE
Remove old jenkins comments

### DIFF
--- a/mungegithub/Makefile
+++ b/mungegithub/Makefile
@@ -19,10 +19,10 @@ READONLY ?= true
 
 # just build the binary
 mungegithub:
-	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o mungegithub
+	CGO_ENABLED=0 GOOS=linux GO15VENDOREXPERIMENT=0 godep go build -a -installsuffix cgo -ldflags '-w' -o mungegithub
 
 test: mungegithub
-	CGO_ENABLED=0 GOOS=linux godep go test ./...
+	CGO_ENABLED=0 GOOS=linux GO15VENDOREXPERIMENT=0 godep go test ./...
 
 # build the container with the binary
 container: test

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -1345,6 +1345,13 @@ func (obj *MungeObject) DeleteComment(comment *github.IssueComment) error {
 		glog.Errorf("Found a comment with nil id for Issue %d", prNum)
 		return err
 	}
+	for i, c := range obj.comments {
+		if c.ID == nil || *c.ID != *comment.ID {
+			continue
+		}
+		obj.comments = append(obj.comments[:i], obj.comments[i+1:]...)
+		break
+	}
 	glog.Infof("Removing comment %d from Issue %d", *comment.ID, prNum)
 	if config.DryRun {
 		return nil

--- a/mungegithub/github/testing/github.go
+++ b/mungegithub/github/testing/github.go
@@ -40,6 +40,19 @@ func boolPtr(val bool) *bool       { return &val }
 
 func timePtr(val time.Time) *time.Time { return &val }
 
+// Comment is a helper to create a valid-ish comment for testing
+func Comment(id int, login string, createdAt time.Time, body string) github.IssueComment {
+	comment := github.IssueComment{
+		ID:        &id,
+		Body:      &body,
+		CreatedAt: &createdAt,
+		User: &github.User{
+			Login: &login,
+		},
+	}
+	return comment
+}
+
 // PullRequest returns a filled out github.PullRequest
 func PullRequest(user string, merged, mergeDetermined, mergeable bool) *github.PullRequest {
 	pr := &github.PullRequest{

--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -55,7 +55,7 @@ type BlockPath struct {
 func init() {
 	b := &BlockPath{}
 	RegisterMungerOrDie(b)
-	registerShouldDeleteCommentFunc(b.isStaleComment)
+	RegisterStaleComments(b)
 }
 
 // Name is the name usable in --pr-mungers
@@ -146,7 +146,10 @@ func (b *BlockPath) Munge(obj *github.MungeObject) {
 	}
 }
 
-func (b *BlockPath) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (b *BlockPath) isStaleComment(obj *github.MungeObject, comment githubapi.IssueComment) bool {
+	if !mergeBotComment(comment) {
+		return false
+	}
 	if *comment.Body != blockPathBody {
 		return false
 	}
@@ -155,4 +158,9 @@ func (b *BlockPath) isStaleComment(obj *github.MungeObject, comment *githubapi.I
 		glog.V(6).Infof("Found stale BlockPath comment")
 	}
 	return stale
+}
+
+// StaleComments returns a slice of stale comments
+func (b *BlockPath) StaleComments(obj *github.MungeObject, comments []githubapi.IssueComment) []githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, b.isStaleComment)
 }

--- a/mungegithub/mungers/comment-deleter-jenkins.go
+++ b/mungegithub/mungers/comment-deleter-jenkins.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"regexp"
+
+	"k8s.io/contrib/mungegithub/github"
+
+	"github.com/golang/glog"
+	githubapi "github.com/google/go-github/github"
+)
+
+const (
+	commentDeleterJenkinsName = "comment-deleter-jenkins"
+	commentRegexpStr          = `GCE e2e build/test \*\*(passed|failed)\*\* for commit [[:xdigit:]]+\.
+\* \[Build Log\]\(http://pr-test\.k8s\.io/[[:digit:]]+/kubernetes-pull-build-test-e2e-gce/[[:digit:]]+/build-log\.txt\)
+\* \[Test Artifacts\]\(https://console\.developers\.google\.com/storage/browser/kubernetes-jenkins/pr-logs/pull/[[:digit:]]+/kubernetes-pull-build-test-e2e-gce/[[:digit:]]+/artifacts/\)
+\* \[Internal Jenkins Results\]\(http://goto\.google\.com/prkubekins/job/kubernetes-pull-build-test-e2e-gce//[[:digit:]]+\)`
+)
+
+var (
+	_             = glog.Infof
+	commentRegexp = regexp.MustCompile(commentRegexpStr)
+)
+
+// CommentDeleterJenkins looks for jenkins comments which are no longer useful
+// and deletes them
+type CommentDeleterJenkins struct{}
+
+func init() {
+	c := CommentDeleterJenkins{}
+	RegisterStaleComments(c)
+}
+
+func isJenkinsTestComment(body string) bool {
+	return commentRegexp.MatchString(body)
+}
+
+// StaleComments returns a slice of comments which are stale
+func (CommentDeleterJenkins) StaleComments(obj *github.MungeObject, comments []githubapi.IssueComment) []githubapi.IssueComment {
+	out := []githubapi.IssueComment{}
+	var last *githubapi.IssueComment
+
+	for i := range comments {
+		comment := comments[i]
+		if !jenkinsBotComment(comment) {
+			continue
+		}
+
+		if !isJenkinsTestComment(*comment.Body) {
+			continue
+		}
+		if last != nil {
+			out = append(out, *last)
+		}
+		last = &comment
+	}
+	return out
+}

--- a/mungegithub/mungers/comment-deleter-jenkins_test.go
+++ b/mungegithub/mungers/comment-deleter-jenkins_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"testing"
+	"time"
+
+	githubapi "github.com/google/go-github/github"
+
+	github_test "k8s.io/contrib/mungegithub/github/testing"
+)
+
+const (
+	passComment = `GCE e2e build/test **passed** for commit 436b966bcb6c19b792b7918e59e4f50195224065.
+* [Build Log](http://pr-test.k8s.io/23958/kubernetes-pull-build-test-e2e-gce/35810/build-log.txt)
+* [Test Artifacts](https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/23958/kubernetes-pull-build-test-e2e-gce/35810/artifacts/)
+* [Internal Jenkins Results](http://goto.google.com/prkubekins/job/kubernetes-pull-build-test-e2e-gce//35810)`
+	failComment = `GCE e2e build/test **failed** for commit 436b966bcb6c19b792b7918e59e4f50195224065.
+* [Build Log](http://pr-test.k8s.io/23958/kubernetes-pull-build-test-e2e-gce/35830/build-log.txt)
+* [Test Artifacts](https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/23958/kubernetes-pull-build-test-e2e-gce/35830/artifacts/)
+* [Internal Jenkins Results](http://goto.google.com/prkubekins/job/kubernetes-pull-build-test-e2e-gce//35830)
+
+Please reference the [list of currently known flakes](https://github.com/kubernetes/kubernetes/issues?q=is:issue+label:kind/flake+is:open) when examining this failure. If you request a re-test, you must reference the issue describing the flake.`
+)
+
+func TestIsJenkinsTestComment(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		isJenkins bool
+	}{
+		{
+			name:      "success comment",
+			value:     passComment,
+			isJenkins: true,
+		},
+		{
+			name:      "fail comment",
+			value:     failComment,
+			isJenkins: true,
+		},
+		{
+			name:      "Empty string",
+			isJenkins: false,
+		},
+		{
+			name:      "Random string",
+			value:     "Bob says do it another way, ok Brendan?!",
+			isJenkins: false,
+		},
+	}
+	for testNum, test := range tests {
+		output := isJenkinsTestComment(test.value)
+		if output != test.isJenkins {
+			t.Errorf("%d:%s: expected: %v, saw: %v for %s", testNum, test.name, test.isJenkins, output, test.value)
+		}
+	}
+}
+
+func comment(id int, body string) githubapi.IssueComment {
+	return github_test.Comment(id, jenkinsBotName, time.Now(), passComment)
+}
+
+func TestJenkinsStaleComments(t *testing.T) {
+	c := CommentDeleterJenkins{}
+
+	tests := []struct {
+		name     string
+		comments []githubapi.IssueComment
+		expected []githubapi.IssueComment
+	}{
+		{
+			name: "single pass",
+			comments: []githubapi.IssueComment{
+				comment(1, passComment),
+			},
+		},
+		{
+			name: "double pass",
+			comments: []githubapi.IssueComment{
+				comment(1, passComment),
+				comment(2, passComment),
+			},
+			expected: []githubapi.IssueComment{
+				comment(1, passComment),
+			},
+		},
+		{
+			name: "pass fail pass",
+			comments: []githubapi.IssueComment{
+				comment(1, passComment),
+				comment(2, failComment),
+				comment(3, passComment),
+			},
+			expected: []githubapi.IssueComment{
+				comment(1, passComment),
+				comment(2, failComment),
+			},
+		},
+	}
+	for testNum, test := range tests {
+		out := c.StaleComments(nil, test.comments)
+		if len(out) != len(test.expected) {
+			t.Errorf("%d:%s: len(expected):%d, len(out):%d", testNum, test.name, len(test.expected), len(out))
+		}
+		for _, cexpected := range test.expected {
+			found := false
+			for _, cout := range out {
+				if *cout.ID == *cexpected.ID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("%d:%s: missing %v from output", testNum, test.name, cexpected)
+			}
+		}
+	}
+}

--- a/mungegithub/mungers/ok-to-test.go
+++ b/mungegithub/mungers/ok-to-test.go
@@ -26,14 +26,14 @@ import (
 )
 
 const (
-	okToTestBody = `@k8s-bot ok to test
-@k8s-bot test this
+	okToTestBody = `ok to test
+@` + jenkinsBotName + ` test this
 
 pr builder appears to be missing, activating due to 'lgtm' label.`
 )
 
 // OkToTestMunger looks for situations where a reviewer has LGTM'd a PR, but it
-// isn't ok to test by the k8s-bot, and adds an 'ok to test' comment to the PR.
+// isn't ok to test by the testBot, and adds an 'ok to test' comment to the PR.
 type OkToTestMunger struct{}
 
 func init() {

--- a/mungegithub/mungers/path_label.go
+++ b/mungegithub/mungers/path_label.go
@@ -36,7 +36,8 @@ var (
 )
 
 const (
-	botName = "k8s-merge-robot"
+	botName        = "k8s-merge-robot"
+	jenkinsBotName = "k8s-bot"
 )
 
 type labelMap struct {

--- a/mungegithub/mungers/rebuild.go
+++ b/mungegithub/mungers/rebuild.go
@@ -40,13 +40,14 @@ const (
 	issueURLRe    = "(?:https?://)?github.com/kubernetes/kubernetes/issues/[0-9]+"
 	rebuildFormat = `@%s
 You must link to the test flake issue which caused you to request this manual re-test.
-Re-test requests should be in the form of: ` + "`" + `k8s-bot test this issue: #<number>` + "`" + `
+Re-test requests should be in the form of: ` + "`" + jenkinsBotName + ` test this issue: #<number>` + "`" + `
 Here is the [list of open test flakes](https://github.com/kubernetes/kubernetes/issues?q=is:issue+label:kind/flake+is:open).`
 )
 
 var (
-	buildMatcher = regexp.MustCompile("@k8s-bot\\s+(?:e2e\\s+)?(?:unit\\s+)?test\\s+this.*")
-	issueMatcher = regexp.MustCompile("\\s+(?:github\\s+)?(issue|flake)\\:?\\s+(?:#(?:IGNORE|[0-9]+)|" + issueURLRe + ")")
+	buildMatcherStr = fmt.Sprintf("@%s\\s+(?:e2e\\s+)?(?:unit\\s+)?test\\s+this.*", jenkinsBotName)
+	buildMatcher    = regexp.MustCompile(buildMatcherStr)
+	issueMatcher    = regexp.MustCompile("\\s+(?:github\\s+)?(issue|flake)\\:?\\s+(?:#(?:IGNORE|[0-9]+)|" + issueURLRe + ")")
 
 	// take the format and replace the %s with \S+
 	rebuildCommentREString = strings.Replace(rebuildFormat, `@%s`, `@\S+`, 1)
@@ -67,7 +68,7 @@ func (r *RebuildMunger) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (r *RebuildMunger) Initialize(config *github.Config, features *features.Features) error {
-	r.robots = sets.NewString("googlebot", "k8s-bot", "k8s-merge-robot")
+	r.robots = sets.NewString("googlebot", jenkinsBotName, botName)
 	return nil
 }
 

--- a/mungegithub/mungers/rebuild_test.go
+++ b/mungegithub/mungers/rebuild_test.go
@@ -28,19 +28,19 @@ func TestIsRebuild(t *testing.T) {
 		isRebuild bool
 	}{
 		{
-			value:     "@k8s-bot test this please",
+			value:     "@" + jenkinsBotName + " test this please",
 			isRebuild: true,
 		},
 		{
-			value:     "@k8s-bot unit test this please",
+			value:     "@" + jenkinsBotName + " unit test this please",
 			isRebuild: true,
 		},
 		{
-			value:     "@k8s-bot e2e test this please",
+			value:     "@" + jenkinsBotName + " e2e test this please",
 			isRebuild: true,
 		},
 		{
-			value:     "@k8s-bot don't test this please",
+			value:     "@" + jenkinsBotName + " don't test this please",
 			isRebuild: false,
 		},
 		{
@@ -65,55 +65,55 @@ func TestRebuildMissingIssue(t *testing.T) {
 		expectMissing bool
 	}{
 		{
-			value:         "@k8s-bot test this please",
+			value:         "@" + jenkinsBotName + " test this please",
 			expectMissing: true,
 		},
 		{
-			value:         "@k8s-bot test this please github issue: #123456",
+			value:         "@" + jenkinsBotName + " test this please github issue: #123456",
 			expectMissing: false,
 		},
 		{
-			value:         "@k8s-bot test this please github issue: #IGNORE",
+			value:         "@" + jenkinsBotName + " test this please github issue: #IGNORE",
 			expectMissing: false,
 		},
 		{
-			value:         "@k8s-bot test this please github issue #123456",
+			value:         "@" + jenkinsBotName + " test this please github issue #123456",
 			expectMissing: false,
 		},
 		{
-			value:         "@k8s-bot test this please github issue #",
+			value:         "@" + jenkinsBotName + " test this please github issue #",
 			expectMissing: true,
 		},
 		{
-			value:         "@k8s-bot test this please github issue IGNORE",
+			value:         "@" + jenkinsBotName + " test this please github issue IGNORE",
 			expectMissing: true,
 		},
 		{
-			value:         "@k8s-bot test this please flake IGNORE",
+			value:         "@" + jenkinsBotName + " test this please flake IGNORE",
 			expectMissing: true,
 		},
 		{
-			value:         "@k8s-bot test this please issue: #IGNORE",
+			value:         "@" + jenkinsBotName + " test this please issue: #IGNORE",
 			expectMissing: false,
 		},
 		{
-			value:         "@k8s-bot test this please flake: #IGNORE",
+			value:         "@" + jenkinsBotName + " test this please flake: #IGNORE",
 			expectMissing: false,
 		},
 		{
-			value:         "@k8s-bot test this please flake: #12345",
+			value:         "@" + jenkinsBotName + " test this please flake: #12345",
 			expectMissing: false,
 		},
 		{
-			value:         "@k8s-bot test this please flake: https://github.com/kubernetes/kubernetes/issues/12345",
+			value:         "@" + jenkinsBotName + " test this please flake: https://github.com/kubernetes/kubernetes/issues/12345",
 			expectMissing: false,
 		},
 		{
-			value:         "@k8s-bot test this please flake: http://github.com/kubernetes/kubernetes/issues/12345",
+			value:         "@" + jenkinsBotName + " test this please flake: http://github.com/kubernetes/kubernetes/issues/12345",
 			expectMissing: false,
 		},
 		{
-			value:         "@k8s-bot test this please flake: github.com/kubernetes/kubernetes/issues/12345",
+			value:         "@" + jenkinsBotName + " test this please flake: github.com/kubernetes/kubernetes/issues/12345",
 			expectMissing: false,
 		},
 	}

--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	staleGreenCIHours = 48
-	greenMsgFormat    = `@k8s-bot test this
+	greenMsgFormat    = `@` + jenkinsBotName + ` test this
 
 Tests are more than %d hours old. Re-running tests.`
 )

--- a/mungegithub/mungers/stale-green-ci_test.go
+++ b/mungegithub/mungers/stale-green-ci_test.go
@@ -90,7 +90,7 @@ func TestOldUnitTestMunge(t *testing.T) {
 			c := new(comment)
 			json.NewDecoder(r.Body).Decode(c)
 			msg := c.Body
-			if strings.HasPrefix(msg, "@k8s-bot test this") {
+			if strings.HasPrefix(msg, "@"+jenkinsBotName+" test this") {
 				tested = true
 				test.ciStatus.State = stringPtr("pending")
 				for id := range test.ciStatus.Statuses {

--- a/mungegithub/mungers/stale-pending-ci.go
+++ b/mungegithub/mungers/stale-pending-ci.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	stalePendingCIHours = 24
-	pendingMsgFormat    = `@k8s-bot test this issue: #IGNORE
+	pendingMsgFormat    = `@` + jenkinsBotName + ` test this issue: #IGNORE
 
 Tests have been pending for %d hours`
 )
@@ -39,7 +39,7 @@ var (
 	pendingMsgBody = fmt.Sprintf(pendingMsgFormat, stalePendingCIHours)
 )
 
-// StalePendingCI will ask the k8s-bot to test any PR with a LGTM that has
+// StalePendingCI will ask the testBot-to test any PR with a LGTM that has
 // been pending for more than 24 hours. This can happen when the jenkins VM
 // is restarted.
 //

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -61,12 +61,12 @@ const (
 
 	githubE2EPollTime = 30 * time.Second
 
-	notInWhitelistBody    = "The author of this PR is not in the whitelist for merge, can one of the admins add the '" + okToMergeLabel + "' label?"
-	verifySafeToMergeBody = "@k8s-bot test this [submit-queue is verifying that this PR is safe to merge]"
+	notInWhitelistBody = "The author of this PR is not in the whitelist for merge, can one of the admins add the '" + okToMergeLabel + "' label?"
 )
 
 var (
-	_ = fmt.Print
+	_                     = fmt.Print
+	verifySafeToMergeBody = fmt.Sprintf("@%s test this [submit-queue is verifying that this PR is safe to merge]", jenkinsBotName)
 )
 
 type submitStatus struct {

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -905,7 +905,7 @@ func TestSubmitQueue(t *testing.T) {
 				c := new(github.IssueComment)
 				json.NewDecoder(r.Body).Decode(c)
 				msg := *c.Body
-				if strings.HasPrefix(msg, "@k8s-bot test this") {
+				if strings.HasPrefix(msg, "@"+jenkinsBotName+" test this") {
 					go fakeRunGithubE2ESuccess(test.ciStatus, test.e2ePass, test.unitPass)
 				}
 				w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This PR will remove 'old' jenkins pass/fail comments. Only the last comment will remain in the PR. For example in https://github.com/kubernetes/kubernetes/pull/24514 this will remove:
- https://github.com/kubernetes/kubernetes/pull/24514#issuecomment-212243186
- https://github.com/kubernetes/kubernetes/pull/24514#issuecomment-213247524
- https://github.com/kubernetes/kubernetes/pull/24514#issuecomment-213556240
- https://github.com/kubernetes/kubernetes/pull/24514#issuecomment-213916894

But will leave:
- https://github.com/kubernetes/kubernetes/pull/24514#issuecomment-213924286