### PR TITLE
[nginx-ingress-controller] Custom errors should be optional

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -1,13 +1,14 @@
 ingress/controllers/nginx/nginx.tmpl:        require("error_page")
-ingress/controllers/nginx/nginx.tmpl:    error_page 403 = @custom_403;
-ingress/controllers/nginx/nginx.tmpl:    error_page 404 = @custom_404;
-ingress/controllers/nginx/nginx.tmpl:    error_page 405 = @custom_405;
-ingress/controllers/nginx/nginx.tmpl:    error_page 408 = @custom_408;
-ingress/controllers/nginx/nginx.tmpl:    error_page 413 = @custom_413;
-ingress/controllers/nginx/nginx.tmpl:    error_page 501 = @custom_501;
-ingress/controllers/nginx/nginx.tmpl:    error_page 502 = @custom_502;
-ingress/controllers/nginx/nginx.tmpl:    error_page 503 = @custom_503;
-ingress/controllers/nginx/nginx.tmpl:    error_page 504 = @custom_504;
+ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp403 }}error_page 403 = @custom_403;{{ end }}
+ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp404 }}error_page 404 = @custom_404;{{ end }}
+ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp405 }}error_page 405 = @custom_405;{{ end }}
+ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp408 }}error_page 408 = @custom_408;{{ end }}
+ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp413 }}error_page 413 = @custom_413;{{ end }}
+ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp501 }}error_page 501 = @custom_501;{{ end }}
+ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp502 }}error_page 502 = @custom_502;{{ end }}
+ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp503 }}error_page 503 = @custom_503;{{ end }}
+ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp504 }}error_page 504 = @custom_504;{{ end }}
+ingress/controllers/nginx/nginx/main.go:	// processing with the error_page directive
 mungegithub/mungers/submit-queue.go:		sq.e2e = &fake_e2e.FakeE2ETester{
 mungegithub/mungers/submit-queue.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"
 mungegithub/mungers/submit-queue_test.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"

--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -1,14 +1,6 @@
 ingress/controllers/nginx/nginx.tmpl:        require("error_page")
-ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp403 }}error_page 403 = @custom_403;{{ end }}
-ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp404 }}error_page 404 = @custom_404;{{ end }}
-ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp405 }}error_page 405 = @custom_405;{{ end }}
-ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp408 }}error_page 408 = @custom_408;{{ end }}
-ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp413 }}error_page 413 = @custom_413;{{ end }}
-ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp501 }}error_page 501 = @custom_501;{{ end }}
-ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp502 }}error_page 502 = @custom_502;{{ end }}
-ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp503 }}error_page 503 = @custom_503;{{ end }}
-ingress/controllers/nginx/nginx.tmpl:    {{ if $cfg.interceptHttp504 }}error_page 504 = @custom_504;{{ end }}
-ingress/controllers/nginx/nginx/main.go:	// processing with the error_page directive
+ingress/controllers/nginx/nginx.tmpl:    error_page {{ $errCode }} = @custom_{{ $errCode }};
+ingress/controllers/nginx/nginx/main.go:	// enables which HTTP codes should be passed for processing with the error_page directive
 mungegithub/mungers/submit-queue.go:		sq.e2e = &fake_e2e.FakeE2ETester{
 mungegithub/mungers/submit-queue.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"
 mungegithub/mungers/submit-queue_test.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"

--- a/ingress/controllers/nginx/nginx.tmpl
+++ b/ingress/controllers/nginx/nginx.tmpl
@@ -123,23 +123,14 @@ http {
     ssl_dhparam {{ .sslDHParam }};
     {{ end }}
 
-    {{  $interceptHttpErrors := $cfg.interceptHttp403 || $cfg.interceptHttp404 || $cfg.interceptHttp405 ||
-                                $cfg.interceptHttp408 || $cfg.interceptHttp413 || $cfg.interceptHttp501 ||
-                                $cfg.interceptHttp502 || $cfg.interceptHttp503 || $cfg.interceptHttp504 }}
-    {{ if $interceptHttpErrors }}
+    {{- if .customErrors }}
     # Custom error pages
     proxy_intercept_errors on;
-    {{ end }}
+    {{ end -}}
 
-    {{ if $cfg.interceptHttp403 }}error_page 403 = @custom_403;{{ end }}
-    {{ if $cfg.interceptHttp404 }}error_page 404 = @custom_404;{{ end }}
-    {{ if $cfg.interceptHttp405 }}error_page 405 = @custom_405;{{ end }}
-    {{ if $cfg.interceptHttp408 }}error_page 408 = @custom_408;{{ end }}
-    {{ if $cfg.interceptHttp413 }}error_page 413 = @custom_413;{{ end }}
-    {{ if $cfg.interceptHttp501 }}error_page 501 = @custom_501;{{ end }}
-    {{ if $cfg.interceptHttp502 }}error_page 502 = @custom_502;{{ end }}
-    {{ if $cfg.interceptHttp503 }}error_page 503 = @custom_503;{{ end }}
-    {{ if $cfg.interceptHttp504 }}error_page 504 = @custom_504;{{ end }}
+    {{- range $errCode := $cfg.customHttpErrors }}
+    error_page {{ $errCode }} = @custom_{{ $errCode }};
+    {{ end }}
 
     # In case of errors try the next upstream server before returning an error
     proxy_next_upstream                     error timeout invalid_header http_502 http_503 http_504 {{ if $cfg.retryNonIdempotent }}non_idempotent{{ end }};
@@ -158,14 +149,13 @@ http {
 
     {{ range $server := .servers }}
     server {
+        server_name {{ $server.Name }};
         listen 80{{ if $cfg.useProxyProtocol }} proxy_protocol{{ end }};
         {{ if $server.SSL }}listen 443 {{ if $cfg.useProxyProtocol }}proxy_protocol{{ end }} ssl {{ if $cfg.useHttp2 }}http2{{ end }};
         {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
         # PEM sha: {{ $server.SSLPemChecksum }}        
         ssl_certificate {{ $server.SSLCertificate }};
         ssl_certificate_key {{ $server.SSLCertificateKey }};{{ end }}
-
-        server_name {{ $server.Name }};
 
         {{ if (and $server.SSL $cfg.hsts) }}
         if ($scheme = http) {
@@ -241,7 +231,7 @@ http {
         location / {
             proxy_pass             http://upstream-default-backend;
         }
-        {{ template "CUSTOM_ERRORS" $cfg }}
+        {{- template "CUSTOM_ERRORS" $cfg }}
     }
 
     # default server for services without endpoints
@@ -249,9 +239,13 @@ http {
         listen 8181;
 
         location / {
+            {{ if .customErrors }}
             content_by_lua_block {
                 openURL(503)
             }
+            {{ else }}
+            return 503;
+            {{ end }}
         }        
     }    
 }
@@ -290,67 +284,12 @@ stream {
 
 {{/* definition of templates to avoid repetitions */}}
 {{ define "CUSTOM_ERRORS" }}
-        {{ if $cfg.interceptHttp403 }}
-        location @custom_403 {
+        {{ range $errCode := .customHttpErrors }}
+        location @custom_{{ $errCode }} {
             internal;
             content_by_lua_block {
-                openURL(403)
+                openURL({{ $errCode }})
             }
-        }{{ end }}
-        {{ if $cfg.interceptHttp404 }}
-        location @custom_404 {
-            internal;
-            content_by_lua_block {
-                openURL(404)
-            }
-        }{{ end }}
-        {{ if $cfg.interceptHttp405 }}
-        location @custom_405 {
-            internal;
-            content_by_lua_block {
-                openURL(405)
-            }
-        }{{ end }}
-        {{ if $cfg.interceptHttp408 }}
-        location @custom_408 {
-            internal;
-            content_by_lua_block {
-                openURL(408)
-            }
-        }{{ end }}
-        {{ if $cfg.interceptHttp413 }}
-        location @custom_413 {
-            internal;
-            content_by_lua_block {
-                openURL(413)
-            }
-        }{{ end }}
-        {{ if $cfg.interceptHttp501 }}
-        location @custom_501 {
-            internal;
-            content_by_lua_block {
-                openURL(501)
-            }
-        }{{ end }}
-        {{ if $cfg.interceptHttp502 }}
-        location @custom_502 {
-            internal;
-            content_by_lua_block {
-                openURL(502)
-            }
-        }{{ end }}
-        {{ if $cfg.interceptHttp503 }}
-        location @custom_503 {
-            internal;
-            content_by_lua_block {
-                openURL(503)
-            }
-        }{{ end }}
-        {{ if $cfg.interceptHttp504 }}
-        location @custom_504 {
-            internal;
-            content_by_lua_block {
-                openURL(504)
-            }
-        }{{ end }}
+        }    
+        {{ end }}
 {{ end }}

--- a/ingress/controllers/nginx/nginx.tmpl
+++ b/ingress/controllers/nginx/nginx.tmpl
@@ -123,18 +123,23 @@ http {
     ssl_dhparam {{ .sslDHParam }};
     {{ end }}
 
+    {{  $interceptHttpErrors := $cfg.interceptHttp403 || $cfg.interceptHttp404 || $cfg.interceptHttp405 ||
+                                $cfg.interceptHttp408 || $cfg.interceptHttp413 || $cfg.interceptHttp501 ||
+                                $cfg.interceptHttp502 || $cfg.interceptHttp503 || $cfg.interceptHttp504 }}
+    {{ if $interceptHttpErrors }}
     # Custom error pages
     proxy_intercept_errors on;
+    {{ end }}
 
-    error_page 403 = @custom_403;
-    error_page 404 = @custom_404;
-    error_page 405 = @custom_405;
-    error_page 408 = @custom_408;
-    error_page 413 = @custom_413;
-    error_page 501 = @custom_501;
-    error_page 502 = @custom_502;
-    error_page 503 = @custom_503;
-    error_page 504 = @custom_504;
+    {{ if $cfg.interceptHttp403 }}error_page 403 = @custom_403;{{ end }}
+    {{ if $cfg.interceptHttp404 }}error_page 404 = @custom_404;{{ end }}
+    {{ if $cfg.interceptHttp405 }}error_page 405 = @custom_405;{{ end }}
+    {{ if $cfg.interceptHttp408 }}error_page 408 = @custom_408;{{ end }}
+    {{ if $cfg.interceptHttp413 }}error_page 413 = @custom_413;{{ end }}
+    {{ if $cfg.interceptHttp501 }}error_page 501 = @custom_501;{{ end }}
+    {{ if $cfg.interceptHttp502 }}error_page 502 = @custom_502;{{ end }}
+    {{ if $cfg.interceptHttp503 }}error_page 503 = @custom_503;{{ end }}
+    {{ if $cfg.interceptHttp504 }}error_page 504 = @custom_504;{{ end }}
 
     # In case of errors try the next upstream server before returning an error
     proxy_next_upstream                     error timeout invalid_header http_502 http_503 http_504 {{ if $cfg.retryNonIdempotent }}non_idempotent{{ end }};
@@ -285,59 +290,67 @@ stream {
 
 {{/* definition of templates to avoid repetitions */}}
 {{ define "CUSTOM_ERRORS" }}
+        {{ if $cfg.interceptHttp403 }}
         location @custom_403 {
             internal;
             content_by_lua_block {
                 openURL(403)
             }
-        }
-
+        }{{ end }}
+        {{ if $cfg.interceptHttp404 }}
         location @custom_404 {
             internal;
             content_by_lua_block {
                 openURL(404)
             }
-        }
-
+        }{{ end }}
+        {{ if $cfg.interceptHttp405 }}
         location @custom_405 {
             internal;
             content_by_lua_block {
                 openURL(405)
             }
-        }
-
+        }{{ end }}
+        {{ if $cfg.interceptHttp408 }}
         location @custom_408 {
             internal;
             content_by_lua_block {
                 openURL(408)
             }
-        }
-
+        }{{ end }}
+        {{ if $cfg.interceptHttp413 }}
         location @custom_413 {
             internal;
             content_by_lua_block {
                 openURL(413)
             }
-        }
-
+        }{{ end }}
+        {{ if $cfg.interceptHttp501 }}
+        location @custom_501 {
+            internal;
+            content_by_lua_block {
+                openURL(501)
+            }
+        }{{ end }}
+        {{ if $cfg.interceptHttp502 }}
         location @custom_502 {
             internal;
             content_by_lua_block {
                 openURL(502)
             }
-        }
-
+        }{{ end }}
+        {{ if $cfg.interceptHttp503 }}
         location @custom_503 {
             internal;
             content_by_lua_block {
                 openURL(503)
             }
-        }
-
+        }{{ end }}
+        {{ if $cfg.interceptHttp504 }}
         location @custom_504 {
             internal;
             content_by_lua_block {
                 openURL(504)
             }
-        }
+        }{{ end }}
 {{ end }}

