### PR TITLE
Loadbalancer role (keepalived/haproxy)

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -40,6 +40,10 @@ insecure_registrys:
 # The port that the Kubernetes apiserver component listens on.
 kube_master_api_port: 443
 
+# Routeable VIP for load balancing api servers.
+# This VIP must be unassigned and routeable from your cluster nodes
+#kube_apiserver_vip: 10.10.10.10
+
 # Kubernetes internal network for services.
 # Kubernetes services will get fake IP addresses from this range.
 # This range must not conflict with anything in your infrastructure. These

--- a/ansible/roles/contiv/templates/contiv.cfg.j2
+++ b/ansible/roles/contiv/templates/contiv.cfg.j2
@@ -1,5 +1,5 @@
 {
-  "K8S_API_SERVER": "https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}",
+  "K8S_API_SERVER": "https://{% if groups['masters']|length > 1 %}{{ kube_apiserver_vip }}{% else %}{{ groups['masters'][0] }}{% endif %}:{{ kube_master_api_port }}",
   "K8S_CA": "{{ kube_cert_dir }}/ca.crt",
   "K8S_KEY": "{{ kube_cert_dir }}/kubecfg.key",
   "K8S_CERT": "{{ kube_cert_dir }}/kubecfg.crt"

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -37,7 +37,7 @@ kube_current_release_directory: "{{ kube_releases_directory }}/{{ kube_version }
 kube_cert_dir: "{{ kube_config_dir }}/certs"
 
 # The IP(s) for which the certificate will be valid
-kube_cert_ip: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | join (',IP:') }}"
+kube_cert_ip: "{{ (hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | join (',IP:'))}}{% if kube_apiserver_vip %},IP:{{ kube_apiserver_vip }}{% endif %}"
 
 # This is where all of the bearer tokens will be stored
 kube_token_dir: "{{ kube_config_dir }}/tokens"

--- a/ansible/roles/kubernetes/templates/config.j2
+++ b/ansible/roles/kubernetes/templates/config.j2
@@ -20,4 +20,4 @@ KUBE_LOG_LEVEL="--v=0"
 KUBE_ALLOW_PRIV="--allow-privileged=true"
 
 # How the replication controller, scheduler, and proxy
-KUBE_MASTER="--master=https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}"
+KUBE_MASTER="--master=https://{% if groups['masters']|length > 1 %}{{ kube_apiserver_vip }}{% else %}{{ groups['masters'][0] }}{% endif %}:{{ kube_master_api_port }}"

--- a/ansible/roles/load-balancer/defaults/main.yml
+++ b/ansible/roles/load-balancer/defaults/main.yml
@@ -1,0 +1,7 @@
+keepalived_config_dir: /etc/keepalived
+kube_keepalived_password: kube-pass
+
+haproxy_config_dir: /etc/haproxy
+haproxy_stats_port: 9999
+
+kube_apiserver_interface: "{{ kube_apiserver_interface|default(ansible_default_ipv4.interface) }}"

--- a/ansible/roles/load-balancer/tasks/main.yml
+++ b/ansible/roles/load-balancer/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Copy haproxy and keepalived pod templates
+  template: src={{ item }}.j2 dest={{ kube_manifest_dir }}/{{ item }}
+  with_items:
+    - haproxy.yml
+    - keepalived.yml
+
+- name: Create haproxy and keepalived directories
+  file: name={{ item }} state=directory
+  with_items:
+    - "{{ haproxy_config_dir }}"
+    - "{{ keepalived_config_dir }}"
+
+- name: Write haproxy config file
+  template: src=haproxy.cfg.j2 dest={{ haproxy_config_dir }}/haproxy.cfg
+
+- name: Write keepalived config file
+  template: src=keepalived.conf.j2 dest={{ keepalived_config_dir }}/keepalived.conf
+
+- name: Enable non-local ip binding
+  sudo: yes
+  command: /bin/sh -c "/usr/sbin/sysctl -w net.ipv4.ip_nonlocal_bind=1"

