### PR TITLE
Retest stale tests after 96 hours, not 48.

### DIFF
--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	staleGreenCIHours = 48
+	staleGreenCIHours = 96
 	greenMsgFormat    = `@` + jenkinsBotName + ` test this
 
 Tests are more than %d hours old. Re-running tests.`


### PR DESCRIPTION
@eparis assuming this works I think it should go in ASAP. We currently can't merge because Jenkins is overloaded and it takes too long for a test to get through the Jenkins queue.