### PR TITLE
refactor common

### DIFF
--- a/ansible/roles/common/defaults/main.yaml
+++ b/ansible/roles/common/defaults/main.yaml
@@ -6,3 +6,10 @@ bin_dir: /usr/bin
 # The directory used by Ansible to temporarily store
 # files on Ansible managed systems.
 ansible_temp_dir: /tmp/.ansible/files
+
+#Some default values that may get modified in etc/tasks/main.yml
+is_atomic: false
+is_coreos: false
+has_rpm: false
+has_firewalld: false
+has_iptables: false

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,27 +1,19 @@
 ---
 - name: Determine if Atomic
   stat: path=/run/ostree-booted
-  register: s
+  register: os_tree_check
   changed_when: false
   always_run: yes
-
-- name: Init the is_atomic fact
-  set_fact:
-    is_atomic: false
 
 - name: Set the is_atomic fact
   set_fact:
     is_atomic: true
-  when: s.stat.exists
+  when: os_tree_check.stat.exists
 
 - name: Determine if CoreOS
   raw: "grep '^NAME=' /etc/os-release | sed s'/NAME=//'"
   register: distro
   always_run: yes
-
-- name: Init the is_coreos fact
-  set_fact:
-    is_coreos: false
 
 - name: Set the is_coreos fact
   set_fact:
@@ -41,26 +33,14 @@
 
 - name: Determine if has rpm
   stat: path=/usr/bin/rpm
-  register: s
+  register: rpm_check
   changed_when: false
   always_run: yes
-
-- name: Init the has_rpm fact
-  set_fact:
-    has_rpm: false
 
 - name: Set the has_rpm fact
   set_fact:
     has_rpm: true
-  when: s.stat.exists
-
-- name: Init the has_firewalld fact
-  set_fact:
-    has_firewalld: false
-
-- name: Init the has_iptables fact
-  set_fact:
-    has_iptables: false
+  when: rpm_check.stat.exists
 
 # collect information about what packages are installed
 - include: rpm.yml

--- a/ansible/roles/common/tasks/rpm.yml
+++ b/ansible/roles/common/tasks/rpm.yml
@@ -1,7 +1,7 @@
 ---
 - name: RPM | Determine if firewalld installed
   command: "rpm -q firewalld"
-  register: s
+  register: firewalld_check
   changed_when: false
   failed_when: false
   always_run: yes
@@ -9,11 +9,11 @@
 - name: Set the has_firewalld fact
   set_fact:
     has_firewalld: true
-  when: s.rc == 0
+  when: firewalld_check.rc == 0
 
 - name: Determine if iptables-services installed
   command: "rpm -q iptables-services"
-  register: s
+  register: iptables_check
   changed_when: false
   failed_when: false
   always_run: yes
@@ -21,4 +21,4 @@
 - name: Set the has_iptables fact
   set_fact:
     has_iptables: true
-  when: s.rc == 0
+  when: iptables_check.rc == 0


### PR DESCRIPTION
- Better naming convention on registered variables
- Removed init facts, put in `defaults/main.yml`

Validated via Virtualbox on CoreOS and CentOS

- plan on a follow up PR to move the `docker_config_dir` to the docker role where it should belong.