--- a/ansible/roles/load-balancer/templates/haproxy.cfg.j2
+++ b/ansible/roles/load-balancer/templates/haproxy.cfg.j2
@@ -1,0 +1,40 @@
+#
+# {{ ansible_managed }}
+#
+global
+    log /dev/log    local0
+    log /dev/log    local1 notice
+    chroot /var/lib/haproxy
+    user haproxy
+    group haproxy
+    daemon
+    stats socket /var/lib/haproxy/stats level admin
+
+defaults
+    log global
+    option  dontlognull
+    timeout connect 5000
+    timeout client 50000
+    timeout server 50000
+
+frontend apiserver-incoming
+    bind {{ kube_apiserver_vip }}:{{ kube_master_api_port }}
+    mode tcp
+    option tcplog
+    default_backend apiserver
+
+backend apiserver
+    mode tcp
+    balance roundrobin
+    option ssl-hello-chk
+{% for host in groups['masters'] %}
+    server {{ hostvars[host].ansible_hostname }} {{ hostvars[host]['ansible_' + kube_apiserver_interface].ipv4.address }}:{{ kube_master_api_port }} check
+{% endfor %}
+
+listen stats
+    bind *:{{ haproxy_stats_port }}
+    mode http
+    stats enable
+    stats hide-version
+    stats realm Haproxy\ Statistics
+    stats uri /

--- a/ansible/roles/load-balancer/templates/haproxy.yml.j2
+++ b/ansible/roles/load-balancer/templates/haproxy.yml.j2
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: haproxy
+spec:
+  hostNetwork: true
+  containers:
+  - name: haproxy
+    image: million12/haproxy:1.6.3 # From https://hub.docker.com/r/million12/haproxy/
+    ports:
+    # Note: Ports for kube-api manifest would need to change if running haproxy/kube-api on same kubelet.
+    - containerPort: {{ kube_master_api_port }}
+      hostPort: {{ kube_master_api_port }}
+      name: https
+    - containerPort: {{ kube_api_insecure_port }}
+      hostPort: {{ kube_api_insecure_port }}
+      name: http
+    volumeMounts:
+    - mountPath: /etc/haproxy
+      name: haproxycfg
+    - mountPath: {{ kube_cert_dir }}
+      name: srvkube
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: {{ haproxy_config_dir }}
+    name: haproxycfg
+    readOnly: true
+  - hostPath:
+      path: {{ kube_cert_dir }}
+    name: srvkube
+    readOnly: true

--- a/ansible/roles/load-balancer/templates/keepalived.conf.j2
+++ b/ansible/roles/load-balancer/templates/keepalived.conf.j2
@@ -1,0 +1,33 @@
+#check that haproxy is runnning on this machine
+vrrp_script chk_haproxy {
+  script "pidof haproxy"
+  interval 2
+  weight 2
+}
+
+vrrp_instance VI_1 {
+  interface {{ kube_apiserver_interface }}
+  state MASTER
+  virtual_router_id 51
+  priority {% if inventory_hostname == groups['masters'][0] %} 101 {% else %} 100 {% endif %} # 101 on master, 100 on backups
+
+  #use unicast so we don't have to tool with multicast
+  unicast_peer {
+    {% for master in groups['masters'] %}
+    {{ hostvars[master]['ansible_' + kube_apiserver_interface].ipv4.address }}
+    {% endfor %}
+  }
+
+  virtual_ipaddress {
+    {{ kube_apiserver_vip }}
+  }
+
+  track_script {
+    chk_haproxy
+  }
+
+  authentication {
+    auth_type PASS
+    auth_pass {{ kube_keepalived_password }}
+  }
+}

--- a/ansible/roles/load-balancer/templates/keepalived.yml.j2
+++ b/ansible/roles/load-balancer/templates/keepalived.yml.j2
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: keepalived
+spec:
+  hostNetwork: true
+  containers:
+  - name: keepalived
+    securityContext:
+      privileged: True
+    image: bara/keepalived:latest # From https://hub.docker.com/r/bara/keepalived/
+    command: ["modprobe", "ip_vs"]
+    command: ["keepalived", "-f", "/etc/keepalived/keepalived.conf", "--dont-fork", "--log-console"]
+    ports:
+    volumeMounts:
+    - mountPath: /etc/keepalived
+      name: keepalivedconf
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: {{ keepalived_config_dir }}
+    name: keepalivedconf

--- a/ansible/roles/master/meta/main.yml
+++ b/ansible/roles/master/meta/main.yml
@@ -2,3 +2,4 @@
 dependencies:
     - { role: common }
     - { role: kubernetes }
+    - { role: load-balancer, when: "groups['masters']|length > 1" }

