### PR TITLE
Make verify-all.sh verbose for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - hack/for-go-proj.sh install
 
 script:
-  - hack/verify-all.sh
+  - hack/verify-all.sh -v
   - hack/for-go-proj.sh test
 
 notifications:


### PR DESCRIPTION
Currently, you can't see why the script fails from the output on travis,
so you have to re-run the command locally. Make the script verbose.