### PR TITLE
etcd ansible_temp_dir use instead of hard coded

### DIFF
--- a/ansible/roles/etcd/tasks/github-release.yml
+++ b/ansible/roles/etcd/tasks/github-release.yml
@@ -1,11 +1,8 @@
 ---
-- name: Create download dir
-  file: path="/tmp/.ansible/files" state=directory
-
 - name: Download tar file
   get_url:
     url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
-    dest: /tmp/.ansible/files
+    dest: "{{ ansible_temp_dir }}"
     validate_certs: False
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
@@ -14,7 +11,7 @@
 
 - name: Extract tar file
   unarchive:
-    src: "/tmp/.ansible/files/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
+    src: "{{ ansible_temp_dir }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
     dest: /usr/local
     copy: no
 


### PR DESCRIPTION
- should use the variable defined in [common/defaults] (https://github.com/kubernetes/contrib/blob/master/ansible/roles/common/defaults/main.yaml#L8)
- removed the directory creation since its in [common/tasks] (https://github.com/kubernetes/contrib/blob/master/ansible/roles/common/tasks/main.yml#L51-L52)