--- a/ansible/roles/master/templates/controller-manager.kubeconfig.j2
+++ b/ansible/roles/master/templates/controller-manager.kubeconfig.j2
@@ -5,7 +5,7 @@ preferences: {}
 clusters:
 - cluster:
     certificate-authority: {{ kube_cert_dir }}/ca.crt
-    server: https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}
+    server: https://{% if groups['masters']|length > 1 %}{{ kube_apiserver_vip }}{% else %}{{ groups['masters'][0] }}{% endif %}:{{ kube_master_api_port }}
   name: {{ cluster_name }}
 contexts:
 - context:

--- a/ansible/roles/master/templates/kubectl.kubeconfig.j2
+++ b/ansible/roles/master/templates/kubectl.kubeconfig.j2
@@ -5,7 +5,7 @@ preferences: {}
 clusters:
 - cluster:
     certificate-authority-data: {{ kube_ca_cert|b64encode }}
-    server: https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}
+    server: https://{% if groups['masters']|length > 1 %}{{ kube_apiserver_vip }}{% else %}{{ groups['masters'][0] }}{% endif %}:{{ kube_master_api_port }}
   name: {{ cluster_name }}
 contexts:
 - context:

--- a/ansible/roles/master/templates/scheduler.kubeconfig.j2
+++ b/ansible/roles/master/templates/scheduler.kubeconfig.j2
@@ -5,7 +5,7 @@ preferences: {}
 clusters:
 - cluster:
     certificate-authority: {{ kube_cert_dir }}/ca.crt
-    server: https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}
+    server: https://{% if groups['masters']|length > 1 %}{{ kube_apiserver_vip }}{% else %}{{ groups['masters'][0] }}{% endif %}:{{ kube_master_api_port }}
   name: {{ cluster_name }}
 contexts:
 - context:

--- a/ansible/roles/node/templates/kubelet.j2
+++ b/ansible/roles/node/templates/kubelet.j2
@@ -11,7 +11,7 @@ KUBELET_ADDRESS="--address=0.0.0.0"
 KUBELET_HOSTNAME="--hostname-override={{ inventory_hostname }}"
 
 # location of the api-server
-KUBELET_API_SERVER="--api-servers=https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}"
+KUBELET_API_SERVER="--api-servers=https://{% if groups['masters']|length > 1 %}{{ kube_apiserver_vip }}{% else %}{{ groups['masters'][0] }}{% endif %}:{{ kube_master_api_port }}"
 
 {% set kubelet_options = [] -%}
 {% if dns_setup -%}

--- a/ansible/roles/node/templates/kubelet.kubeconfig.j2
+++ b/ansible/roles/node/templates/kubelet.kubeconfig.j2
@@ -5,7 +5,7 @@ preferences: {}
 clusters:
 - cluster:
     certificate-authority: {{ kube_cert_dir }}/ca.crt
-    server: https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}
+    server: https://{% if groups['masters']|length > 1 %}{{ kube_apiserver_vip }}{% else %}{{ groups['masters'][0] }}{% endif %}:{{ kube_master_api_port }}
   name: {{ cluster_name }}
 contexts:
 - context:

--- a/ansible/roles/node/templates/proxy.kubeconfig.j2
+++ b/ansible/roles/node/templates/proxy.kubeconfig.j2
@@ -10,7 +10,7 @@ contexts:
 clusters:
 - cluster:
     certificate-authority: {{ kube_cert_dir }}/ca.crt
-    server: https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}
+    server: https://{% if groups['masters']|length > 1 %}{{ kube_apiserver_vip }}{% else %}{{ groups['masters'][0] }}{% endif %}:{{ kube_master_api_port }}
   name: {{ cluster_name }}
 users:
 - name: proxy

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -170,6 +170,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.extra_vars = {
         flannel_opts: "--iface=eth1",
         etcd_interface: "eth1",
+        kube_apiserver_interface: "eth1",
         netplugin_interface: "eth1",
         netmaster_interface: "eth1",
         kube_apiserver_bind_address: master_ip,


### PR DESCRIPTION
Added load-balancer role for HA master configuration of cluster. 

When there is more than one master node, an haproxy and leader-elected keepalived pod (via unicast) is run on each master node. A VIP is specified in group_vars for the apiserver. Haproxy uses round-robin load balancing with SSL pass-through.

This PR depends on #761. I'll make changes here as that evolves.

/cc: @danehans @rutsky @eparis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/843)

<!-- Reviewable:end -->
