### PR TITLE
[ansible] includes kubernetes addons from release tag 'v1.2.4'

### DIFF
--- a/ansible/roles/kubernetes-addons/defaults/main.yml
+++ b/ansible/roles/kubernetes-addons/defaults/main.yml
@@ -2,8 +2,12 @@ kube_addons_dir: "{{ kube_config_dir }}/addons"
 
 local_temp_addon_dir: /tmp/kubernetes/addons
 
-heapster_memory: (200 + length(groups['nodes']) + 12)|string + "Mi"
+metrics_memory_initial: 200
+metrics_memory_per_node: 4
+metrics_memory: "{{ metrics_memory_initial + (metrics_memory_per_node * (groups['nodes'] | count)) }}Mi"
+
+eventer_memory_initial: 200
+eventer_memory_per_node: 500
+eventer_memory: "{{ eventer_memory_initial + (eventer_memory_per_node * (groups['nodes'] | count) / 1024) | round | int }}Mi"
 
 grains: ""
-
-kube_addons_download_source_dir: cluster/addons/addon-manager

--- a/ansible/roles/kubernetes-addons/files/common/kube-addon-update.sh
+++ b/ansible/roles/kubernetes-addons/files/common/kube-addon-update.sh
@@ -1,0 +1,514 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The business logic for whether a given object should be created
+# was already enforced by salt, and /etc/kubernetes/addons is the
+# managed result is of that. Start everything below that directory.
+
+# Parameters
+# $1 path to add-ons
+
+
+# LIMITATIONS
+# 1. controllers are not updated unless their name is changed
+# 3. Services will not be updated unless their name is changed,
+#    but for services we actually want updates without name change.
+# 4. Json files are not handled at all. Currently addons must be
+#    in yaml files
+# 5. exit code is probably not always correct (I haven't checked
+#    carefully if it works in 100% cases)
+# 6. There are no unittests
+# 8. Will not work if the total length of paths to addons is greater than
+#    bash can handle. Probably it is not a problem: ARG_MAX=2097152 on GCE.
+# 9. Performance issue: yaml files are read many times in a single execution.
+
+# cosmetic improvements to be done
+# 1. improve the log function; add timestamp, file name, etc.
+# 2. logging doesn't work from files that print things out.
+# 3. kubectl prints the output to stderr (the output should be captured and then
+#    logged)
+
+
+
+# global config
+KUBECTL=${TEST_KUBECTL:-}   # substitute for tests
+KUBECTL=${KUBECTL:-${KUBECTL_BIN:-}}
+KUBECTL=${KUBECTL:-/usr/local/bin/kubectl}
+if [[ ! -x ${KUBECTL} ]]; then
+    echo "ERROR: kubectl command (${KUBECTL}) not found or is not executable" 1>&2
+    exit 1
+fi
+
+# If an add-on definition is incorrect, or a definition has just disappeared
+# from the local directory, the script will still keep on retrying.
+# The script does not end until all retries are done, so
+# one invalid manifest may block updates of other add-ons.
+# Be careful how you set these parameters
+NUM_TRIES=1    # will be updated based on input parameters
+DELAY_AFTER_ERROR_SEC=${TEST_DELAY_AFTER_ERROR_SEC:=10}
+
+
+# remember that you can't log from functions that print some output (because
+# logs are also printed on stdout)
+# $1 level
+# $2 message
+function log() {
+  # manage log levels manually here
+
+  # add the timestamp if you find it useful
+  case $1 in
+    DB3 )
+#        echo "$1: $2"
+        ;;
+    DB2 )
+#        echo "$1: $2"
+        ;;
+    DBG )
+#        echo "$1: $2"
+        ;;
+    INFO )
+        echo "$1: $2"
+        ;;
+    WRN )
+        echo "$1: $2"
+        ;;
+    ERR )
+        echo "$1: $2"
+        ;;
+    * )
+        echo "INVALID_LOG_LEVEL $1: $2"
+        ;;
+  esac
+}
+
+#$1 yaml file path
+function get-object-kind-from-file() {
+    # prints to stdout, so log cannot be used
+    #WARNING: only yaml is supported
+    cat $1 | ${PYTHON} -c '''
+try:
+        import pipes,sys,yaml
+        y = yaml.load(sys.stdin)
+        labels = y["metadata"]["labels"]
+        if ("kubernetes.io/cluster-service", "true") not in labels.iteritems():
+            # all add-ons must have the label "kubernetes.io/cluster-service".
+            # Otherwise we are ignoring them (the update will not work anyway)
+            print "ERROR"
+        else:
+            print y["kind"]
+except Exception, ex:
+        print "ERROR"
+    '''
+}
+
+# $1 yaml file path
+# returns a string of the form <namespace>/<name> (we call it nsnames)
+function get-object-nsname-from-file() {
+    # prints to stdout, so log cannot be used
+    #WARNING: only yaml is supported
+    #addons that do not specify a namespace are assumed to be in "default".
+    cat $1 | ${PYTHON} -c '''
+try:
+        import pipes,sys,yaml
+        y = yaml.load(sys.stdin)
+        labels = y["metadata"]["labels"]
+        if ("kubernetes.io/cluster-service", "true") not in labels.iteritems():
+            # all add-ons must have the label "kubernetes.io/cluster-service".
+            # Otherwise we are ignoring them (the update will not work anyway)
+            print "ERROR"
+        else:
+            try:
+                print "%s/%s" % (y["metadata"]["namespace"], y["metadata"]["name"])
+            except Exception, ex:
+                print "default/%s" % y["metadata"]["name"]
+except Exception, ex:
+        print "ERROR"
+    '''
+}
+
+# $1 addon directory path
+# $2 addon type (e.g. ReplicationController)
+# echoes the string with paths to files containing addon for the given type
+# works only for yaml files (!) (ignores json files)
+function get-addon-paths-from-disk() {
+    # prints to stdout, so log cannot be used
+    local -r addon_dir=$1
+    local -r obj_type=$2
+    local kind
+    local file_path
+    for file_path in $(find ${addon_dir} -name \*.yaml); do
+        kind=$(get-object-kind-from-file ${file_path})
+        # WARNING: assumption that the topmost indentation is zero (I'm not sure yaml allows for topmost indentation)
+        if [[ "${kind}" == "${obj_type}" ]]; then
+            echo ${file_path}
+        fi
+    done
+}
+
+# waits for all subprocesses
+# returns 0 if all of them were successful and 1 otherwise
+function wait-for-jobs() {
+    local rv=0
+    local pid
+    for pid in $(jobs -p); do
+        wait ${pid}
+        if [[ $? -ne 0 ]]; then
+            rv=1;
+            log ERR "error in pid ${pid}"
+        fi
+        log DB2 "pid ${pid} completed, current error code: ${rv}"
+    done
+    return ${rv}
+}
+
+
+function run-until-success() {
+    local -r command=$1
+    local tries=$2
+    local -r delay=$3
+    local -r command_name=$1
+    while [ ${tries} -gt 0 ]; do
+        log DBG "executing: '$command'"
+        # let's give the command as an argument to bash -c, so that we can use
+        # && and || inside the command itself
+        /bin/bash -c "${command}" && \
+            log DB3 "== Successfully executed ${command_name} at $(date -Is) ==" && \
+            return 0
+        let tries=tries-1
+        log INFO "== Failed to execute ${command_name} at $(date -Is). ${tries} tries remaining. =="
+        sleep ${delay}
+    done
+    return 1
+}
+
+# $1 object type
+# returns a list of <namespace>/<name> pairs (nsnames)
+function get-addon-nsnames-from-server() {
+    local -r obj_type=$1
+    "${KUBECTL}" get "${obj_type}" --all-namespaces -o go-template="{{range.items}}{{.metadata.namespace}}/{{.metadata.name}} {{end}}" --api-version=v1 -l kubernetes.io/cluster-service=true
+}
+
+# returns the characters after the last separator (including)
+# If the separator is empty or if it doesn't appear in the string,
+# an empty string is printed
+# $1 input string
+# $2 separator (must be single character, or empty)
+function get-suffix() {
+    # prints to stdout, so log cannot be used
+    local -r input_string=$1
+    local -r separator=$2
+    local suffix
+
+    if [[ "${separator}" == "" ]]; then
+        echo ""
+        return
+    fi
+
+    if  [[ "${input_string}" == *"${separator}"* ]]; then
+        suffix=$(echo "${input_string}" | rev | cut -d "${separator}" -f1 | rev)
+        echo "${separator}${suffix}"
+    else
+        echo ""
+    fi
+}
+
+# returns the characters up to the last '-' (without it)
+# $1 input string
+# $2 separator
+function get-basename() {
+    # prints to stdout, so log cannot be used
+    local -r input_string=$1
+    local -r separator=$2
+    local suffix
+    suffix="$(get-suffix ${input_string} ${separator})"
+    # this will strip the suffix (if matches)
+    echo ${input_string%$suffix}
+}
+
+function stop-object() {
+    local -r obj_type=$1
+    local -r namespace=$2
+    local -r obj_name=$3
+    log INFO "Stopping ${obj_type} ${namespace}/${obj_name}"
+
+    run-until-success "${KUBECTL} stop --namespace=${namespace} ${obj_type} ${obj_name}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+}
+
+function create-object() {
+    local -r obj_type=$1
+    local -r file_path=$2
+
+    local nsname_from_file
+    nsname_from_file=$(get-object-nsname-from-file ${file_path})
+    if [[ "${nsname_from_file}" == "ERROR" ]]; then
+       log INFO "Cannot read object name from ${file_path}. Ignoring"
+       return 1
+    fi
+    IFS='/' read namespace obj_name <<< "${nsname_from_file}"
+
+    log INFO "Creating new ${obj_type} from file ${file_path} in namespace ${namespace}, name: ${obj_name}"
+    # this will keep on failing if the ${file_path} disappeared in the meantime.
+    # Do not use too many retries.
+    run-until-success "${KUBECTL} create --namespace=${namespace} -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+}
+
+function update-object() {
+    local -r obj_type=$1
+    local -r namespace=$2
+    local -r obj_name=$3
+    local -r file_path=$4
+    log INFO "updating the ${obj_type} ${namespace}/${obj_name} with the new definition ${file_path}"
+    stop-object ${obj_type} ${namespace} ${obj_name}
+    create-object ${obj_type} ${file_path}
+}
+
+# deletes the objects from the server
+# $1 object type
+# $2 a list of object nsnames
+function stop-objects() {
+    local -r obj_type=$1
+    local -r obj_nsnames=$2
+    local namespace
+    local obj_name
+    for nsname in ${obj_nsnames}; do
+        IFS='/' read namespace obj_name <<< "${nsname}"
+        stop-object ${obj_type} ${namespace} ${obj_name} &
+    done
+}
+
+# creates objects from the given files
+# $1 object type
+# $2 a list of paths to definition files
+function create-objects() {
+    local -r obj_type=$1
+    local -r file_paths=$2
+    local file_path
+    for file_path in ${file_paths}; do
+        # Remember that the file may have disappear by now
+        # But we don't want to check it here because
+        # such race condition may always happen after
+        # we check it. Let's have the race
+        # condition happen a bit more often so that
+        # we see that our tests pass anyway.
+        create-object ${obj_type} ${file_path} &
+    done
+}
+
+# updates objects
+# $1 object type
+# $2 a list of update specifications
+# each update specification is a ';' separated pair: <nsname>;<file path>
+function update-objects() {
+    local -r obj_type=$1      # ignored
+    local -r update_spec=$2
+    local objdesc
+    local nsname
+    local obj_name
+    local namespace
+
+    for objdesc in ${update_spec}; do
+        IFS=';' read nsname file_path <<< "${objdesc}"
+        IFS='/' read namespace obj_name <<< "${nsname}"
+
+        update-object ${obj_type} ${namespace} ${obj_name} ${file_path} &
+    done
+}
+
+# Global variables set by function match-objects.
+nsnames_for_delete=""   # a list of object nsnames to be deleted
+for_update=""           # a list of pairs <nsname>;<filePath> for objects that should be updated
+nsnames_for_ignore=""   # a list of object nsnames that will be ignored
+new_files=""            # a list of file paths that weren't matched by any existing objects (these objects must be created now)
+
+
+# $1 path to files with objects
+# $2 object type in the API (ReplicationController or Service)
+# $3 name separator (single character or empty)
+function match-objects() {
+    local -r addon_dir=$1
+    local -r obj_type=$2
+    local -r separator=$3
+
+    # output variables (globals)
+    nsnames_for_delete=""
+    for_update=""
+    nsnames_for_ignore=""
+    new_files=""
+
+    addon_nsnames_on_server=$(get-addon-nsnames-from-server "${obj_type}")
+    # if the api server is unavailable then abandon the update for this cycle 
+    if [[ $? -ne 0 ]]; then
+        log ERR "unable to query ${obj_type} - exiting"
+        exit 1
+    fi
+
+    addon_paths_in_files=$(get-addon-paths-from-disk "${addon_dir}" "${obj_type}")
+
+    log DB2 "addon_nsnames_on_server=${addon_nsnames_on_server}"
+    log DB2 "addon_paths_in_files=${addon_paths_in_files}"
+
+    local matched_files=""
+
+    local basensname_on_server=""
+    local nsname_on_server=""
+    local suffix_on_server=""
+    local nsname_from_file=""
+    local suffix_from_file=""
+    local found=0
+    local addon_path=""
+
+    # objects that were moved between namespaces will have different nsname
+    # because the namespace is included. So they will be treated
+    # like different objects and not updated but deleted and created again
+    # (in the current version update is also delete+create, so it does not matter)
+    for nsname_on_server in ${addon_nsnames_on_server}; do
+        basensname_on_server=$(get-basename ${nsname_on_server} ${separator})
+        suffix_on_server="$(get-suffix ${nsname_on_server} ${separator})"
+
+        log DB3 "Found existing addon ${nsname_on_server}, basename=${basensname_on_server}"
+
+        # check if the addon is present in the directory and decide
+        # what to do with it
+        # this is not optimal because we're reading the files over and over
+        # again. But for small number of addons it doesn't matter so much.
+        found=0
+        for addon_path in ${addon_paths_in_files}; do
+            nsname_from_file=$(get-object-nsname-from-file ${addon_path})
+            if [[ "${nsname_from_file}" == "ERROR" ]]; then
+                log INFO "Cannot read object name from ${addon_path}. Ignoring"
+                continue
+            else
+                log DB2 "Found object name '${nsname_from_file}' in file ${addon_path}"
+            fi
+            suffix_from_file="$(get-suffix ${nsname_from_file} ${separator})"
+
+            log DB3 "matching: ${basensname_on_server}${suffix_from_file} == ${nsname_from_file}"
+            if [[ "${basensname_on_server}${suffix_from_file}" == "${nsname_from_file}" ]]; then
+                log DB3 "matched existing ${obj_type} ${nsname_on_server} to file ${addon_path}; suffix_on_server=${suffix_on_server}, suffix_from_file=${suffix_from_file}"
+                found=1
+                matched_files="${matched_files} ${addon_path}"
+                if [[ "${suffix_on_server}" == "${suffix_from_file}" ]]; then
+                    nsnames_for_ignore="${nsnames_for_ignore} ${nsname_from_file}"
+                else
+                    for_update="${for_update} ${nsname_on_server};${addon_path}"
+                fi
+                break
+            fi
+        done
+        if [[ ${found} -eq 0 ]]; then
+            log DB2 "No definition file found for replication controller ${nsname_on_server}. Scheduling for deletion"
+            nsnames_for_delete="${nsnames_for_delete} ${nsname_on_server}"
+        fi
+    done
+
+    log DB3 "matched_files=${matched_files}"
+
+
+    # note that if the addon file is invalid (or got removed after listing files
+    # but before we managed to match it) it will not be matched to any
+    # of the existing objects. So we will treat it as a new file
+    # and try to create its object.
+    for addon_path in ${addon_paths_in_files}; do
+        echo ${matched_files} | grep "${addon_path}" >/dev/null
+        if [[ $? -ne 0 ]]; then
+            new_files="${new_files} ${addon_path}"
+        fi
+    done
+}
+
+
+
+function reconcile-objects() {
+    local -r addon_path=$1
+    local -r obj_type=$2
+    local -r separator=$3    # name separator
+    match-objects ${addon_path} ${obj_type} ${separator}
+
+    log DBG "${obj_type}: nsnames_for_delete=${nsnames_for_delete}"
+    log DBG "${obj_type}: for_update=${for_update}"
+    log DBG "${obj_type}: nsnames_for_ignore=${nsnames_for_ignore}"
+    log DBG "${obj_type}: new_files=${new_files}"
+
+    stop-objects "${obj_type}" "${nsnames_for_delete}"
+    # wait for jobs below is a protection against changing the basename
+    # of a replication controllerm without changing the selector.
+    # If we don't wait, the new rc may be created before the old one is deleted
+    # In such case the old one will wait for all its pods to be gone, but the pods
+    # are created by the new replication controller.
+    # passing --cascade=false could solve the problem, but we want
+    # all orphan pods to be deleted.
+    wait-for-jobs
+    stopResult=$?
+
+    create-objects "${obj_type}" "${new_files}"
+    update-objects "${obj_type}" "${for_update}"
+
+    local nsname
+    for nsname in ${nsnames_for_ignore}; do
+        log DB2 "The ${obj_type} ${nsname} is already up to date"
+    done
+
+    wait-for-jobs
+    createUpdateResult=$?
+
+    if [[ ${stopResult} -eq 0 ]] && [[ ${createUpdateResult} -eq 0 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function update-addons() {
+    local -r addon_path=$1
+    # be careful, reconcile-objects uses global variables
+    reconcile-objects ${addon_path} ReplicationController "-" &
+    reconcile-objects ${addon_path} Deployment "-" &
+
+    # We don't expect names to be versioned for the following kinds, so
+    # we match the entire name, ignoring version suffix.
+    # That's why we pass an empty string as the version separator.
+    # If the description differs on disk, the object should be recreated.
+    # This is not implemented in this version.
+    reconcile-objects ${addon_path} Service "" &
+    reconcile-objects ${addon_path} PersistentVolume "" &
+    reconcile-objects ${addon_path} PersistentVolumeClaim "" &
+
+    wait-for-jobs
+    if [[ $? -eq 0 ]]; then
+        log INFO "== Kubernetes addon update completed successfully at $(date -Is) =="
+    else
+        log WRN "== Kubernetes addon update completed with errors at $(date -Is) =="
+    fi
+}
+
+# input parameters:
+# $1 input directory
+# $2 retry period in seconds - the script will retry api-server errors for approximately
+#     this amound of time (it is not very precise), at interval equal $DELAY_AFTER_ERROR_SEC.
+#
+
+if [[ $# -ne 2 ]]; then
+    echo "Illegal number of parameters. Usage $0 addon-dir [retry-period]" 1>&2
+    exit 1
+fi
+
+NUM_TRIES=$(($2 / ${DELAY_AFTER_ERROR_SEC}))
+if [[ ${NUM_TRIES} -le 0 ]]; then
+    NUM_TRIES=1
+fi
+
+addon_path=$1
+update-addons ${addon_path}

--- a/ansible/roles/kubernetes-addons/files/common/kube-addons.sh
+++ b/ansible/roles/kubernetes-addons/files/common/kube-addons.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The business logic for whether a given object should be created
+# was already enforced by salt, and /etc/kubernetes/addons is the
+# managed result is of that. Start everything below that directory.
+KUBECTL=${KUBECTL_BIN:-/usr/local/bin/kubectl}
+
+ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC:-600}
+
+SYSTEM_NAMESPACE=kube-system
+token_dir=${TOKEN_DIR:-/srv/kubernetes}
+trusty_master=${TRUSTY_MASTER:-false}
+
+function ensure_python() {
+  if ! python --version > /dev/null 2>&1; then    
+    echo "No python on the machine, will use a python image"
+    local -r PYTHON_IMAGE=python:2.7-slim-pyyaml
+    export PYTHON="docker run --interactive --rm --net=none ${PYTHON_IMAGE} python"
+  else
+    export PYTHON=python
+  fi
+}
+
+function create-kubeconfig-secret() {
+  local -r token=$1
+  local -r username=$2
+  local -r server=$3
+  local -r safe_username=$(tr -s ':_' '--' <<< "${username}")
+
+  # Make a kubeconfig file with the token.
+  if [[ ! -z "${CA_CERT:-}" ]]; then
+    # If the CA cert is available, put it into the secret rather than using
+    # insecure-skip-tls-verify.
+    read -r -d '' kubeconfig <<EOF
+apiVersion: v1
+kind: Config
+users:
+- name: ${username}
+  user:
+    token: ${token}
+clusters:
+- name: local
+  cluster:
+     server: ${server}
+     certificate-authority-data: ${CA_CERT}
+contexts:
+- context:
+    cluster: local
+    user: ${username}
+    namespace: ${SYSTEM_NAMESPACE} 
+  name: service-account-context
+current-context: service-account-context
+EOF
+  else
+    read -r -d '' kubeconfig <<EOF
+apiVersion: v1
+kind: Config
+users:
+- name: ${username}
+  user:
+    token: ${token}
+clusters:
+- name: local
+  cluster:
+     server: ${server}
+     insecure-skip-tls-verify: true
+contexts:
+- context:
+    cluster: local
+    user: ${username}
+    namespace: ${SYSTEM_NAMESPACE}
+  name: service-account-context
+current-context: service-account-context
+EOF
+  fi
+
+  local -r kubeconfig_base64=$(echo "${kubeconfig}" | base64 -w0)
+  read -r -d '' secretyaml <<EOF
+apiVersion: v1
+data:
+  kubeconfig: ${kubeconfig_base64}
+kind: Secret
+metadata:
+  name: token-${safe_username}
+type: Opaque
+EOF
+  create-resource-from-string "${secretyaml}" 100 10 "Secret-for-token-for-user-${username}" "${SYSTEM_NAMESPACE}" &
+}
+
+# $1 filename of addon to start.
+# $2 count of tries to start the addon.
+# $3 delay in seconds between two consecutive tries
+# $4 namespace
+function start_addon() {
+  local -r addon_filename=$1;
+  local -r tries=$2;
+  local -r delay=$3;
+  local -r namespace=$4
+
+  create-resource-from-string "$(cat ${addon_filename})" "${tries}" "${delay}" "${addon_filename}" "${namespace}"
+}
+
+# $1 string with json or yaml.
+# $2 count of tries to start the addon.
+# $3 delay in seconds between two consecutive tries
+# $4 name of this object to use when logging about it.
+# $5 namespace for this object
+function create-resource-from-string() {
+  local -r config_string=$1;
+  local tries=$2;
+  local -r delay=$3;
+  local -r config_name=$4;
+  local -r namespace=$5;
+  while [ ${tries} -gt 0 ]; do
+    echo "${config_string}" | ${KUBECTL} --namespace="${namespace}" create -f - && \
+        echo "== Successfully started ${config_name} in namespace ${namespace} at $(date -Is)" && \
+        return 0;
+    let tries=tries-1;
+    echo "== Failed to start ${config_name} in namespace ${namespace} at $(date -Is). ${tries} tries remaining. =="
+    sleep ${delay};
+  done
+  return 1;
+}
+
+# $1 is the directory containing all of the docker images
+function load-docker-images() {
+  local success
+  local restart_docker
+  while true; do
+    success=true
+    restart_docker=false
+    for image in "$1/"*; do
+      timeout 30 docker load -i "${image}" &>/dev/null
+      rc=$?
+      if [[ "$rc" == 124 ]]; then
+        restart_docker=true
+      elif [[ "$rc" != 0 ]]; then
+        success=false
+      fi
+    done
+    if [[ "$success" == "true" ]]; then break; fi
+    if [[ "$restart_docker" == "true" ]]; then service docker restart; fi
+    sleep 15
+  done
+}
+
+# The business logic for whether a given object should be created
+# was already enforced by salt, and /etc/kubernetes/addons is the
+# managed result is of that. Start everything below that directory.
+echo "== Kubernetes addon manager started at $(date -Is) with ADDON_CHECK_INTERVAL_SEC=${ADDON_CHECK_INTERVAL_SEC} =="
+
+# Load any images that we may need. This is not needed for trusty master and
+# the way it restarts docker daemon does not work for trusty.
+if [[ "${trusty_master}" == "false" ]]; then
+  load-docker-images /srv/salt/kube-addons-images
+fi
+
+ensure_python
+
+# Load the kube-env, which has all the environment variables we care
+# about, in a flat yaml format.
+kube_env_yaml="/var/cache/kubernetes-install/kube_env.yaml"
+if [ ! -e "${kubelet_kubeconfig_file}" ]; then
+  eval $(${PYTHON} -c '''
+import pipes,sys,yaml
+
+for k,v in yaml.load(sys.stdin).iteritems():
+  print("readonly {var}={value}".format(var = k, value = pipes.quote(str(v))))
+''' < "${kube_env_yaml}")
+fi
+
+
+# Create the namespace that will be used to host the cluster-level add-ons.
+start_addon /etc/kubernetes/addons/namespace.yaml 100 10 "" &
+
+# Wait for the default service account to be created in the kube-system namespace.
+token_found=""
+while [ -z "${token_found}" ]; do
+  sleep .5
+  token_found=$(${KUBECTL} get --namespace="${SYSTEM_NAMESPACE}" serviceaccount default -o go-template="{{with index .secrets 0}}{{.name}}{{end}}" || true)
+done
+
+echo "== default service account in the ${SYSTEM_NAMESPACE} namespace has token ${token_found} =="
+
+# Generate secrets for "internal service accounts".
+# TODO(etune): move to a completely yaml/object based
+# workflow so that service accounts can be created
+# at the same time as the services that use them.
+# NOTE: needs to run as root to read this file.
+# Read each line in the csv file of tokens.
+# Expect errors when the script is started again.
+# NOTE: secrets are created asynchronously, in background.
+while read line; do
+  # Split each line into the token and username.
+  IFS=',' read -a parts <<< "${line}"
+  token=${parts[0]}
+  username=${parts[1]}
+  # DNS is special, since it's necessary for cluster bootstrapping.
+  if [[ "${username}" == "system:dns" ]] && [[ ! -z "${KUBERNETES_MASTER_NAME:-}" ]]; then
+    create-kubeconfig-secret "${token}" "${username}" "https://${KUBERNETES_MASTER_NAME}"
+  else
+    # Set the server to https://kubernetes. Pods/components that
+    # do not have DNS available will have to override the server.
+    create-kubeconfig-secret "${token}" "${username}" "https://kubernetes.default"
+  fi
+done < "${token_dir}/known_tokens.csv"
+
+# Create admission_control objects if defined before any other addon services. If the limits
+# are defined in a namespace other than default, we should still create the limits for the
+# default namespace.
+for obj in $(find /etc/kubernetes/admission-controls \( -name \*.yaml -o -name \*.json \)); do
+  start_addon "${obj}" 100 10 default &
+  echo "++ obj ${obj} is created ++"
+done
+
+# Check if the configuration has changed recently - in case the user
+# created/updated/deleted the files on the master.
+while true; do
+  start_sec=$(date +"%s")
+  #kube-addon-update.sh must be deployed in the same directory as this file
+  `dirname $0`/kube-addon-update.sh /etc/kubernetes/addons ${ADDON_CHECK_INTERVAL_SEC}
+  end_sec=$(date +"%s")
+  len_sec=$((${end_sec}-${start_sec}))
+  # subtract the time passed from the sleep time
+  if [[ ${len_sec} -lt ${ADDON_CHECK_INTERVAL_SEC} ]]; then
+    sleep_time=$((${ADDON_CHECK_INTERVAL_SEC}-${len_sec}))
+    sleep ${sleep_time}
+  fi
+done

--- a/ansible/roles/kubernetes-addons/files/common/namespace.yaml
+++ b/ansible/roles/kubernetes-addons/files/common/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system

--- a/ansible/roles/kubernetes-addons/files/common/python-image/Dockerfile
+++ b/ansible/roles/kubernetes-addons/files/common/python-image/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:2.7-slim
+
+RUN pip install pyyaml

--- a/ansible/roles/kubernetes-addons/files/get_files.sh
+++ b/ansible/roles/kubernetes-addons/files/get_files.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+branch="v1.2.4"
+github_url="https://raw.githubusercontent.com/kubernetes/kubernetes/${branch}"
+
+mkdir -p common
+for filename in namespace.yaml kube-addons.sh kube-addon-update.sh; do
+    curl -Lfo common/${filename} "${github_url}/cluster/saltbase/salt/kube-addons/${filename}"
+done
+
+mkdir -p common/python-image
+curl -Lfo common/python-image/Dockerfile "${github_url}/cluster/addons/python-image/Dockerfile"

--- a/ansible/roles/kubernetes-addons/tasks/cluster-logging.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-logging.yml
@@ -2,16 +2,14 @@
 - name: LOGGING | Assures {{ kube_addons_dir }}/cluster-logging dir exists
   file: path={{ kube_addons_dir }}/cluster-logging state=directory
 
-- name: LOGGING | Download logging files from Kubernetes repo
-  get_url:
-    url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/fluentd-elasticsearch/{{ item }}
-    dest="{{ kube_addons_dir }}/cluster-logging/"
-    force=yes
-    validate_certs=False
-  environment:
-    http_proxy: "{{ http_proxy|default('') }}"
-    https_proxy: "{{ https_proxy|default('') }}"
-    no_proxy: "{{ no_proxy|default('') }}"
+- name: LOGGING | Copy logging manifests to master
+  template:
+  args:
+    src: "cluster-logging/{{ item }}.j2"
+    dest: "{{ kube_addons_dir }}/cluster-logging/{{ item }}"
+    mode: 0644
+    owner: root
+    group: root
   with_items:
     - es-controller.yaml
     - es-service.yaml

--- a/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
+++ b/ansible/roles/kubernetes-addons/tasks/cluster-monitoring.yml
@@ -2,62 +2,12 @@
 - name: MONITORING | Assures {{ kube_config_dir }}/addons/cluster-monitoring dir exists
   file: path={{ kube_addons_dir }}/cluster-monitoring state=directory
 
-- name: MONITORING | Assures local temporary {{ local_temp_addon_dir }}/cluster-monitoring dir exists
-  local_action: file
-    path={{ local_temp_addon_dir }}/cluster-monitoring
-    state=directory
-  sudo: no
-
-- name: MONITORING | Download monitoring files from Kubernetes repo
-  local_action: get_url
-    url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/cluster-monitoring/influxdb/{{ item }}
-    dest="{{ local_temp_addon_dir }}/cluster-monitoring/{{ item }}.j2"
-    force=yes
-    validate_certs=False
-  sudo: no
-  with_items:
-    - grafana-service.yaml
-    - heapster-controller.yaml
-    - heapster-service.yaml
-    - influxdb-grafana-controller.yaml
-    - influxdb-service.yaml
-  changed_when: false
-
-- name: MONITORING | Remove instances of getting pillar dicts
-  local_action: lineinfile
-    dest="{{ local_temp_addon_dir }}/cluster-monitoring/{{ item }}.j2"
-    regexp="set\s+\w+\s+=\s+pillar\.get\("
-    state=absent
-  sudo: no
-  with_items:
-    - grafana-service.yaml
-    - heapster-controller.yaml
-    - heapster-service.yaml
-    - influxdb-grafana-controller.yaml
-    - influxdb-service.yaml
-  changed_when: false
-
-- name: MONITORING | Add tests for pillar vars converted to ansible vars
-  local_action: lineinfile
-    dest="{{ local_temp_addon_dir }}/cluster-monitoring/{{ item }}.j2"
-    regexp="(.*)if\s+(\w+)\s+([<>=]+.*)"
-    line="\1if \2 is defined and \2 \3"
-    backrefs=yes
-  sudo: no
-  with_items:
-    - grafana-service.yaml
-    - heapster-controller.yaml
-    - heapster-service.yaml
-    - influxdb-grafana-controller.yaml
-    - influxdb-service.yaml
-  changed_when: false
-
 - name: MONITORING | Install template from converted saltfile
   template:
   args:
-    src: "{{ local_temp_addon_dir }}/cluster-monitoring/{{ item }}.j2"
+    src: "cluster-monitoring/{{ item }}.j2"
     dest: "{{ kube_addons_dir }}/cluster-monitoring/{{ item }}"
-    mode: 0755
+    mode: 0644
     owner: root
     group: root
   with_items:

--- a/ansible/roles/kubernetes-addons/tasks/dns.yml
+++ b/ansible/roles/kubernetes-addons/tasks/dns.yml
@@ -2,41 +2,12 @@
 - name: DNS | Assures {{ kube_addons_dir }}/dns dir exists
   file: path={{ kube_addons_dir }}/dns state=directory
 
-- name: DNS | Assures local dns addon dir exists
-  local_action: file
-    path={{ local_temp_addon_dir }}/dns
-    state=directory
-  sudo: no
-
-- name: DNS | Download yaml files from Kubernetes repo
-  local_action: get_url
-    url=https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/cluster/addons/dns/{{ item }}.in
-    dest="{{ local_temp_addon_dir }}/dns/{{ item }}.j2"
-    force=yes
-    validate_certs=False
-  sudo: no
-  changed_when: false
-  with_items:
-  - skydns-rc.yaml
-  - skydns-svc.yaml
-
-- name: DNS | Convert pillar vars to ansible vars for yaml files
-  local_action: replace
-    dest="{{ local_temp_addon_dir }}/dns/{{ item }}.j2"
-    regexp="pillar\[\'(\w*)\'\]"
-    replace="\1"
-  sudo: no
-  changed_when: false
-  with_items:
-  - skydns-rc.yaml
-  - skydns-svc.yaml
-
 - name: DNS | Install Template from converted saltfiles
   template:
   args:
-    src: "{{ local_temp_addon_dir }}/dns/{{ item }}.j2"
+    src: "dns/{{ item }}.j2"
     dest: "{{ kube_addons_dir }}/dns/{{ item }}"
-    mode: 0755
+    mode: 0644
     owner: root
     group: root
   with_items:

--- a/ansible/roles/kubernetes-addons/tasks/kube-dash.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-dash.yml
@@ -2,16 +2,14 @@
 - name: KUBE-DASH | Assures {{ kube_addons_dir }}/kube-dash dir exists
   file: path={{ kube_addons_dir }}/kube-dash state=directory
 
-- name: KUBE-DASH | Download kube-dash files from Kubernetes repo
-  get_url:
-    url=https://raw.githubusercontent.com/kubernetes/kubedash/master/deploy/{{ item }}
-    dest="{{ kube_addons_dir }}/kube-dash/"
-    force=yes
-    validate_certs=False
-  environment:
-    http_proxy: "{{ http_proxy|default('') }}"
-    https_proxy: "{{ https_proxy|default('') }}"
-    no_proxy: "{{ no_proxy|default('') }}"
+- name: KUBE-DASH | Copy kube-dash manifests to master
+  template:
+  args:
+    src: "kube-dash/{{ item }}.j2"
+    dest: "{{ kube_addons_dir }}/kube-dash/{{ item }}"
+    mode: 0644
+    owner: root
+    group: root
   with_items:
     - kube-dash-rc.yaml
     - kube-dash-svc.yaml

--- a/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
+++ b/ansible/roles/kubernetes-addons/tasks/kube-ui.yml
@@ -2,16 +2,14 @@
 - name: KUBE-UI | Assures {{ kube_addons_dir }}/kube-ui dir exists
   file: path={{ kube_addons_dir }}/kube-ui state=directory
 
-- name: KUBE-UI | Download kube-ui files from Kubernetes repo
-  get_url:
-    url=https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dashboard/{{ item }}
-    dest="{{ kube_addons_dir }}/kube-ui/"
-    force=yes
-    validate_certs=False
-  environment:
-    http_proxy: "{{ http_proxy|default('') }}"
-    https_proxy: "{{ https_proxy|default('') }}"
-    no_proxy: "{{ no_proxy|default('') }}"
+- name: KUBE-UI | Copy kube-ui manifests to master
+  template:
+  args:
+    src: "kube-ui/{{ item }}.j2"
+    dest: "{{ kube_addons_dir }}/kube-ui/{{ item }}"
+    mode: 0644
+    owner: root
+    group: root
   with_items:
     - dashboard-controller.yaml
     - dashboard-service.yaml

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -12,15 +12,9 @@
   sudo: no
 
 - name: Make sure the system services namespace exists
-  get_url:
-    url=https://raw.githubusercontent.com/kubernetes/kubernetes/master/{{ kube_addons_download_source_dir }}/namespace.yaml
-    dest="{{ kube_config_dir }}/addons/"
-    force=yes
-    validate_certs=False
-  environment:
-    http_proxy: "{{ http_proxy|default('') }}"
-    https_proxy: "{{ https_proxy|default('') }}"
-    no_proxy: "{{ no_proxy|default('') }}"
+  copy:
+    src=common/namespace.yaml
+    dest="{{ kube_config_dir }}/addons/namespace.yaml"
 
 - include: dns.yml
   when: dns_setup
@@ -38,38 +32,30 @@
   when: kube-dash
 
 - name: Get kube-addons script from Kubernetes
-  get_url:
-    url=https://raw.githubusercontent.com/kubernetes/kubernetes/master/{{ kube_addons_download_source_dir }}/kube-addons.sh
+  copy:
+    src=common/kube-addons.sh
     dest={{ kube_script_dir }}/kube-addons.sh mode=0755
-    force=yes
-    validate_certs=False
-  environment:
-    http_proxy: "{{ http_proxy|default('') }}"
-    https_proxy: "{{ https_proxy|default('') }}"
-    no_proxy: "{{ no_proxy|default('') }}"
   notify:
     - restart kube-addons
 
 - name: Get kube-addon-update script from Kubernetes
-  get_url:
-    url=https://raw.githubusercontent.com/kubernetes/kubernetes/master/{{ kube_addons_download_source_dir }}/kube-addon-update.sh
+  copy:
+    src=common/kube-addon-update.sh
     dest={{ kube_script_dir }}/kube-addon-update.sh mode=0755
-    force=yes
-    validate_certs=False
-  environment:
-    http_proxy: "{{ http_proxy|default('') }}"
-    https_proxy: "{{ https_proxy|default('') }}"
-    no_proxy: "{{ no_proxy|default('') }}"
   notify:
     - restart kube-addons
 
-- name: Build Python image to use in Kubernetes Addons
-  shell: docker build -t python:2.7-slim-pyyaml https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/python-image/Dockerfile
-  environment:
-    http_proxy: "{{ http_proxy|default('') }}"
-    https_proxy: "{{ https_proxy|default('') }}"
-    no_proxy: "{{ no_proxy|default('') }}"
+
+- name: Get Python image Dockerfile
+  copy:
+    src=common/python-image/
+    dest={{ kube_script_dir }}/python-image
   when: is_coreos
+  register: kube_addons_python_image_dockerfile
+
+- name: Build Python image to use in Kubernetes Addons
+  shell: "docker build -t python:2.7-slim-pyyaml {{ kube_script_dir }}/python-image"
+  when: is_coreos and kube_addons_python_image_dockerfile | changed
 
 - name: Run kube-gen-token script to create {{ kube_token_dir }}/known_tokens.csv
   command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item }}"

--- a/ansible/roles/kubernetes-addons/templates/cluster-logging/es-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-logging/es-controller.yaml.j2
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: elasticsearch-logging-v1
+  namespace: kube-system
+  labels:
+    k8s-app: elasticsearch-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 2
+  selector:
+    k8s-app: elasticsearch-logging
+    version: v1
+  template:
+    metadata:
+      labels:
+        k8s-app: elasticsearch-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - image: gcr.io/google_containers/elasticsearch:1.8
+        name: elasticsearch-logging         
+        resources:
+          # keep request = limit to keep this container in guaranteed class
+          limits:
+            cpu: 100m
+          requests:
+            cpu: 100m
+        ports:
+        - containerPort: 9200
+          name: db
+          protocol: TCP
+        - containerPort: 9300
+          name: transport
+          protocol: TCP
+        volumeMounts:
+        - name: es-persistent-storage
+          mountPath: /data
+      volumes:
+      - name: es-persistent-storage
+        emptyDir: {}

--- a/ansible/roles/kubernetes-addons/templates/cluster-logging/es-service.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-logging/es-service.yaml.j2
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-logging
+  namespace: kube-system
+  labels:
+    k8s-app: elasticsearch-logging
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Elasticsearch"
+spec:
+  ports:
+  - port: 9200
+    protocol: TCP
+    targetPort: db
+  selector:
+    k8s-app: elasticsearch-logging

--- a/ansible/roles/kubernetes-addons/templates/cluster-logging/kibana-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-logging/kibana-controller.yaml.j2
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kibana-logging-v1
+  namespace: kube-system
+  labels:
+    k8s-app: kibana-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    k8s-app: kibana-logging
+    version: v1
+  template:
+    metadata:
+      labels:
+        k8s-app: kibana-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: kibana-logging
+        image: gcr.io/google_containers/kibana:1.3
+        resources:
+          # keep request = limit to keep this container in guaranteed class
+          limits:
+            cpu: 100m
+          requests:
+            cpu: 100m
+        env:
+          - name: "ELASTICSEARCH_URL"
+            value: "http://elasticsearch-logging:9200"
+        ports:
+        - containerPort: 5601
+          name: ui
+          protocol: TCP

--- a/ansible/roles/kubernetes-addons/templates/cluster-logging/kibana-service.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-logging/kibana-service.yaml.j2
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana-logging
+  namespace: kube-system
+  labels:
+    k8s-app: kibana-logging
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Kibana"
+spec:
+  ports:
+  - port: 5601
+    protocol: TCP
+    targetPort: ui
+  selector:
+    k8s-app: kibana-logging

--- a/ansible/roles/kubernetes-addons/templates/cluster-monitoring/grafana-service.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-monitoring/grafana-service.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitoring-grafana
+  namespace: kube-system
+  labels: 
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Grafana"
+spec:
+  # On production clusters, consider setting up auth for grafana, and
+  # exposing Grafana either using a LoadBalancer or a public IP.
+  # type: LoadBalancer
+  ports: 
+    - port: 80
+      targetPort: 3000
+  selector: 
+    k8s-app: influxGrafana
+

--- a/ansible/roles/kubernetes-addons/templates/cluster-monitoring/heapster-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-monitoring/heapster-controller.yaml.j2
@@ -1,0 +1,109 @@
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: heapster-v1.0.2
+  namespace: kube-system
+  labels:
+    k8s-app: heapster
+    kubernetes.io/cluster-service: "true"
+    version: v1.0.2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: heapster
+      version: v1.0.2
+  template:
+    metadata:
+      labels:
+        k8s-app: heapster
+        version: v1.0.2
+    spec:
+      containers:
+        - image: gcr.io/google_containers/heapster:v1.0.2
+          name: heapster
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 100m
+              memory: {{ metrics_memory }}
+            requests:
+              cpu: 100m
+              memory: {{ metrics_memory }}
+          command:
+            - /heapster
+            - --source=kubernetes.summary_api:''
+            - --sink=influxdb:http://monitoring-influxdb:8086
+            - --metric_resolution=60s
+        - image: gcr.io/google_containers/heapster:v1.0.2
+          name: eventer
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 100m
+              memory: {{ eventer_memory }}
+            requests:
+              cpu: 100m
+              memory: {{ eventer_memory }}
+          command:
+            - /eventer
+            - --source=kubernetes:''
+            - --sink=influxdb:http://monitoring-influxdb:8086
+        - image: gcr.io/google_containers/addon-resizer:1.0
+          name: heapster-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory={{ metrics_memory }}
+            - --extra-memory={{ metrics_memory_per_node }}Mi
+            - --threshold=5
+            - --deployment=heapster-v1.0.2
+            - --container=heapster
+            - --poll-period=300000
+        - image: gcr.io/google_containers/addon-resizer:1.0
+          name: eventer-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory={{ eventer_memory }}
+            - --extra-memory={{ eventer_memory_per_node }}Ki
+            - --threshold=5
+            - --deployment=heapster-v1.0.2
+            - --container=eventer
+            - --poll-period=300000
+

--- a/ansible/roles/kubernetes-addons/templates/cluster-monitoring/heapster-service.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-monitoring/heapster-service.yaml.j2
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: heapster
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Heapster"
+spec: 
+  ports: 
+    - port: 80
+      targetPort: 8082
+  selector: 
+    k8s-app: heapster

--- a/ansible/roles/kubernetes-addons/templates/cluster-monitoring/influxdb-grafana-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-monitoring/influxdb-grafana-controller.yaml.j2
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: monitoring-influxdb-grafana-v3
+  namespace: kube-system
+  labels: 
+    k8s-app: influxGrafana
+    version: v3
+    kubernetes.io/cluster-service: "true"
+spec: 
+  replicas: 1
+  selector: 
+    k8s-app: influxGrafana
+    version: v3
+  template: 
+    metadata: 
+      labels: 
+        k8s-app: influxGrafana
+        version: v3
+        kubernetes.io/cluster-service: "true"
+    spec: 
+      containers: 
+        - image: gcr.io/google_containers/heapster_influxdb:v0.5
+          name: influxdb
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 100m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 500Mi
+          ports: 
+            - containerPort: 8083
+            - containerPort: 8086
+          volumeMounts:
+          - name: influxdb-persistent-storage
+            mountPath: /data
+        - image: gcr.io/google_containers/heapster_grafana:v2.6.0-2
+          name: grafana
+          env:
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          env:
+            # This variable is required to setup templates in Grafana.
+            - name: INFLUXDB_SERVICE_URL
+              value: http://monitoring-influxdb:8086
+              # The following env variables are required to make Grafana accessible via
+              # the kubernetes api-server proxy. On production clusters, we recommend
+              # removing these env variables, setup auth for grafana, and expose the grafana
+              # service using a LoadBalancer or a public IP.
+            - name: GF_AUTH_BASIC_ENABLED
+              value: "false"
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Admin
+            - name: GF_SERVER_ROOT_URL
+              value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+          volumeMounts:
+          - name: grafana-persistent-storage
+            mountPath: /var
+      volumes:
+      - name: influxdb-persistent-storage
+        emptyDir: {}
+      - name: grafana-persistent-storage
+        emptyDir: {}
+

--- a/ansible/roles/kubernetes-addons/templates/cluster-monitoring/influxdb-service.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-monitoring/influxdb-service.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitoring-influxdb
+  namespace: kube-system
+  labels: 
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "InfluxDB"
+spec: 
+  ports: 
+    - name: http
+      port: 8083
+      targetPort: 8083
+    - name: api
+      port: 8086
+      targetPort: 8086
+  selector: 
+    k8s-app: influxGrafana
+

--- a/ansible/roles/kubernetes-addons/templates/dns/skydns-rc.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/dns/skydns-rc.yaml.j2
@@ -1,0 +1,129 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kube-dns-v11
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    version: v11
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: {{ dns_replicas }}
+  selector:
+    k8s-app: kube-dns
+    version: v11
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+        version: v11
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: etcd
+        image: gcr.io/google_containers/etcd-amd64:2.2.1
+        resources:
+          # TODO: Set memory limits when we've profiled the container for large
+          # clusters, then set request = limit to keep this container in
+          # guaranteed class. Currently, this container falls into the
+          # "burstable" category so the kubelet doesn't backoff from restarting it.
+          limits:
+            cpu: 100m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        command:
+        - /usr/local/bin/etcd
+        - -data-dir
+        - /var/etcd/data
+        - -listen-client-urls
+        - http://127.0.0.1:2379,http://127.0.0.1:4001
+        - -advertise-client-urls
+        - http://127.0.0.1:2379,http://127.0.0.1:4001
+        - -initial-cluster-token
+        - skydns-etcd
+        volumeMounts:
+        - name: etcd-storage
+          mountPath: /var/etcd/data
+      - name: kube2sky
+        image: gcr.io/google_containers/kube2sky:1.14
+        resources:
+          # TODO: Set memory limits when we've profiled the container for large
+          # clusters, then set request = limit to keep this container in
+          # guaranteed class. Currently, this container falls into the
+          # "burstable" category so the kubelet doesn't backoff from restarting it.
+          limits:
+            cpu: 100m
+            # Kube2sky watches all pods.
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8081
+            scheme: HTTP
+          # we poll on pod startup for the Kubernetes master service and
+          # only setup the /readiness HTTP server once that's available.
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        args:
+        # command = "/kube2sky"
+        - --domain={{ dns_domain }}
+      - name: skydns
+        image: gcr.io/google_containers/skydns:2015-10-13-8c72f8c
+        resources:
+          # TODO: Set memory limits when we've profiled the container for large
+          # clusters, then set request = limit to keep this container in
+          # guaranteed class. Currently, this container falls into the
+          # "burstable" category so the kubelet doesn't backoff from restarting it.
+          limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        args:
+        # command = "/skydns"
+        - -machines=http://127.0.0.1:4001
+        - -addr=0.0.0.0:53
+        - -ns-rotate=false
+        - -domain={{ dns_domain }}.
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+      - name: healthz
+        image: gcr.io/google_containers/exechealthz:1.0
+        resources:
+          # keep request = limit to keep this container in guaranteed class
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        args:
+        - -cmd=nslookup kubernetes.default.svc.{{ dns_domain }} 127.0.0.1 >/dev/null
+        - -port=8080
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+      volumes:
+      - name: etcd-storage
+        emptyDir: {}
+      dnsPolicy: Default  # Don't use cluster DNS.

--- a/ansible/roles/kubernetes-addons/templates/dns/skydns-svc.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/dns/skydns-svc.yaml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "KubeDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP:  {{ dns_server }}
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP

--- a/ansible/roles/kubernetes-addons/templates/get_templates.sh
+++ b/ansible/roles/kubernetes-addons/templates/get_templates.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+branch="v1.2.4"
+github_url="https://raw.githubusercontent.com/kubernetes/kubernetes/${branch}"
+
+# get dns templates
+dir="dns"
+mkdir -p $dir
+for filename in skydns-rc.yaml skydns-svc.yaml; do
+    filepath="${dir}/${filename}.j2"
+    curl -Lfo ${filepath} "${github_url}/cluster/addons/dns/${filename}.in"
+    sed -i "s/pillar\['\(.*\)'\]/\1/g" $filepath
+done
+
+# get cluster monitoring
+dir="cluster-monitoring"
+mkdir -p $dir
+for filename in grafana-service.yaml heapster-controller.yaml heapster-service.yaml influxdb-grafana-controller.yaml influxdb-service.yaml; do
+    filepath="${dir}/${filename}.j2"
+    curl -Lfo ${filepath} "${github_url}/cluster/addons/cluster-monitoring/influxdb/${filename}"
+    sed -i "s/pillar\['\(.*\)'\]/\1/g" $filepath
+done
+# remove some saltstack templating
+sed -i "/{%/d" ${dir}/heapster-controller.yaml.j2
+
+# get cluster logging
+dir="cluster-logging"
+mkdir -p $dir
+for filename in es-controller.yaml es-service.yaml kibana-controller.yaml kibana-service.yaml; do
+    filepath="${dir}/${filename}.j2"
+    curl -Lfo ${filepath} "${github_url}/cluster/addons/fluentd-elasticsearch/${filename}"
+done
+
+# get kube dash
+dir="kube-dash"
+mkdir -p $dir
+for filename in kube-dash-rc.yaml kube-dash-svc.yaml; do
+    filepath="${dir}/${filename}.j2"
+    curl -Lfo ${filepath} "https://raw.githubusercontent.com/kubernetes/kubedash/master/deploy/${filename}"
+done
+

--- a/ansible/roles/kubernetes-addons/templates/kube-dash/kube-dash-rc.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-dash/kube-dash-rc.yaml.j2
@@ -1,0 +1,40 @@
+---
+  apiVersion: "v1"
+  kind: "ReplicationController"
+  metadata:
+    labels:
+      name: "kubedash"
+      kubernetes.io/cluster-service: "true"
+    name: "kubedash"
+    namespace: "kube-system"
+  spec:
+    replicas: 1
+    selector:
+      name: "kubedash"
+    template:
+      metadata:
+        labels:
+          name: "kubedash"
+          kubernetes.io/cluster-service: "true"
+      spec:
+        containers:
+          -
+            image: "gcr.io/google_containers/kubedash:v0.2.1"
+            name: "kubedash"
+            command:
+              - "/kubedash"
+            resources:
+              limits:
+                cpu: 50m
+                memory: 100Mi
+            volumeMounts:
+              -
+                name: "ssl-certs"
+                mountPath: "/etc/ssl/certs"
+                readOnly: true
+        volumes:
+          -
+            name: "ssl-certs"
+            hostPath:
+              path: "/etc/ssl/certs"
+

--- a/ansible/roles/kubernetes-addons/templates/kube-dash/kube-dash-svc.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-dash/kube-dash-svc.yaml.j2
@@ -1,0 +1,17 @@
+---
+  apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    labels:
+      name: "kubedash"
+      kubernetes.io/cluster-service: "true"
+    name: "kubedash"
+    namespace: "kube-system"
+  spec:
+    type: "LoadBalancer"
+    ports:
+      -
+        port: 80
+        targetPort: 8289
+    selector:
+      name: "kubedash"

--- a/ansible/roles/kubernetes-addons/templates/kube-ui/dashboard-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-ui/dashboard-controller.yaml.j2
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  # Keep the name in sync with image version and
+  # gce/coreos/kube-manifests/addons/dashboard counterparts
+  name: kubernetes-dashboard-v1.0.1
+  namespace: kube-system
+  labels:
+    k8s-app: kubernetes-dashboard
+    version: v1.0.1
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+        version: v1.0.1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: kubernetes-dashboard
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.0.1
+        resources:
+          # keep request = limit to keep this container in guaranteed class
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        ports:
+        - containerPort: 9090
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9090
+          initialDelaySeconds: 30
+          timeoutSeconds: 30

--- a/ansible/roles/kubernetes-addons/templates/kube-ui/dashboard-service.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-ui/dashboard-service.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-dashboard
+  namespace: kube-system
+  labels:
+    k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    k8s-app: kubernetes-dashboard
+  ports:
+  - port: 80
+    targetPort: 9090


### PR DESCRIPTION
This should include all external resources/artifacts needed for kube-addons. I decided to get them from the stable release tag 'v1.2.4'. (as proposed in #931)

* includes scripts `get_files.sh` / `get_templates.sh` to get updated versions from k8s project easily
 cf. #931 
* compatibility with `eventer` and `metrics` memory limits from newer heapster replication controllers
* build new `python-image` only if Dockerfile actually changed

This should fix #941, #938 as well