### PR TITLE
Updated the etcd_download_url

### DIFF
--- a/ansible/roles/etcd/defaults/main.yaml
+++ b/ansible/roles/etcd/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 # etcd_source_type: package | github-release
 etcd_source_type: package
-etcd_version: v2.2.3
+etcd_version: 2.2.3
 
 etcd_client_port: 2379
 etcd_peer_port: 2380
@@ -43,3 +43,6 @@ etcd_advertise_client_legacy_urls: "{{ etcd_url_scheme }}://{{ etcd_machine_addr
 etcd_listen_client_legacy_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port }},{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_legacy_port }}"
 
 etcd_data_dir: /var/lib/etcd
+
+etcd_download_url_base: "https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}"
+etcd_download_url: "{{ etcd_download_url_base }}/etcd-v{{ etcd_version }}-linux-amd64.tar.gz"

--- a/ansible/roles/etcd/tasks/github-release.yml
+++ b/ansible/roles/etcd/tasks/github-release.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download tar file
   get_url:
-    url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
+    url: "{{ etcd_download_url }}"
     dest: "{{ ansible_temp_dir }}"
     validate_certs: False
   environment:


### PR DESCRIPTION
- Variablized the download url, only applicable for Ubuntu. Removed the v from the version number.
- Follows the same pattern we use in [flannel](https://github.com/kubernetes/contrib/blob/master/ansible/roles/flannel/defaults/main.yaml#L18-L19) , [kube](https://github.com/kubernetes/contrib/blob/master/ansible/roles/kubernetes/defaults/main.yml#L21), and [pypy] (https://github.com/kubernetes/contrib/blob/master/ansible/roles/pre-ansible/defaults/main.yml#L10-L11)