### PR TITLE
[WIP/RFC] Simple ingress -> DNS controller, using AWS Route53

### DIFF
--- a/dns/Dockerfile
+++ b/dns/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2015 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:jessie
+
+COPY dns-controller /
+
+WORKDIR /
+
+CMD ["/dns-controller"]

--- a/dns/Godeps/Godeps.json
+++ b/dns/Godeps/Godeps.json
@@ -1,0 +1,406 @@
+{
+	"ImportPath": "k8s.io/contrib/dns",
+	"GoVersion": "go1.6",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "bitbucket.org/ww/goautoneg",
+			"Comment": "null-5",
+			"Rev": "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go/aws",
+			"Comment": "v1.1.20",
+			"Rev": "965c78a34d6fdf13a1788b96340c95edc548f553"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go/private/endpoints",
+			"Comment": "v1.1.20",
+			"Rev": "965c78a34d6fdf13a1788b96340c95edc548f553"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol",
+			"Comment": "v1.1.20",
+			"Rev": "965c78a34d6fdf13a1788b96340c95edc548f553"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go/private/signer/v4",
+			"Comment": "v1.1.20",
+			"Rev": "965c78a34d6fdf13a1788b96340c95edc548f553"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go/private/waiter",
+			"Comment": "v1.1.20",
+			"Rev": "965c78a34d6fdf13a1788b96340c95edc548f553"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go/service/elb",
+			"Comment": "v1.1.20",
+			"Rev": "965c78a34d6fdf13a1788b96340c95edc548f553"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go/service/route53",
+			"Comment": "v1.1.20",
+			"Rev": "965c78a34d6fdf13a1788b96340c95edc548f553"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go/vendor/github.com/go-ini/ini",
+			"Comment": "v1.1.20",
+			"Rev": "965c78a34d6fdf13a1788b96340c95edc548f553"
+		},
+		{
+			"ImportPath": "github.com/aws/aws-sdk-go/vendor/github.com/jmespath/go-jmespath",
+			"Comment": "v1.1.20",
+			"Rev": "965c78a34d6fdf13a1788b96340c95edc548f553"
+		},
+		{
+			"ImportPath": "github.com/beorn7/perks/quantile",
+			"Rev": "b965b613227fddccbfffe13eae360ed3fa822f8d"
+		},
+		{
+			"ImportPath": "github.com/blang/semver",
+			"Comment": "v3.0.1",
+			"Rev": "31b736133b98f26d5e078ec9eb591666edfd091f"
+		},
+		{
+			"ImportPath": "github.com/cpuguy83/go-md2man/md2man",
+			"Comment": "v1.0.3-2-g71acacd",
+			"Rev": "71acacd42f85e5e82f70a55327789582a5200a90"
+		},
+		{
+			"ImportPath": "github.com/davecgh/go-spew/spew",
+			"Rev": "3e6e67c4dcea3ac2f25fd4731abc0e1deaf36216"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/mount",
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/parsers",
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
+		},
+		{
+			"ImportPath": "github.com/docker/go-units",
+			"Comment": "v0.1.0-21-g0bbddae",
+			"Rev": "0bbddae09c5a5419a8c6dcdd7ff90da3d450393b"
+		},
+		{
+			"ImportPath": "github.com/emicklei/go-restful",
+			"Comment": "v1.2",
+			"Rev": "777bb3f19bcafe2575ffb2a3e46af92509ae9594"
+		},
+		{
+			"ImportPath": "github.com/evanphx/json-patch",
+			"Rev": "7dd4489c2eb6073e5a9d7746c3274c5b5f0387df"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient",
+			"Rev": "1399676f53e6ccf46e0bf00751b21bed329bc60e"
+		},
+		{
+			"ImportPath": "github.com/ghodss/yaml",
+			"Rev": "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
+		},
+		{
+			"ImportPath": "github.com/golang/glog",
+			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
+		},
+		{
+			"ImportPath": "github.com/golang/groupcache/lru",
+			"Rev": "604ed5785183e59ae2789449d89e73f3a2a77987"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "7f07925444bb51fa4cf9dfe6f7661876f8852275"
+		},
+		{
+			"ImportPath": "github.com/google/cadvisor/info/v1",
+			"Comment": "v0.22.0-22-gb9e3644",
+			"Rev": "b9e36443c490f54cee2f1539d27364730a226e33"
+		},
+		{
+			"ImportPath": "github.com/google/gofuzz",
+			"Rev": "bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5"
+		},
+		{
+			"ImportPath": "github.com/imdario/mergo",
+			"Comment": "0.1.3-8-g6633656",
+			"Rev": "6633656539c1639d9d78127b7d47c622b5d7b6dc"
+		},
+		{
+			"ImportPath": "github.com/inconshreveable/mousetrap",
+			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+		},
+		{
+			"ImportPath": "github.com/juju/ratelimit",
+			"Rev": "77ed1c8a01217656d2080ad51981f6e99adaa177"
+		},
+		{
+			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+			"Rev": "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
+		},
+		{
+			"ImportPath": "github.com/opencontainers/runc/libcontainer/cgroups",
+			"Comment": "v0.0.7",
+			"Rev": "7ca2aa4873aea7cb4265b1726acb24b90d8726c6"
+		},
+		{
+			"ImportPath": "github.com/opencontainers/runc/libcontainer/configs",
+			"Comment": "v0.0.7",
+			"Rev": "7ca2aa4873aea7cb4265b1726acb24b90d8726c6"
+		},
+		{
+			"ImportPath": "github.com/opencontainers/runc/libcontainer/system",
+			"Comment": "v0.0.7",
+			"Rev": "7ca2aa4873aea7cb4265b1726acb24b90d8726c6"
+		},
+		{
+			"ImportPath": "github.com/pborman/uuid",
+			"Rev": "ca53cad383cad2479bbba7f7a1a05797ec1386e4"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_golang/prometheus",
+			"Comment": "0.7.0-39-g3b78d7a",
+			"Rev": "3b78d7a77f51ccbc364d4bc170920153022cfd08"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_model/go",
+			"Comment": "model-0.0.2-12-gfa8ad6f",
+			"Rev": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/expfmt",
+			"Rev": "ef7a9a5fb138aa5d3a19988537606226869a0390"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/model",
+			"Rev": "ef7a9a5fb138aa5d3a19988537606226869a0390"
+		},
+		{
+			"ImportPath": "github.com/prometheus/procfs",
+			"Rev": "490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d"
+		},
+		{
+			"ImportPath": "github.com/russross/blackfriday",
+			"Comment": "v1.2-42-g77efab5",
+			"Rev": "77efab57b2f74dd3f9051c79752b2e8995c8b789"
+		},
+		{
+			"ImportPath": "github.com/shurcooL/sanitized_anchor_name",
+			"Rev": "9a8b7d4e8f347bfa230879db9d7d4e4d9e19f962"
+		},
+		{
+			"ImportPath": "github.com/spf13/cobra",
+			"Rev": "1c44ec8d3f1552cac48999f9306da23c4d8a288b"
+		},
+		{
+			"ImportPath": "github.com/spf13/pflag",
+			"Rev": "08b1a584251b5b62f458943640fc8ebd4d50aaa5"
+		},
+		{
+			"ImportPath": "github.com/ugorji/go/codec",
+			"Rev": "f1f1a805ed361a0e078bb537e4ea78cd37dcf065"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "991d3e32f76f19ee6d9caadb3a22eae8d23315f7"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "d466437aa4adc35830964cffc5b5f262c63ddcb4"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apimachinery",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/metrics",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/auth/user",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/capabilities",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/cache",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/metrics",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/record",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/restclient",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/transport",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/discovery",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/conversion",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/fieldpath",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/fields",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubectl",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/qos",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/labels",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/master/ports",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/runtime",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/types",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/version",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/watch",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/third_party/forked/json",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/third_party/forked/reflect",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/third_party/golang/template",
+			"Comment": "v1.2.3",
+			"Rev": "882d296a99218da8f6b2a340eb0e81c69e66ecc7"
+		},
+		{
+			"ImportPath": "speter.net/go/exp/math/dec/inf",
+			"Rev": "42ca6cd68aa922bc3f32f1e056e61b65945d9ad7"
+		}
+	]
+}

