### PR TITLE
Fix nginx ingress controller bug around config map merging

### DIFF
--- a/ingress/controllers/nginx/nginx/template.go
+++ b/ingress/controllers/nginx/nginx/template.go
@@ -48,10 +48,6 @@ func (ngx *Manager) loadTemplate() {
 }
 
 func (ngx *Manager) writeCfg(cfg nginxConfiguration, ingressCfg IngressConfig) (bool, error) {
-	fromMap := structs.Map(cfg)
-	toMap := structs.Map(ngx.defCfg)
-	curNginxCfg := merge(toMap, fromMap)
-
 	conf := make(map[string]interface{})
 	conf["upstreams"] = ingressCfg.Upstreams
 	conf["servers"] = ingressCfg.Servers
@@ -59,7 +55,7 @@ func (ngx *Manager) writeCfg(cfg nginxConfiguration, ingressCfg IngressConfig) (
 	conf["udpUpstreams"] = ingressCfg.UDPUpstreams
 	conf["defResolver"] = ngx.defResolver
 	conf["sslDHParam"] = ngx.sslDHParam
-	conf["cfg"] = fixKeyNames(curNginxCfg)
+	conf["cfg"] = fixKeyNames(structs.Map(cfg))
 
 	buffer := new(bytes.Buffer)
 	err := ngx.template.Execute(buffer, conf)

--- a/ingress/controllers/nginx/nginx/utils_test.go
+++ b/ingress/controllers/nginx/nginx/utils_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nginx
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func getConfigNginxBool(data map[string]string) nginxConfiguration {
+	manager := &Manager{}
+	configMap := &api.ConfigMap{
+		Data: data,
+	}
+	return manager.ReadConfig(configMap)
+}
+
+func TestManagerReadConfigBoolFalse(t *testing.T) {
+	configNginx := getConfigNginxBool(map[string]string{
+		"hts-include-subdomains": "false",
+		"use-proxy-protocol":     "false",
+	})
+	if configNginx.HTSIncludeSubdomains {
+		t.Error("Failed to config boolean value (default true) to false")
+	}
+	if configNginx.UseProxyProtocol {
+		t.Error("Failed to config boolean value (default false) to false")
+	}
+}
+
+func TestManagerReadConfigBoolTrue(t *testing.T) {
+	configNginx := getConfigNginxBool(map[string]string{
+		"hts-include-subdomains": "true",
+		"use-proxy-protocol":     "true",
+	})
+	if !configNginx.HTSIncludeSubdomains {
+		t.Error("Failed to config boolean value (default true) to true")
+	}
+	if !configNginx.UseProxyProtocol {
+		t.Error("Failed to config boolean value (default false) to true")
+	}
+}
+
+func TestManagerReadConfigBoolNothing(t *testing.T) {
+	configNginx := getConfigNginxBool(map[string]string{
+		"invaild-key": "true",
+	})
+	if !configNginx.HTSIncludeSubdomains {
+		t.Error("Failed to get default boolean value true")
+	}
+	if configNginx.UseProxyProtocol {
+		t.Error("Failed to get default boolean value false")
+	}
+}
+
+func TestManagerReadConfigStringSet(t *testing.T) {
+	configNginx := getConfigNginxBool(map[string]string{
+		"ssl-protocols": "TLSv1.2",
+	})
+	exp := "TLSv1.2"
+	if configNginx.SSLProtocols != exp {
+		t.Error("Failed to set string value true actual='%s' expected='%s'", configNginx.SSLProtocols, exp)
+	}
+}
+
+func TestManagerReadConfigStringNothing(t *testing.T) {
+	configNginx := getConfigNginxBool(map[string]string{
+		"not-existing": "TLSv1.2",
+	})
+	exp := "10m"
+	if configNginx.SSLSessionTimeout != exp {
+		t.Error("Failed to set string value true actual='%s' expected='%s'", configNginx.SSLSessionTimeout, exp)
+	}
+}


### PR DESCRIPTION
Hi I just discovered a bug around the nginx config merge (defaults are merged with configmap)

 * a config map bool value of false cannot overwritte a true value from
   defaults
 * implement merging in ReadConfig
 * remove helper function merge
 * adds tests to ensure config is read properly