### PR TITLE
Turn off blunderbuss

### DIFF
--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         command:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
-        - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue
+        - --pr-mungers=lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue
         - --dry-run=true
         image: gcr.io/google_containers/submit-queue:2015-10-26-2a7f8fd
         ports:


### PR DESCRIPTION
Currently the github api is lying to us!  some time around 3:05 eastern
github started claiming that all issues were unassigned. See for example
the output about PR 16000 from

https://api.github.com/repos/kubernetes/kubernetes/issues?direction=asc&sort=created&state=open&per_page=100&page=13

```
  {
    "url": "https://api.github.com/repos/kubernetes/kubernetes/issues/16000",
    "repository_url": "https://api.github.com/repos/kubernetes/kubernetes",
    "labels_url": "https://api.github.com/repos/kubernetes/kubernetes/issues/16000/labels{/name}",
    "comments_url": "https://api.github.com/repos/kubernetes/kubernetes/issues/16000/comments",
    "events_url": "https://api.github.com/repos/kubernetes/kubernetes/issues/16000/events",
    "html_url": "https://github.com/kubernetes/kubernetes/pull/16000",
    "id": 112490923,
    "number": 16000,
    "title": "Changed docker storage driver to overlayfs",
    "user": {
      "login": "aanm",
      "id": 5714066,
      "avatar_url": "https://avatars.githubusercontent.com/u/5714066?v=3",
      "gravatar_id": "",
      "url": "https://api.github.com/users/aanm",
      "html_url": "https://github.com/aanm",
      "followers_url": "https://api.github.com/users/aanm/followers",
      "following_url": "https://api.github.com/users/aanm/following{/other_user}",
      "gists_url": "https://api.github.com/users/aanm/gists{/gist_id}",
      "starred_url": "https://api.github.com/users/aanm/starred{/owner}{/repo}",
      "subscriptions_url": "https://api.github.com/users/aanm/subscriptions",
      "organizations_url": "https://api.github.com/users/aanm/orgs",
      "repos_url": "https://api.github.com/users/aanm/repos",
      "events_url": "https://api.github.com/users/aanm/events{/privacy}",
      "received_events_url": "https://api.github.com/users/aanm/received_events",
      "type": "User",
      "site_admin": false
    },
    "labels": [
      {
        "url": "https://api.github.com/repos/kubernetes/kubernetes/labels/cla:%20yes",
        "name": "cla: yes",
        "color": "bfe5bf"
      },
      {
        "url": "https://api.github.com/repos/kubernetes/kubernetes/labels/needs-ok-to-merge",
        "name": "needs-ok-to-merge",
        "color": "ededed"
      },
      {
        "url": "https://api.github.com/repos/kubernetes/kubernetes/labels/release-note-label-needed",
        "name": "release-note-label-needed",
        "color": "db5a64"
      },
      {
        "url": "https://api.github.com/repos/kubernetes/kubernetes/labels/size/XS",
        "name": "size/XS",
        "color": "009900"
      }
    ],
    "state": "open",
    "locked": false,
    "assignee": null,
    "milestone": null,
    "comments": 17,
    "created_at": "2015-10-21T01:01:16Z",
    "updated_at": "2016-05-03T12:58:31Z",
    "closed_at": null,
    "pull_request": {
      "url": "https://api.github.com/repos/kubernetes/kubernetes/pulls/16000",
      "html_url": "https://github.com/kubernetes/kubernetes/pull/16000",
      "diff_url": "https://github.com/kubernetes/kubernetes/pull/16000.diff",
      "patch_url": "https://github.com/kubernetes/kubernetes/pull/16000.patch"
    },
    "body": "Changed docker storage driver to `overlayfs` so the creation and removal of docker containers could be faster.\r\n\r\nDepends on https://github.com/kubernetes/kubernetes/pull/15998\r\n\r\nSigned-off-by: André Martins <aanm90@gmail.com>"
  },
```

This turns off the auto-assigner. It should be reverted when github stops lyin' bro!