### PR TITLE
GCE Ingress Controller - Added flag for healthcheck interval

### DIFF
--- a/ingress/controllers/gce/backends/backends_test.go
+++ b/ingress/controllers/gce/backends/backends_test.go
@@ -31,7 +31,7 @@ func newBackendPool(f BackendServices, fakeIGs instances.InstanceGroups, syncWit
 	namer := utils.Namer{}
 	return NewBackendPool(
 		f,
-		healthchecks.NewHealthChecker(healthchecks.NewFakeHealthChecks(), "/", namer),
+		healthchecks.NewHealthChecker(healthchecks.NewFakeHealthChecks(), 1, "/", namer),
 		instances.NewNodePool(fakeIGs, "default-zone"), namer, []int64{}, syncWithCloud)
 }
 

--- a/ingress/controllers/gce/controller/fakes.go
+++ b/ingress/controllers/gce/controller/fakes.go
@@ -50,7 +50,7 @@ func NewFakeClusterManager(clusterName string) *fakeClusterManager {
 	fakeHCs := healthchecks.NewFakeHealthChecks()
 	namer := utils.Namer{clusterName}
 	nodePool := instances.NewNodePool(fakeIGs, defaultZone)
-	healthChecker := healthchecks.NewHealthChecker(fakeHCs, "/", namer)
+	healthChecker := healthchecks.NewHealthChecker(fakeHCs, 1, "/", namer)
 	backendPool := backends.NewBackendPool(
 		fakeBackends,
 		healthChecker, nodePool, namer, []int64{}, false)

--- a/ingress/controllers/gce/healthchecks/healthchecks.go
+++ b/ingress/controllers/gce/healthchecks/healthchecks.go
@@ -26,16 +26,17 @@ import (
 
 // HealthChecks manages health checks.
 type HealthChecks struct {
-	cloud       SingleHealthCheck
-	defaultPath string
-	namer       utils.Namer
+	cloud           SingleHealthCheck
+	defaultInterval int64
+	defaultPath     string
+	namer           utils.Namer
 }
 
 // NewHealthChecker creates a new health checker.
 // cloud: the cloud object implementing SingleHealthCheck.
 // defaultHealthCheckPath: is the HTTP path to use for health checks.
-func NewHealthChecker(cloud SingleHealthCheck, defaultHealthCheckPath string, namer utils.Namer) HealthChecker {
-	return &HealthChecks{cloud, defaultHealthCheckPath, namer}
+func NewHealthChecker(cloud SingleHealthCheck, defaultHealthCheckInterval int64, defaultHealthCheckPath string, namer utils.Namer) HealthChecker {
+	return &HealthChecks{cloud, defaultHealthCheckInterval, defaultHealthCheckPath, namer}
 }
 
 // Add adds a healthcheck if one for the same port doesn't already exist.
@@ -54,7 +55,7 @@ func (h *HealthChecks) Add(port int64, path string) error {
 				RequestPath: path,
 				Description: "Default kubernetes L7 Loadbalancing health check.",
 				// How often to health check.
-				CheckIntervalSec: 1,
+				CheckIntervalSec: h.defaultInterval,
 				// How long to wait before claiming failure of a health check.
 				TimeoutSec: 1,
 				// Number of healthchecks to pass for a vm to be deemed healthy.

--- a/ingress/controllers/gce/loadbalancers/loadbalancers_test.go
+++ b/ingress/controllers/gce/loadbalancers/loadbalancers_test.go
@@ -37,7 +37,7 @@ func newFakeLoadBalancerPool(f LoadBalancers, t *testing.T) LoadBalancerPool {
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString())
 	fakeHCs := healthchecks.NewFakeHealthChecks()
 	namer := utils.Namer{}
-	healthChecker := healthchecks.NewHealthChecker(fakeHCs, "/", namer)
+	healthChecker := healthchecks.NewHealthChecker(fakeHCs, 1, "/", namer)
 	backendPool := backends.NewBackendPool(
 		fakeBackends, healthChecker, instances.NewNodePool(fakeIGs, defaultZone), namer, []int64{}, false)
 	return NewLoadBalancerPool(f, backendPool, testDefaultBeNodePort, namer)

--- a/ingress/controllers/gce/main.go
+++ b/ingress/controllers/gce/main.go
@@ -100,6 +100,11 @@ var (
 		`Path used to health-check a backend service. All Services must serve
 		a 200 page on this path. Currently this is only configurable globally.`)
 
+	healthCheckInterval = flags.Int64("health-check-interval", 1,
+		`Interval in seconds used to health-check a backend service. This might
+		result in services taking longer to be marked healthy or unhealthy.
+		Currently this is only configurable globally.`)
+
 	watchNamespace = flags.String("watch-namespace", api.NamespaceAll,
 		`Namespace to watch for Ingress/Services/Endpoints.`)
 
@@ -188,7 +193,7 @@ func main() {
 	if *inCluster || *useRealCloud {
 		// Create cluster manager
 		clusterManager, err = controller.NewClusterManager(
-			*clusterName, defaultBackendNodePort, *healthCheckPath)
+			*clusterName, defaultBackendNodePort, *healthCheckInterval, *healthCheckPath)
 		if err != nil {
 			glog.Fatalf("%v", err)
 		}


### PR DESCRIPTION
When using GCE ingress and the default 1 second interval you can end up generating a large number of requests to your services. This is made worse if you have a large cluster as it will be receiving the health check to each node for each service every second, it wouldn't be unrealistic for you to end up with 100rps from just health checks in a large cluster.

I believe there are discussions to have more granular ways to configure healthcheck and other params, but for now this added a flag to allow the interval to be increased.

Much like the `--health-check-path` this is simply `--health-check-internval`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/924)

<!-- Reviewable:end -->
