### PR TITLE
ansible: make the flannel backend configurable

### DIFF
--- a/ansible/roles/flannel/defaults/main.yaml
+++ b/ansible/roles/flannel/defaults/main.yaml
@@ -11,6 +11,9 @@ flannel_releases_dir: /opt
 #flannel_version
 flannel_version: 0.5.5
 
+#The backend that flannel should use
+flannel_backend: vxlan
+
 #The default url to download the flannel tar from
 flannel_download_url_base: "https://github.com/coreos/flannel/releases/download/v{{ flannel_version }}"
 flannel_download_url: "{{ flannel_download_url_base }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz"

--- a/ansible/roles/flannel/templates/flannel-conf.json.j2
+++ b/ansible/roles/flannel/templates/flannel-conf.json.j2
@@ -1,1 +1,1 @@
-{ "Network": "{{ flannel_subnet }}/{{ flannel_prefix }}", "SubnetLen": {{ flannel_host_prefix }}, "Backend": { "Type": "vxlan" } }
+{ "Network": "{{ flannel_subnet }}/{{ flannel_prefix }}", "SubnetLen": {{ flannel_host_prefix }}, "Backend": { "Type": "{{ flannel_backend }}" } }


### PR DESCRIPTION
Needed to  support other backends like aws-vpc, host-gw

@eparis 