--- a/dns/Godeps/Readme
+++ b/dns/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/dns/Makefile
+++ b/dns/Makefile
@@ -1,0 +1,30 @@
+all: push
+
+# 0.0 shouldn't clobber any release builds
+TAG = 0.5
+PREFIX = gcr.io/google_containers/dns-controller
+
+REPO_INFO=$(shell git config --get remote.origin.url)
+
+ifndef VERSION
+  VERSION := git-$(shell git rev-parse --short HEAD)
+endif
+
+#dns-controller: clean
+#	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags \
+#		"-w -X main.version=${VERSION} -X main.gitRepo=${REPO_INFO}" \
+#		-o dns-controller
+dns-controller: clean
+	CGO_ENABLED=0 GOOS=linux godep go build \
+		-ldflags "-w -X main.version=${VERSION} -X main.gitRepo=${REPO_INFO}" \
+		-o dns-controller \
+		k8s.io/contrib/dns/cmd/dns-controller
+
+container: dns-controller
+  docker build -t $(PREFIX):$(TAG) .
+
+push: container
+	gcloud docker push $(PREFIX):$(TAG)
+
+clean:
+	rm -f dns-controller

--- a/dns/README.md
+++ b/dns/README.md
@@ -1,0 +1,2 @@
+# Simple DNS Controller
+

