### PR TITLE
ingress - nginx - non-ascii character used for option - "dump-nginx—configuration"

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -75,7 +75,7 @@ vrrp-password
 watch-namespace
 weak-stable-jobs
 whitelist-override-label
-dump-nginx—configuration
+dump-nginx-configuration
 nginx-configmap
 tcp-services-configmap
 udp-services-configmap

--- a/ingress/controllers/nginx/main.go
+++ b/ingress/controllers/nginx/main.go
@@ -81,7 +81,7 @@ var (
 
 	healthzPort = flags.Int("healthz-port", healthPort, "port for healthz endpoint.")
 
-	buildCfg = flags.Bool("dump-nginx—configuration", false, `Returns a ConfigMap with the default nginx conguration.
+	buildCfg = flags.Bool("dump-nginx-configuration", false, `Returns a ConfigMap with the default nginx conguration.
 		This can be used as a guide to create a custom configuration.`)
 
 	profiling = flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)


### PR DESCRIPTION
fixes #874
non-ascii character used.