### PR TITLE
[ansible] Make sure kubelet service is up.

### DIFF
--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -59,7 +59,7 @@
     - restart kubelet
 
 - name: Enable kubelet
-  service: name=kubelet enabled=yes 
+  service: name=kubelet enabled=yes state=started 
   notify:
     - restart kubelet
 


### PR DESCRIPTION
When kubelet service is stopped, run the playbook does not get the
service up.