--- a/dns/cmd/dns-controller/controller.go
+++ b/dns/cmd/dns-controller/controller.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/client/record"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/contrib/dns/pkg/providers"
+)
+
+var (
+	keyFunc = framework.DeletionHandlingMetaNamespaceKeyFunc
+)
+
+// dnsController watches the kubernetes api and adds/removes DNS entries
+type dnsController struct {
+	provider             providers.DNSProvider
+	publishServices []string
+
+	client               *client.Client
+	ingController        *framework.Controller
+	svcController        *framework.Controller
+	ingLister            StoreToIngressLister
+	svcLister            cache.StoreToServiceLister
+
+	recorder             record.EventRecorder
+
+	syncQueue            *taskQueue
+
+	// stopLock is used to enforce only a single call to Stop is active.
+	// Needed because we allow stopping through an http endpoint and
+	// allowing concurrent stoppers leads to stack traces.
+	stopLock             sync.Mutex
+	shutdown             bool
+	stopCh               chan struct{}
+}
+
+// newDNSController creates a controller for DNS
+func newDNSController(kubeClient *client.Client,
+			resyncPeriod time.Duration,
+			provider providers.DNSProvider,
+watchNamespace string,
+			publishServices []string) (*dnsController, error) {
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartRecordingToSink(kubeClient.Events(""))
+
+	lbc := dnsController{
+		provider: provider,
+		publishServices: publishServices,
+		client:       kubeClient,
+		stopCh:       make(chan struct{}),
+		recorder:     eventBroadcaster.NewRecorder(api.EventSource{Component: "loadbalancer-controller"}),
+	}
+
+	lbc.syncQueue = NewTaskQueue(lbc.sync)
+
+	ingEventHandler := framework.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			addIng := obj.(*extensions.Ingress)
+			lbc.recorder.Eventf(addIng, api.EventTypeNormal, "CREATE", fmt.Sprintf("%s/%s", addIng.Namespace, addIng.Name))
+			lbc.syncQueue.enqueue(obj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			upIng := obj.(*extensions.Ingress)
+			lbc.recorder.Eventf(upIng, api.EventTypeNormal, "DELETE", fmt.Sprintf("%s/%s", upIng.Namespace, upIng.Name))
+			lbc.syncQueue.enqueue(obj)
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			if !reflect.DeepEqual(old, cur) {
+				upIng := cur.(*extensions.Ingress)
+				lbc.recorder.Eventf(upIng, api.EventTypeNormal, "UPDATE", fmt.Sprintf("%s/%s", upIng.Namespace, upIng.Name))
+				lbc.syncQueue.enqueue(cur)
+			}
+		},
+	}
+
+	lbc.ingLister.Store, lbc.ingController = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc:  ingressListFunc(lbc.client, watchNamespace),
+			WatchFunc: ingressWatchFunc(lbc.client, watchNamespace),
+		},
+		&extensions.Ingress{}, resyncPeriod, ingEventHandler)
+
+	lbc.svcLister.Store, lbc.svcController = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc:  serviceListFunc(lbc.client, watchNamespace),
+			WatchFunc: serviceWatchFunc(lbc.client, watchNamespace),
+		},
+		&api.Service{}, resyncPeriod, framework.ResourceEventHandlerFuncs{})
+
+	return &lbc, nil
+}
+
+func ingressListFunc(c *client.Client, ns string) func(api.ListOptions) (runtime.Object, error) {
+	return func(opts api.ListOptions) (runtime.Object, error) {
+		return c.Extensions().Ingress(ns).List(opts)
+	}
+}
+
+func ingressWatchFunc(c *client.Client, ns string) func(options api.ListOptions) (watch.Interface, error) {
+	return func(options api.ListOptions) (watch.Interface, error) {
+		return c.Extensions().Ingress(ns).Watch(options)
+	}
+}
+
+func serviceListFunc(c *client.Client, ns string) func(api.ListOptions) (runtime.Object, error) {
+	return func(opts api.ListOptions) (runtime.Object, error) {
+		return c.Services(ns).List(opts)
+	}
+}
+
+func serviceWatchFunc(c *client.Client, ns string) func(options api.ListOptions) (watch.Interface, error) {
+	return func(options api.ListOptions) (watch.Interface, error) {
+		return c.Services(ns).Watch(options)
+	}
+}
+
+func (lbc *dnsController) controllersInSync() bool {
+	return lbc.ingController.HasSynced() && lbc.svcController.HasSynced()
+}
+
+func (lbc *dnsController) sync(key string) {
+	if !lbc.controllersInSync() {
+		lbc.syncQueue.requeue(key, fmt.Errorf("deferring sync till endpoints controller has synced"))
+		return
+	}
+
+	ings := lbc.ingLister.Store.List()
+	names := lbc.buildDNSNames(ings)
+
+	targets := lbc.findTargets()
+
+	err := lbc.provider.EnsureNames(names, targets)
+	if err != nil {
+		glog.Warningf("error while trying to create names: %v", err)
+		// TODO: Add retry logic
+	}
+}
+
+func (lbc *dnsController) buildDNSNames(data []interface{}) map[string]*providers.DNSName {
+	hostnames := make(map[string]*providers.DNSName)
+
+	for _, ingIf := range data {
+		ing := ingIf.(*extensions.Ingress)
+
+		for _, rule := range ing.Spec.Rules {
+			if _, ok := hostnames[rule.Host]; !ok {
+				hostnames[rule.Host] = &providers.DNSName{Name: rule.Host}
+			}
+		}
+	}
+
+	return hostnames
+}
+
+func (lbc*dnsController) findTargets() []api.LoadBalancerIngress {
+	var ingress []api.LoadBalancerIngress
+
+	for _, externalServiceName := range lbc.publishServices {
+		svcObj, svcExists, err := lbc.svcLister.Store.GetByKey(externalServiceName)
+		if err != nil {
+			// TODO: Add retry logic
+			glog.Warningf("error getting service %v: %v", externalServiceName, err)
+			continue
+		}
+
+		if !svcExists {
+			glog.Warningf("service %v was not found", externalServiceName)
+			continue
+		}
+
+		svc := svcObj.(*api.Service)
+
+		ingress = append(ingress, svc.Status.LoadBalancer.Ingress...)
+	}
+	return ingress
+}
+
+// Stop stops the loadbalancer controller.
+func (lbc *dnsController) Stop() error {
+	// Stop is invoked from the http endpoint.
+	lbc.stopLock.Lock()
+	defer lbc.stopLock.Unlock()
+
+	// Only try draining the workqueue if we haven't already.
+	if !lbc.shutdown {
+		close(lbc.stopCh)
+		glog.Infof("shutting down controller queues")
+		lbc.shutdown = true
+		lbc.syncQueue.shutdown()
+
+		return nil
+	}
+
+	return fmt.Errorf("shutdown already in progress")
+}
+
+// Run starts the loadbalancer controller.
+func (lbc *dnsController) Run() {
+	glog.Infof("starting DNS controller")
+
+	go lbc.ingController.Run(lbc.stopCh)
+	go lbc.svcController.Run(lbc.stopCh)
+
+	go lbc.syncQueue.run(time.Second, lbc.stopCh)
+
+	<-lbc.stopCh
+	glog.Infof("shutting down DNS controller")
+}

