### PR TITLE
Relax the matching regexp to ignore links

### DIFF
--- a/mungegithub/mungers/comment-deleter-jenkins.go
+++ b/mungegithub/mungers/comment-deleter-jenkins.go
@@ -27,10 +27,10 @@ import (
 
 const (
 	commentDeleterJenkinsName = "comment-deleter-jenkins"
-	commentRegexpStr          = `GCE e2e build/test \*\*(passed|failed)\*\* for commit [[:xdigit:]]+\.
-\* \[Build Log\]\(http://pr-test\.k8s\.io/[[:digit:]]+/kubernetes-pull-build-test-e2e-gce/[[:digit:]]+/build-log\.txt\)
-\* \[Test Artifacts\]\(https://console\.developers\.google\.com/storage/browser/kubernetes-jenkins/pr-logs/pull/[[:digit:]]+/kubernetes-pull-build-test-e2e-gce/[[:digit:]]+/artifacts/\)
-\* \[Internal Jenkins Results\]\(http://goto\.google\.com/prkubekins/job/kubernetes-pull-build-test-e2e-gce//[[:digit:]]+\)`
+	commentRegexpStr          = `GCE e2e( test)? build/test \*\*(passed|failed)\*\* for commit [[:xdigit:]]+\.
+\* \[Build Log\]\([^)]+\)
+\* \[Test Artifacts\]\([^)]+\)
+\* \[Internal Jenkins Results\]\([^)]+\)`
 )
 
 var (

--- a/mungegithub/mungers/comment-deleter-jenkins_test.go
+++ b/mungegithub/mungers/comment-deleter-jenkins_test.go
@@ -36,6 +36,10 @@ const (
 * [Internal Jenkins Results](http://goto.google.com/prkubekins/job/kubernetes-pull-build-test-e2e-gce//35830)
 
 Please reference the [list of currently known flakes](https://github.com/kubernetes/kubernetes/issues?q=is:issue+label:kind/flake+is:open) when examining this failure. If you request a re-test, you must reference the issue describing the flake.`
+	oldBuildLinkComment = `GCE e2e test build/test **passed** for commit c801f3fc6221e4b1a54fd08378f35009dd01f052.
+* [Build Log](https://storage.cloud.google.com/kubernetes-jenkins/pr-logs/pull/13006/kubernetes-pull-build-test-e2e-gce/26147/build-log.txt)
+* [Test Artifacts](https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/13006/kubernetes-pull-build-test-e2e-gce/26147/artifacts/)
+* [Internal Jenkins Results](http://goto.google.com/prkubekins/job/kubernetes-pull-build-test-e2e-gce//26147)`
 )
 
 func TestIsJenkinsTestComment(t *testing.T) {
@@ -52,6 +56,11 @@ func TestIsJenkinsTestComment(t *testing.T) {
 		{
 			name:      "fail comment",
 			value:     failComment,
+			isJenkins: true,
+		},
+		{
+			name:      "other comment",
+			value:     oldBuildLinkComment,
 			isJenkins: true,
 		},
 		{


### PR DESCRIPTION
The link forms have changed quite a bit over time.

This results in over 1400 removed comments from open PRs