### PR TITLE
cluster-autoscaler: Fix slicing pods into old pods and new pods

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -15,9 +15,9 @@ test-unit: clean deps build
 	$(ENVVAR) godep go test --test.short -race ./... $(FLAGS)
 
 release: build
-
 ifndef REGISTRY
-    $(error REGISTRY is undefined)
+	ERR = $(error REGISTRY is undefined)
+	$(ERR)
 endif
 	docker build -t ${REGISTRY}/cluster-autoscaler:${TAG} .
 	gcloud docker push ${REGISTRY}/cluster-autoscaler:${TAG}

--- a/cluster-autoscaler/deploy/deploy.sh
+++ b/cluster-autoscaler/deploy/deploy.sh
@@ -17,6 +17,8 @@
 # Usage:
 #   REGISTRY=<my_reg> MIG_LINK=<my_mig> [MIN=1] [MAX=4] [VERSION=v1.1] deploy.sh 
 
+set -e
+
 ROOT=$(dirname "${BASH_SOURCE}")/..
 
 if [ -z "$REGISTRY" ]; then


### PR DESCRIPTION
Previously after updating pod status all pods had `LastTransitionTime` after the threshold (time of newest node becoming available).

Additionally fix our makefile so that it's not required to set `REGISTRY` for every rule.

https://github.com/kubernetes/kubernetes/issues/24404

@mwielgus @jszczepkowski @piosz 
