### PR TITLE
Flannel version number in defaults

### DIFF
--- a/ansible/roles/flannel/defaults/main.yaml
+++ b/ansible/roles/flannel/defaults/main.yaml
@@ -8,6 +8,9 @@ flannel_source_type: package
 # (in case of using github-releases).
 flannel_releases_dir: /opt
 
+#flannel_version
+flannel_version: 0.5.5
+
 #The default url to download the flannel tar from
 flannel_download_url_base: "https://github.com/coreos/flannel/releases/download/v{{ flannel_version }}"
 flannel_download_url: "{{ flannel_download_url_base }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz"

--- a/ansible/roles/flannel/tasks/github-release.yml
+++ b/ansible/roles/flannel/tasks/github-release.yml
@@ -1,8 +1,4 @@
 ---
-- name: Set Flannel Version fact
-  set_fact:
-    flannel_version: 0.5.5
-
 - stat: path={{ flannel_releases_dir }}/flannel-{{ flannel_version }}
   register: st
 


### PR DESCRIPTION
- we should be handling the flannel version numbers in defaults, not setting the fact in the task
- validated on Vagrant + CoreOS