--- a/ingress/controllers/nginx/nginx/main.go
+++ b/ingress/controllers/nginx/nginx/main.go
@@ -124,19 +124,11 @@ type nginxConfiguration struct {
 	// accessed using HTTPS.
 	HSTSMaxAge string `structs:"hsts-max-age,omitempty"`
 
-	// enables or disable if HTTP codes should be passed to a client or be redirected to nginx for
-	// processing with the error_page directive
+	// enables which HTTP codes should be passed for processing with the error_page directive
 	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
 	// By default this is disabled
-	InterceptHTTP403 bool `structs:"intercept-error-403,omitempty"`
-	InterceptHTTP404 bool `structs:"intercept-error-404,omitempty"`
-	InterceptHTTP405 bool `structs:"intercept-error-405,omitempty"`
-	InterceptHTTP408 bool `structs:"intercept-error-408,omitempty"`
-	InterceptHTTP413 bool `structs:"intercept-error-413,omitempty"`
-	InterceptHTTP501 bool `structs:"intercept-error-502,omitempty"`
-	InterceptHTTP502 bool `structs:"intercept-error-502,omitempty"`
-	InterceptHTTP503 bool `structs:"intercept-error-503,omitempty"`
-	InterceptHTTP504 bool `structs:"intercept-error-504,omitempty"`
+	CustomHTTPErrors []int
 
 	// Time during which a keep-alive client connection will stay open on the server side.
 	// The zero value disables keep-alive client connections
@@ -290,6 +282,7 @@ func newDefaultNginxCfg() nginxConfiguration {
 		WorkerProcesses:          strconv.Itoa(runtime.NumCPU()),
 		VtsStatusZoneSize:        "10m",
 		UseHTTP2:                 true,
+		CustomHTTPErrors:         []int{},
 	}
 
 	if glog.V(5) {

--- a/ingress/controllers/nginx/nginx/main.go
+++ b/ingress/controllers/nginx/nginx/main.go
@@ -124,6 +124,20 @@ type nginxConfiguration struct {
 	// accessed using HTTPS.
 	HSTSMaxAge string `structs:"hsts-max-age,omitempty"`
 
+	// enables or disable if HTTP codes should be passed to a client or be redirected to nginx for
+	// processing with the error_page directive
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors
+	// By default this is disabled
+	InterceptHTTP403 bool `structs:"intercept-error-403,omitempty"`
+	InterceptHTTP404 bool `structs:"intercept-error-404,omitempty"`
+	InterceptHTTP405 bool `structs:"intercept-error-405,omitempty"`
+	InterceptHTTP408 bool `structs:"intercept-error-408,omitempty"`
+	InterceptHTTP413 bool `structs:"intercept-error-413,omitempty"`
+	InterceptHTTP501 bool `structs:"intercept-error-502,omitempty"`
+	InterceptHTTP502 bool `structs:"intercept-error-502,omitempty"`
+	InterceptHTTP503 bool `structs:"intercept-error-503,omitempty"`
+	InterceptHTTP504 bool `structs:"intercept-error-504,omitempty"`
+
 	// Time during which a keep-alive client connection will stay open on the server side.
 	// The zero value disables keep-alive client connections
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout

--- a/ingress/controllers/nginx/nginx/template.go
+++ b/ingress/controllers/nginx/nginx/template.go
@@ -56,14 +56,8 @@ func (ngx *Manager) writeCfg(cfg nginxConfiguration, ingressCfg IngressConfig) (
 	conf["udpUpstreams"] = ingressCfg.UDPUpstreams
 	conf["defResolver"] = ngx.defResolver
 	conf["sslDHParam"] = ngx.sslDHParam
+	conf["customErrors"] = len(cfg.CustomHTTPErrors) > 0
 	conf["cfg"] = fixKeyNames(structs.Map(cfg))
-
-	buffer := new(bytes.Buffer)
-	err := ngx.template.Execute(buffer, conf)
-	if err != nil {
-		glog.Infof("NGINX error: %v", err)
-		return false, err
-	}
 
 	if glog.V(3) {
 		b, err := json.Marshal(conf)
@@ -71,6 +65,13 @@ func (ngx *Manager) writeCfg(cfg nginxConfiguration, ingressCfg IngressConfig) (
 			fmt.Println("error:", err)
 		}
 		glog.Infof("NGINX configuration: %v", string(b))
+	}
+
+	buffer := new(bytes.Buffer)
+	err := ngx.template.Execute(buffer, conf)
+	if err != nil {
+		glog.Infof("NGINX error: %v", err)
+		return false, err
 	}
 
 	changed, err := ngx.needsReload(buffer)


### PR DESCRIPTION
Without this change the errors in the upstream server are redirected to the default backend.

fixes #897