--- a/dns/cmd/dns-controller/main.go
+++ b/dns/cmd/dns-controller/main.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned"
+	kubectl_util "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/contrib/dns/pkg/providers/route53"
+)
+
+const (
+	healthPort = 10249
+)
+
+var (
+	// value overwritten during build. This can be used to resolve issues.
+	version = "0.5"
+	gitRepo = "https://github.com/kubernetes/contrib"
+
+	flags = pflag.NewFlagSet("", pflag.ExitOnError)
+
+	publishServices = flags.StringSlice("publish-service", nil,
+		`Service that we target for the DNS alias.  Typically the service for the ingress controller.`)
+
+	resyncPeriod = flags.Duration("sync-period", 30 * time.Second,
+		`Relist and confirm cloud resources this often.`)
+
+	watchNamespace = flags.String("watch-namespace", api.NamespaceAll,
+		`Namespace to watch for Ingress. Default is to watch all namespaces`)
+
+	healthzPort = flags.Int("healthz-port", healthPort, "port for healthz endpoint.")
+
+	inCluster = flags.Bool("running-in-cluster", true,
+		`Optional, if this controller is running in a kubernetes cluster, use the
+		 pod secrets for creating a Kubernetes client.`)
+
+	profiling = flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)
+)
+
+func main() {
+	var kubeClient *unversioned.Client
+	flags.AddGoFlagSet(flag.CommandLine)
+	flags.Parse(os.Args)
+	clientConfig := kubectl_util.DefaultClientConfig(flags)
+
+	glog.Infof("Using build: %v - %v", gitRepo, version)
+
+	if publishServices == nil || len(*publishServices) == 0 {
+		glog.Fatalf("Please specify --publish-service")
+	}
+
+	var err error
+	if *inCluster {
+		kubeClient, err = unversioned.NewInCluster()
+	} else {
+		config, connErr := clientConfig.ClientConfig()
+		if connErr != nil {
+			glog.Fatalf("error connecting to the client: %v", err)
+		}
+		kubeClient, err = unversioned.New(config)
+	}
+	if err != nil {
+		glog.Fatalf("failed to create client: %v", err)
+	}
+
+	providerID := "route53"
+
+	provider, err := route53.NewRoute53Provider()
+	if err != nil {
+		glog.Fatalf("failed to build provider %q: %v", providerID, err)
+	}
+	lbc, err := newDNSController(kubeClient, *resyncPeriod, provider, *watchNamespace, *publishServices)
+	if err != nil {
+		glog.Fatalf("%v", err)
+	}
+
+	go registerHandlers(lbc)
+	go handleSigterm(lbc)
+
+	lbc.Run()
+
+	for {
+		glog.Infof("Handled quit, awaiting pod deletion")
+		time.Sleep(30 * time.Second)
+	}
+}
+
+// podInfo contains runtime information about the pod
+type podInfo struct {
+	PodName      string
+	PodNamespace string
+	NodeIP       string
+}
+
+func registerHandlers(lbc *dnsController) {
+	mux := http.NewServeMux()
+	// TODO: healthz
+	//healthz.InstallHandler(mux, lbc.nginx)
+
+	http.HandleFunc("/build", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "build: %v - %v", gitRepo, version)
+	})
+
+	http.HandleFunc("/stop", func(w http.ResponseWriter, r *http.Request) {
+		lbc.Stop()
+	})
+
+	if *profiling {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	}
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%v", *healthzPort),
+		Handler: mux,
+	}
+	glog.Fatal(server.ListenAndServe())
+}
+
+func handleSigterm(lbc *dnsController) {
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGTERM)
+	<-signalChan
+	glog.Infof("Received SIGTERM, shutting down")
+
+	exitCode := 0
+	if err := lbc.Stop(); err != nil {
+		glog.Infof("Error during shutdown %v", err)
+		exitCode = 1
+	}
+	glog.Infof("Exiting with %v", exitCode)
+	os.Exit(exitCode)
+}

