### PR TITLE
Dummy grains variable

### DIFF
--- a/ansible/roles/kubernetes-addons/defaults/main.yml
+++ b/ansible/roles/kubernetes-addons/defaults/main.yml
@@ -3,3 +3,5 @@ kube_addons_dir: "{{ kube_config_dir }}/addons"
 local_temp_addon_dir: /tmp/kubernetes/addons
 
 heapster_memory: (200 + length(groups['nodes']) + 12)|string + "Mi"
+
+grains: ""


### PR DESCRIPTION
Currently task "DNS | Install Template from converted saltfiles" broken, because skydns-rc.yaml.in contains "grains" variable https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/dns/skydns-rc.yaml.in