### PR TITLE
Add a flag to control which domains we send shame emails to

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -1,3 +1,4 @@
+allowed-shame-domains
 api-token
 balance-algorithm
 block-path-config

--- a/mungegithub/Dockerfile-shame-mailer
+++ b/mungegithub/Dockerfile-shame-mailer
@@ -32,6 +32,7 @@
 #          -e SMTP_SERVER=smtp.example.com:1234 \
 #          -e SMTP_USER=smtp_example_user \
 #          -e SMTP_PASS=my_super_secret_smtp_password \
+#          -e ALLOWED_SHAME_DOMAINS=example.com,example.net \
 #          gcr.io/google_containers/shame-mailer:TAG
 
 FROM google/debian:jessie

--- a/mungegithub/shame_entrypoint.sh
+++ b/mungegithub/shame_entrypoint.sh
@@ -17,4 +17,5 @@
 ./mungegithub --token="${GITHUB_API_TOKEN}" --issue-reports=shame\
 	      --shame-from="${SHAME_FROM}" --shame-reply-to="${SHAME_REPLY_TO}"\
 	      --shame-cc="${SHAME_CC}"\
-	      --shame-report-cmd="mailx -v -t -S smtp=${SMTP_SERVER} -S smtp-auth=login -S smtp-auth-user=${SMTP_USER} -S smtp-auth-password=${SMTP_PASS}"
+	      --shame-report-cmd="mailx -v -t -S smtp=${SMTP_SERVER} -S smtp-auth=login -S smtp-auth-user=${SMTP_USER} -S smtp-auth-password=${SMTP_PASS}" \
+              --allowed-shame-domains="${ALLOWED_SHAME_DOMAINS}"


### PR DESCRIPTION
Intent is to make it easy to add permitted domains like redhat.com, as discussed in https://github.com/kubernetes/test-infra/pull/11#discussion_r61953400, all without having to rebuild everything.

cc @kubernetes/sig-testing 