--- a/dns/cmd/dns-controller/utils.go
+++ b/dns/cmd/dns-controller/utils.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+)
+
+// StoreToIngressLister makes a Store that lists Ingress.
+type StoreToIngressLister struct {
+	cache.Store
+}
+
+// taskQueue manages a work queue through an independent worker that
+// invokes the given sync function for every work item inserted.
+type taskQueue struct {
+	// queue is the work queue the worker polls
+	queue *workqueue.Type
+	// sync is called for each item in the queue
+	sync func(string)
+	// workerDone is closed when the worker exits
+	workerDone chan struct{}
+}
+
+func (t *taskQueue) run(period time.Duration, stopCh <-chan struct{}) {
+	wait.Until(t.worker, period, stopCh)
+}
+
+// enqueue enqueues ns/name of the given api object in the task queue.
+func (t *taskQueue) enqueue(obj interface{}) {
+	key, err := keyFunc(obj)
+	if err != nil {
+		glog.Infof("could not get key for object %+v: %v", obj, err)
+		return
+	}
+	t.queue.Add(key)
+}
+
+func (t *taskQueue) requeue(key string, err error) {
+	glog.V(3).Infof("requeuing %v, err %v", key, err)
+	t.queue.Add(key)
+}
+
+// worker processes work in the queue through sync.
+func (t *taskQueue) worker() {
+	for {
+		key, quit := t.queue.Get()
+		if quit {
+			close(t.workerDone)
+			return
+		}
+		glog.V(3).Infof("syncing %v", key)
+		t.sync(key.(string))
+		t.queue.Done(key)
+	}
+}
+
+// shutdown shuts down the work queue and waits for the worker to ACK
+func (t *taskQueue) shutdown() {
+	t.queue.ShutDown()
+	<-t.workerDone
+}
+
+// NewTaskQueue creates a new task queue with the given sync function.
+// The sync function is called for every element inserted into the queue.
+func NewTaskQueue(syncFn func(string)) *taskQueue {
+	return &taskQueue{
+		queue:      workqueue.New(),
+		sync:       syncFn,
+		workerDone: make(chan struct{}),
+	}
+}

