### PR TITLE
Bump up the perfdash version to 0.6

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 0.5
+TAG = 0.6
 
 PROJ = google_containers
 

--- a/perfdash/pod.yaml
+++ b/perfdash/pod.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "0.5"
+    version: "0.6"
 spec:
   containers:
-  - image: gcr.io/google_containers/perfdash:0.5
+  - image: gcr.io/google_containers/perfdash:0.6
     command:
       - /perfdash
       -   --www=true


### PR DESCRIPTION
Minor change.

As @vishh suggested, we should have a better version control for perfdash image. :)

@gmarek BTW, I updated the running perfdash first. It would run happily now~
