### PR TITLE
Make shame command print out to stdout/stderr

### DIFF
--- a/mungegithub/reports/shame.go
+++ b/mungegithub/reports/shame.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -151,6 +152,8 @@ func (s *ShameReport) runCmd(r io.Reader) error {
 	args = args[1:]
 	cmd := exec.Command(bin, args...)
 	cmd.Stdin = r
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 


### PR DESCRIPTION
We're running `mailx` in verbose mode, but the stdout/stderr was going nowhere, which was of no use.

This change helped me root-cause #862.

@eparis @krousey @lavalamp 