--- a/dns/dns.iml
+++ b/dns/dns.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="GO_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Go 1.6" jdkType="Go SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="GOPATH &lt;dns&gt;" level="project" />
+  </component>
+</module>

--- a/dns/examples/ingress.yaml
+++ b/dns/examples/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: guestbook
+spec:
+  rules:
+  - host: guestbook.bar.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: guestbook
+          servicePort: 3000
+
+

--- a/dns/pkg/providers/provider.go
+++ b/dns/pkg/providers/provider.go
@@ -1,0 +1,18 @@
+package providers
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"fmt"
+)
+
+type DNSProvider interface {
+	EnsureNames(names map[string]*DNSName, ingress []api.LoadBalancerIngress) error
+}
+
+type DNSName struct {
+	Name string
+}
+
+func (n *DNSName) String() string {
+	return fmt.Sprintf("DNSName{Name:%q}", n.Name)
+}

--- a/dns/pkg/providers/route53/route53.go
+++ b/dns/pkg/providers/route53/route53.go
@@ -1,0 +1,315 @@
+package route53
+
+import (
+	"k8s.io/contrib/dns/pkg/providers"
+	"k8s.io/kubernetes/pkg/api"
+	"github.com/aws/aws-sdk-go/aws/session"
+	awsr53 "github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/aws"
+	"fmt"
+	"strings"
+	"github.com/golang/glog"
+	"github.com/aws/aws-sdk-go/service/elb"
+)
+
+type Route53Provider struct {
+	r53Client *awsr53.Route53
+	elbClient *elb.ELB
+}
+
+var _ providers.DNSProvider = &Route53Provider{}
+
+func NewRoute53Provider() (*Route53Provider, error) {
+	awsConfig := &aws.Config{}
+	awsSession := session.New()
+	r53Client := awsr53.New(awsSession, awsConfig)
+	elbClient := elb.New(awsSession, awsConfig)
+
+	p := &Route53Provider{
+		r53Client: r53Client,
+		elbClient : elbClient,
+	}
+	return p, nil
+}
+
+func (p*Route53Provider) getELBInfo(dnsName string) (*elb.LoadBalancerDescription, error) {
+	// TODO: Cache
+	// TODO: Check if "looks like" an ELB?
+	// TODO: Only do this if service type=LoadBalancer
+
+	tokens := strings.Split(dnsName, ".")
+	elbNameTokens := strings.Split(tokens[0], "-")
+
+	if len(elbNameTokens) != 2 {
+		glog.Infof("does not look like an ELB name: %q", dnsName)
+		return nil, nil
+	}
+
+	elbName := elbNameTokens[0]
+
+	glog.V(2).Infof("Querying ELB for load balancer information for %q", elbName)
+	request := &elb.DescribeLoadBalancersInput{
+		LoadBalancerNames: []*string{
+			&elbName,
+		},
+	}
+	response, err := p.elbClient.DescribeLoadBalancers(request)
+	if err != nil {
+		return nil, fmt.Errorf("error describing load balancer %q: %v", elbName, err)
+	}
+
+	if len(response.LoadBalancerDescriptions) == 0 {
+		glog.V(4).Infof("ELB not found %q; assuming not an ELB", elbName)
+		return nil, nil
+	}
+	if len(response.LoadBalancerDescriptions) > 1 {
+		return nil, fmt.Errorf("found multiple ELBs with name %q", elbName)
+	}
+	return response.LoadBalancerDescriptions[0], nil
+}
+
+func (p *Route53Provider) EnsureNames(names map[string]*providers.DNSName, ingress []api.LoadBalancerIngress) error {
+	glog.V(8).Infof("EnsureNames: names %v, ingress %v", names, ingress)
+
+	hostedZones, err := p.listHostedZones()
+	if err != nil {
+		return err
+	}
+
+	namesByZone := make(map[string][]*providers.DNSName)
+	for _, v := range names {
+		name := v.Name
+		firstDot := strings.IndexRune(name, '.')
+		if firstDot == -1 {
+			glog.Warningf("Ignoring name with no dot: %q", name)
+			continue
+		}
+
+		zone := name[firstDot + 1:]
+		if zone == "" {
+			glog.Warningf("ignoring name with unexpected structure: %q", name)
+		}
+
+		// TODO: Move to "normalizeZone" function ?
+		if !strings.HasSuffix(zone, ".") {
+			zone = zone + "."
+		}
+
+		// Not sure if needed?
+		zone = strings.ToLower(zone)
+
+		names := namesByZone[zone]
+		names = append(names, v)
+		namesByZone[zone] = names
+	}
+
+	var errors []error
+	for _, hostedZone := range hostedZones {
+		zone := aws.StringValue(hostedZone.Name)
+		if zone == "" {
+			glog.Warningf("ignoring HostedZone with empty name: %v", hostedZone)
+			continue
+		}
+
+		if !strings.HasSuffix(zone, ".") {
+			zone = zone + "."
+		}
+
+		// Not sure if needed?
+		zone = strings.ToLower(zone)
+
+		names := namesByZone[zone]
+		if len(names) == 0 {
+			glog.V(8).Infof("no names for zone %q", zone)
+			continue
+		}
+
+		// The route53 API is awkward...
+		hostedZoneID := aws.StringValue(hostedZone.Id)
+		hostedZoneID = strings.TrimPrefix(hostedZoneID, "/hostedzone/")
+
+		// Clear it so that we can warn about unmanaged zones later
+		namesByZone[zone] = nil
+
+		var changes []*awsr53.Change
+
+		for _, n := range names {
+			// TODO: Query zone and be much more efficient
+
+			// TODO: Only call this once per loop
+			rrs, err := p.buildRRS(n.Name, ingress)
+			if err != nil {
+				// TODO: Invalidate cache if "zone not found" ?
+				glog.Warningf("error building records for name %q: %v", n.Name, err)
+				errors = append(errors, err)
+			}
+
+			if rrs != nil {
+				change := &awsr53.Change{
+					Action:            aws.String("UPSERT"),
+					ResourceRecordSet: rrs,
+				}
+				changes = append(changes, change)
+			}
+
+			// TODO: Remove old records (and thus avoid making the call here if records already match...)
+		}
+
+		if len(changes) == 0 {
+			glog.V(4).Infof("No changes for zone %q; skipping", zone)
+			continue
+		}
+
+		batch := &awsr53.ChangeBatch{
+			Changes: changes,
+			// TODO: Comment with our pod id?
+			//Comment *string `type:"string"`
+		}
+
+		changeRequest := &awsr53.ChangeResourceRecordSetsInput{
+			HostedZoneId: aws.String(hostedZoneID),
+			ChangeBatch: batch,
+		}
+
+		// TODO: cope with limits
+		// A request cannot contain more than 100 Change elements.
+		// A request cannot contain more than 1000 ResourceRecord elements.
+		// The sum of the number of characters (including spaces) in all Value elements in a request cannot exceed 32,000 characters.
+
+		glog.Infof("making Route53 request to change zone %q", zone)
+		glog.V(4).Infof("change request is %v", changeRequest)
+		response, err := p.r53Client.ChangeResourceRecordSets(changeRequest)
+		if err != nil {
+			// TODO: Invalidate cache if "zone not found" ?
+			glog.Warningf("error applying change to hosted zone %q: %v", zone, err)
+			errors = append(errors, err)
+		}
+		glog.V(4).Infof("change response is %v", response)
+	}
+
+	for zone, names := range namesByZone {
+		if len(names) == 0 {
+			continue
+		}
+
+		// TODO: Periodically resync list of zones (or maybe just when we see a request for an unmanaged zone?)
+		glog.Warningf("Ignoring unmanaged zone: %q", zone)
+	}
+
+	if len(errors) != 0 {
+		return fmt.Errorf("error applying changes to zones: %v", errors)
+	}
+
+	return nil
+}
+
+func (p*Route53Provider) listHostedZones() ([]*awsr53.HostedZone, error) {
+	// TODO: Cache (with periodic resync for new zones)
+	var hostedZones []*awsr53.HostedZone
+	request := &awsr53.ListHostedZonesInput{}
+	glog.V(2).Infof("querying Route53 for hosted zones")
+	err := p.r53Client.ListHostedZonesPages(request, func(p *awsr53.ListHostedZonesOutput, lastPage bool) (/*shouldContinue*/
+	bool) {
+		hostedZones = append(hostedZones, p.HostedZones...)
+		return true
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing hosted zones: %v", err)
+	}
+
+	glog.V(8).Infof("Hosted zones: %v", hostedZones)
+
+	return hostedZones, nil
+}
+
+func (p*Route53Provider) buildRRS(name string, ingress []api.LoadBalancerIngress) (*awsr53.ResourceRecordSet, error) {
+	// TODO: Most of this construction logic does not depend on the name
+	var elbs []*elb.LoadBalancerDescription
+	var hostnames []string
+	var ips []string
+
+	for _, target := range ingress {
+		if target.Hostname != "" {
+			elbInfo, err := p.getELBInfo(target.Hostname)
+			if err != nil {
+				return nil, fmt.Errorf("error querying ELB %q: %v", target.Hostname, err)
+			}
+			if elbInfo == nil {
+				hostnames = append(hostnames, target.Hostname)
+			} else {
+				elbs = append(elbs, elbInfo)
+			}
+		} else if target.IP != "" {
+
+		} else {
+			glog.Warningf("Ignoring LoadBalancerIngress with neither Hostname nor IP")
+		}
+	}
+
+	var rrs *awsr53.ResourceRecordSet
+
+	if len(elbs) == 0 && len(ips) == 0 && len(hostnames) == 0 {
+		glog.Warningf("no ingress elbs nor ips; ignoring")
+		return nil, nil
+	} else if len(elbs) == 1 && len(ips) == 0 && len(hostnames) == 0 {
+		// TODO: Cope with cross-account ELBs?
+		aliasTarget := &awsr53.AliasTarget{
+			DNSName:              elbs[0].DNSName,
+			EvaluateTargetHealth: aws.Bool(false),
+			HostedZoneId:         elbs[0].CanonicalHostedZoneNameID,
+		}
+
+		rrs = &awsr53.ResourceRecordSet{
+			AliasTarget: aliasTarget,
+			Name:        aws.String(name),
+			Type:        aws.String("A"),
+		}
+	} else if len(elbs) == 0 && len(hostnames) == 0 {
+		var records []*awsr53.ResourceRecord
+		for _, ip := range ips {
+			// I think we can join these into a single string, but this feels clearer
+			record := &awsr53.ResourceRecord{
+				Value: aws.String(ip),
+			}
+			records = append(records, record)
+		}
+
+		rrs = &awsr53.ResourceRecordSet{
+			Name:        aws.String(name),
+			Type:        aws.String("A"),
+			ResourceRecords: records,
+		}
+	} else if len(ips) == 0 {
+		// CNAMEs
+		var records []*awsr53.ResourceRecord
+		for _, hostname := range hostnames {
+			// I think we can join these into a single string, but this feels clearer
+			record := &awsr53.ResourceRecord{
+				Value: aws.String(hostname),
+			}
+			records = append(records, record)
+		}
+
+		if len(elbs) != 0 {
+			// TODO: Is this right?  Should we warn here (less efficient, we're losing health-checks etc)
+			glog.Warningf("Using CNAMEs for multiple ELBs")
+			var records []*awsr53.ResourceRecord
+			for _, elb := range elbs {
+				record := &awsr53.ResourceRecord{
+					Value: elb.DNSName,
+				}
+				records = append(records, record)
+			}
+		}
+
+		rrs = &awsr53.ResourceRecordSet{
+			Name:        aws.String(name),
+			Type:        aws.String("CNAME"),
+			ResourceRecords: records,
+		}
+	} else {
+		return nil, fmt.Errorf("cannot mix IP and hostnames in DNS")
+	}
+
+	return rrs, nil
+}


### PR DESCRIPTION
This is a simple controller, that observes the hostnames configured on ingress resources, and configures them in AWS Route53 (where the HostedZones are already configured).  This controller would be launched as a pod (single-instance), and is configured with a service to expose (likely the nginx service).  It watches for that service, observes the ingress name/IP.  It also watches all ingress objects.  Whenever an ingress object is created with a hostname rule, we try to configure that in Route53, pointing the name to the configured service.

It (mostly?) works, but I have done no optimization yet (e.g. to reduce the number of API calls).  Also I would naturally add a backend for GCE DNS (and I'm sure there will be a desire for other services also, hence it is pluggable)

Comments appreciated (though I think mostly on the concept rather than the details of the implementation at this stage)

@iterion - similar to work you've done for services

cc @bprashanth because you seem to be the ingress guru - can you give me any pointers about whether this is useful, who I should talk to etc.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/841)

<!-- Reviewable:end -->
