### PR TITLE
ignore failures that don't happen twice in a row

### DIFF
--- a/mungegithub/mungers/e2e/e2e_test.go
+++ b/mungegithub/mungers/e2e/e2e_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -178,6 +179,37 @@ func TestCheckGCSBuilds(t *testing.T) {
 				"bar": {Status: "Not Stable", ID: "44"},
 			},
 		},
+
+		{
+			paths: map[string][]byte{
+				"/foo/latest-build.txt": []byte(strconv.Itoa(latestBuildNumberFoo)),
+				fmt.Sprintf("/foo/%v/finished.json", latestBuildNumberFoo): marshalOrDie(utils.FinishedFile{
+					Result:    "SUCCESS",
+					Timestamp: 1234,
+				}, t),
+				"/bar/latest-build.txt": []byte(strconv.Itoa(latestBuildNumberBar)),
+				fmt.Sprintf("/bar/%v/finished.json", latestBuildNumberBar): marshalOrDie(utils.FinishedFile{
+					Result:    "UNSTABLE",
+					Timestamp: 1234,
+				}, t),
+				fmt.Sprintf("/bar/%v/artifacts/junit_01.xml", latestBuildNumberBar-1): getJUnit(5, 0),
+				fmt.Sprintf("/bar/%v/artifacts/junit_02.xml", latestBuildNumberBar-1): getJUnit(5, 0),
+				fmt.Sprintf("/bar/%v/artifacts/junit_03.xml", latestBuildNumberBar-1): getJUnit(5, 0),
+				fmt.Sprintf("/bar/%v/artifacts/junit_01.xml", latestBuildNumberBar):   getJUnit(5, 0),
+				fmt.Sprintf("/bar/%v/artifacts/junit_02.xml", latestBuildNumberBar):   getRealJUnitFailure(),
+				fmt.Sprintf("/bar/%v/artifacts/junit_03.xml", latestBuildNumberBar):   getJUnit(5, 0),
+				fmt.Sprintf("/bar/%v/finished.json", latestBuildNumberBar-1): marshalOrDie(utils.FinishedFile{
+					Result:    "STABLE",
+					Timestamp: 999,
+				}, t),
+			},
+			expectStable: true,
+			expectedStatus: map[string]BuildInfo{
+				"foo": {Status: "Stable", ID: "42"},
+				"bar": {Status: "Ignorable flake", ID: "44"},
+			},
+		},
+
 		{
 			paths: map[string][]byte{
 				"/foo/latest-build.txt": []byte(strconv.Itoa(latestBuildNumberFoo)),
@@ -258,7 +290,7 @@ func TestCheckGCSBuilds(t *testing.T) {
 			BuildStatus:          map[string]BuildInfo{},
 			GoogleGCSBucketUtils: utils.NewUtils(server.URL),
 		}
-		stable := e2e.GCSBasedStable()
+		stable, _ := e2e.GCSBasedStable()
 		if stable != test.expectStable {
 			t.Errorf("expected: %v, saw: %v", test.expectStable, stable)
 		}
@@ -271,6 +303,31 @@ func TestCheckGCSBuilds(t *testing.T) {
 func getJUnit(testsNo int, failuresNo int) []byte {
 	return []byte(fmt.Sprintf("%v\n<testsuite tests=\"%v\" failures=\"%v\" time=\"1234\">\n</testsuite>",
 		ExpectedXMLHeader, testsNo, failuresNo))
+}
+
+func getRealJUnitFailure() []byte {
+	return []byte(`<testsuite tests="7" failures="1" time="275.882258919">
+<testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a loadBalancer service." classname="Kubernetes e2e suite" time="17.759834805"/>
+<testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="21.201547548"/>
+<testcase name="[k8s.io] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc [Conformance]" classname="Kubernetes e2e suite" time="126.756441938">
+<failure type="Failure">
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/kubectl.go:972 May 18 13:02:24.715: No pods matched the filter.
+</failure>
+</testcase>
+<testcase name="[k8s.io] hostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="9.246191421"/>
+<testcase name="[k8s.io] Volumes [Feature:Volumes] [k8s.io] Ceph RBD should be mountable" classname="Kubernetes e2e suite" time="0">
+<skipped/>
+</testcase>
+<testcase name="[k8s.io] Deployment deployment should label adopted RSs and pods" classname="Kubernetes e2e suite" time="16.557498555"/>
+<testcase name="[k8s.io] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+<skipped/>
+</testcase>
+<testcase name="[k8s.io] V1Job should scale a job down" classname="Kubernetes e2e suite" time="77.122626914"/>
+<testcase name="[k8s.io] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="7.169679079"/>
+<testcase name="[k8s.io] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+<skipped/>
+</testcase>
+</testsuite>`)
 }
 
 func TestCheckGCSWeakBuilds(t *testing.T) {
@@ -466,5 +523,16 @@ func TestCheckGCSWeakBuilds(t *testing.T) {
 		if !reflect.DeepEqual(test.expectedStatus, e2e.BuildStatus) {
 			t.Errorf("expected: %v, saw: %v", test.expectedStatus, e2e.BuildStatus)
 		}
+	}
+}
+
+func TestJUnitFailureParse(t *testing.T) {
+	junitFailReader := bytes.NewReader(getRealJUnitFailure())
+	got, err := getJUnitFailures(junitFailReader)
+	if err != nil {
+		t.Fatalf("Parse error? %v", err)
+	}
+	if e, a := []string{"[k8s.io] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc [Conformance] {Kubernetes e2e suite}"}, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %v, got %v", e, a)
 	}
 }

--- a/mungegithub/mungers/e2e/fake/fake.go
+++ b/mungegithub/mungers/e2e/fake/fake.go
@@ -25,7 +25,7 @@ type FakeE2ETester struct {
 }
 
 // GCSBasedStable is always true.
-func (e *FakeE2ETester) GCSBasedStable() bool { return true }
+func (e *FakeE2ETester) GCSBasedStable() (bool, bool) { return true, false }
 
 // GCSWeakStable is always true.
 func (e *FakeE2ETester) GCSWeakStable() bool { return true }


### PR DESCRIPTION
Actually parse the junit result, allow merging to continue as long as we were able to get the list of failed tests and it doesn't intersect with the same list for the previous run.
