### PR TITLE
virtualbox as the default provider

### DIFF
--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -37,9 +37,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.insert_key = false
 
   # This explicitly sets the order that vagrant will use by default if no --provider given
+  config.vm.provider "virtualbox"
   config.vm.provider "openstack"
   config.vm.provider "libvirt"
-  config.vm.provider "virtualbox"
 
   def set_openstack_box(config)
     case $os_image


### PR DESCRIPTION
- My assumption is most people don't have an openstack cluster at their disposal to work with, so why is it the default, we should order these by which is the most likely vagrant deployment platform first and so on... If it's openstack -> libvirt -> virtualbox then we can close here, just wanted to bring it into question. 