### PR TITLE
Allow to open cadvisor 4194/tcp port when deploying nodes.

### DIFF
--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -1,2 +1,3 @@
 kubelet_working_dir: /var/lib/kubelet
 localBuildOutput: ../../_output/local/go/bin
+open_cadvisor_port: false

--- a/ansible/roles/node/tasks/firewalld.yml
+++ b/ansible/roles/node/tasks/firewalld.yml
@@ -7,6 +7,16 @@
   firewalld: port=10250/tcp permanent=true state=enabled
   ignore_errors: yes
 
+- name: Open firewalld port for the cadvisor
+  firewalld: port=4194/tcp permanent=false state=enabled
+  ignore_errors: yes
+  when: open_cadvisor_port
+
+- name: Save firewalld port for the cadvisor
+  firewalld: port=4194/tcp permanent=true state=enabled
+  ignore_errors: yes
+  when: open_cadvisor_port
+
 - name: Open redirected service traffic
   command: /bin/firewall-cmd --direct --add-rule ipv4 filter INPUT 1
            -i docker0 -j ACCEPT -m comment --comment "kube-proxy redirects"


### PR DESCRIPTION
If the 4194/tcp port is not opened when deploying nodes, some e2e tests proxing to cadvisor fail with:

```
Error: 'dial tcp 10.8.52.190:4194: getsockopt: no route to host'
Trying to reach: 'http://10.8.52.190:4194/containers/'
```

This patch does not change the current list of ports opened publicly. 
It just provides to CI operator a choice to decide to open the port when running e2e tests for:

** ``[k8s.io] Proxy version v1 [It] should proxy to cadvisor``
** ``[k8s.io] Proxy version v1 [It] should proxy to cadvisor using proxy subresource``

Not sure if keeping the port closed to public by default is intended. Maybe it should be opened by default and the ``open_cadvisor_port`` variable removed.