### PR TITLE
extracted etcd_download_file_name and added usage in github-release.yml

### DIFF
--- a/ansible/roles/etcd/defaults/main.yaml
+++ b/ansible/roles/etcd/defaults/main.yaml
@@ -45,4 +45,5 @@ etcd_listen_client_legacy_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_
 etcd_data_dir: /var/lib/etcd
 
 etcd_download_url_base: "https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}"
-etcd_download_url: "{{ etcd_download_url_base }}/etcd-v{{ etcd_version }}-linux-amd64.tar.gz"
+etcd_download_file_name: "etcd-v{{ etcd_version }}-linux-amd64"
+etcd_download_url: "{{ etcd_download_url_base }}/{{ etcd_download_file_name }}.tar.gz"

--- a/ansible/roles/etcd/tasks/github-release.yml
+++ b/ansible/roles/etcd/tasks/github-release.yml
@@ -11,13 +11,13 @@
 
 - name: Extract tar file
   unarchive:
-    src: "{{ ansible_temp_dir }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
+    src: "{{ ansible_temp_dir }}/{{ etcd_download_file_name }}.tar.gz"
     dest: /usr/local
     copy: no
 
 - name: Create symlinks
   file:
-    src: /usr/local/etcd-{{ etcd_version }}-linux-amd64/{{ item }}
+    src: /usr/local/{{ etcd_download_file_name }}/{{ item }}
     dest: /usr/bin/{{ item }}
     state: link
   with_items:


### PR DESCRIPTION
I ran into this when trying to spin up the cluster on a ubuntu cluster.
Mainly the v of version was missing but I extracted it as a constant so it is consistent 
with the overall style.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/995)

<!-- Reviewable:end -->
