### PR TITLE
[nginx-ingress-controller] Enable configuration to disable http2

### DIFF
--- a/ingress/controllers/nginx/nginx.tmpl
+++ b/ingress/controllers/nginx/nginx.tmpl
@@ -154,7 +154,7 @@ http {
     {{ range $server := .servers }}
     server {
         listen 80{{ if $cfg.useProxyProtocol }} proxy_protocol{{ end }};
-        {{ if $server.SSL }}listen 443{{ if $cfg.useProxyProtocol }} proxy_protocol{{ end }} ssl http2;
+        {{ if $server.SSL }}listen 443 {{ if $cfg.useProxyProtocol }}proxy_protocol{{ end }} ssl {{ if $cfg.useHttp2 }}http2{{ end }};
         {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
         # PEM sha: {{ $server.SSLPemChecksum }}        
         ssl_certificate {{ $server.SSLCertificate }};

--- a/ingress/controllers/nginx/nginx/main.go
+++ b/ingress/controllers/nginx/nginx/main.go
@@ -214,6 +214,11 @@ type nginxConfiguration struct {
 	// http://nginx.org/en/docs/http/ngx_http_gzip_module.html
 	UseGzip bool `structs:"use-gzip,omitempty"`
 
+	// Enables or disables the HTTP/2 support in secure connections
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html
+	// Default: true
+	UseHTTP2 bool `structs:"use-http2,omitempty"`
+
 	// MIME types in addition to "text/html" to compress. The special value “*” matches any MIME type.
 	// Responses with the “text/html” type are always compressed if UseGzip is enabled
 	GzipTypes string `structs:"gzip-types,omitempty"`
@@ -270,6 +275,7 @@ func newDefaultNginxCfg() nginxConfiguration {
 		UseGzip:                  true,
 		WorkerProcesses:          strconv.Itoa(runtime.NumCPU()),
 		VtsStatusZoneSize:        "10m",
+		UseHTTP2:                 true,
 	}
 
 	if glog.V(5) {


### PR DESCRIPTION
fixes #960

Latest safari have issues with http2 https://trac.nginx.org/nginx/ticket/979
