### PR TITLE
On Atomic hosts address the conditional check ''etcd-legacy' not in..

### DIFF
--- a/ansible/roles/etcd/tasks/firewalld.yml
+++ b/ansible/roles/etcd/tasks/firewalld.yml
@@ -19,7 +19,7 @@
   firewalld: port={{ item }}/tcp permanent=false state=enabled
   # in case this is also a node where firewalld turned off
   ignore_errors: yes
-  when: networking == contiv
+  when: networking == 'contiv'
   with_items:
     - "{{ etcd_client_legacy_port }}"
     - "{{ etcd_peer_legacy_port }}"
@@ -28,7 +28,7 @@
   firewalld: port={{ item }}/tcp permanent=true state=enabled
   # in case this is also a node where firewalld turned off
   ignore_errors: yes
-  when: networking == contiv
+  when: networking == 'contiv'
   with_items:
     - "{{ etcd_client_legacy_port }}"
     - "{{ etcd_peer_legacy_port }}"

--- a/ansible/roles/etcd/tasks/iptables.yml
+++ b/ansible/roles/etcd/tasks/iptables.yml
@@ -18,7 +18,7 @@
 
 - name: Open etcd client legacy port with iptables
   command: /sbin/iptables -I INPUT 1 -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "etcd-legacy"
-  when: "'etcd-legacy' not in iptablesrules.stdout and networking == contiv"
+  when: "'etcd-legacy' not in iptablesrules.stdout and networking == 'contiv'"
   notify:
     - Save iptables rules
   with_items:


### PR DESCRIPTION
The following error occurs when running against Atomic hosts.  

TASK [etcd : Open etcd client legacy port with iptables] ***********************
fatal: [<host>]: FAILED! => {"failed": true, "msg": "The conditional check ''etcd-legacy' not in iptablesrules.stdout and networking == contiv' failed. The error was: error while evaluating conditional ('etcd-legacy' not in iptablesrules.stdout and networking == contiv): 'contiv' is undefined\n\nThe error appears to have been in... 