### PR TITLE
Assign issues based on the "fixes #<n>" in the PR body

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -26,6 +26,7 @@ extra-memory
 extra-storage
 fake-e2e
 forward-services
+fixes-issue-reassign
 generated-files-config
 health-check-path
 healthz-port

--- a/mungegithub/mungers/assign-fixes.go
+++ b/mungegithub/mungers/assign-fixes.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"k8s.io/contrib/mungegithub/features"
+	"k8s.io/contrib/mungegithub/github"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+// AssignFixesMunger will assign issues to users based on the config file
+// provided by --assignfixes-config.
+type AssignFixesMunger struct {
+	config              *github.Config
+	features            *features.Features
+	assignfixesReassign bool
+}
+
+func init() {
+	assignfixes := &AssignFixesMunger{}
+	RegisterMungerOrDie(assignfixes)
+}
+
+// Name is the name usable in --pr-mungers
+func (a *AssignFixesMunger) Name() string { return "assign-fixes" }
+
+// RequiredFeatures is a slice of 'features' that must be provided
+func (a *AssignFixesMunger) RequiredFeatures() []string { return []string{} }
+
+// Initialize will initialize the munger
+func (a *AssignFixesMunger) Initialize(config *github.Config, features *features.Features) error {
+	a.features = features
+	a.config = config
+	return nil
+}
+
+// EachLoop is called at the start of every munge loop
+func (a *AssignFixesMunger) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (a *AssignFixesMunger) AddFlags(cmd *cobra.Command, config *github.Config) {
+	cmd.Flags().BoolVar(&a.assignfixesReassign, "fixes-issue-reassign", false, "Assign fixes Issues even if they're already assigned")
+}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (a *AssignFixesMunger) Munge(obj *github.MungeObject) {
+	if !obj.IsPR() {
+		return
+	}
+	// we need the PR for the "User" (creator of the PR not the assignee)
+	pr, err := obj.GetPR()
+	if err != nil {
+		glog.Infof("Couldn't get PR %v", obj.Issue.Number)
+		return
+	}
+	prOwner := github.DescribeUser(pr.User)
+
+	issuesFixed := obj.GetPRFixesList()
+	if issuesFixed == nil {
+		return
+	}
+	for _, fixesNum := range issuesFixed {
+		// "issue" is the issue referenced by the "fixes #<num>"
+		issueObj, err := a.config.GetObject(fixesNum)
+		if err != nil {
+			glog.Infof("Couldn't get issue %v", fixesNum)
+			continue
+		}
+		issue := issueObj.Issue
+		if !a.assignfixesReassign && issue.Assignee != nil {
+			glog.V(6).Infof("skipping %v: reassign: %v assignee: %v", *issue.Number, a.assignfixesReassign, github.DescribeUser(issue.Assignee))
+			continue
+		}
+		glog.Infof("Assigning %v to %v (previously assigned to %v)", *issue.Number, prOwner, github.DescribeUser(issue.Assignee))
+		// although it says "AssignPR" it's more generic than that and is really just an issue.
+		issueObj.AssignPR(prOwner)
+	}
+
+}

--- a/mungegithub/mungers/assign-fixes_test.go
+++ b/mungegithub/mungers/assign-fixes_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"runtime"
+	"testing"
+
+	github_util "k8s.io/contrib/mungegithub/github"
+	github_test "k8s.io/contrib/mungegithub/github/testing"
+
+	"github.com/golang/glog"
+	"github.com/google/go-github/github"
+)
+
+var (
+	_ = fmt.Printf
+	_ = glog.Errorf
+)
+
+func TestAssignFixes(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	tests := []struct {
+		name       string
+		assignee   string
+		pr         *github.PullRequest
+		prIssue    *github.Issue
+		prBody     string
+		fixesIssue *github.Issue
+	}{
+		{
+			name:       "fixes an issue",
+			assignee:   "dev45",
+			pr:         github_test.PullRequest("dev45", false, true, true),
+			prIssue:    github_test.Issue("fred", 7779, []string{}, true),
+			prBody:     "does stuff and fixes #8889.",
+			fixesIssue: github_test.Issue("jill", 8889, []string{}, true),
+		},
+	}
+	for _, test := range tests {
+		test.prIssue.Body = &test.prBody
+		client, server, mux := github_test.InitServer(t, test.prIssue, test.pr, nil, nil, nil, nil)
+		path := fmt.Sprintf("/repos/o/r/issues/%d", *test.fixesIssue.Number)
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			data, err := json.Marshal(test.fixesIssue)
+			if err != nil {
+				t.Errorf("%v", err)
+			}
+			if r.Method != "PATCH" && r.Method != "GET" {
+				t.Errorf("Unexpected method: expected: GET/PATCH got: %s", r.Method)
+			}
+			if r.Method == "PATCH" {
+				body, _ := ioutil.ReadAll(r.Body)
+
+				type IssuePatch struct {
+					Assignee string
+				}
+				var ip IssuePatch
+				err := json.Unmarshal(body, &ip)
+				if err != nil {
+					fmt.Println("error:", err)
+				}
+				if ip.Assignee != test.assignee {
+					t.Errorf("Patching the incorrect Assignee %v instead of %v", ip.Assignee, test.assignee)
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(data)
+		})
+
+		config := &github_util.Config{}
+		config.Org = "o"
+		config.Project = "r"
+		config.SetClient(client)
+
+		c := AssignFixesMunger{}
+		err := c.Initialize(config, nil)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		err = c.EachLoop()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		obj, err := config.GetObject(*test.prIssue.Number)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		c.Munge(obj)
+		server.Close()
+	}
+}

--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/contrib/mungegithub/github"
 
 	"github.com/golang/glog"
-	githubapi "github.com/google/go-github/github"
 	"github.com/spf13/cobra"
 )
 
@@ -69,14 +68,6 @@ func (b *BlunderbussMunger) AddFlags(cmd *cobra.Command, config *github.Config) 
 	cmd.Flags().BoolVar(&b.blunderbussReassign, "blunderbuss-reassign", false, "Assign PRs even if they're already assigned; use with -dry-run to judge changes to the assignment algorithm")
 }
 
-// u may be nil.
-func describeUser(u *githubapi.User) string {
-	if u != nil && u.Login != nil {
-		return *u.Login
-	}
-	return "<nil>"
-}
-
 func chance(val, total int64) float64 {
 	return 100.0 * float64(val) / float64(total)
 }
@@ -99,7 +90,7 @@ func (b *BlunderbussMunger) Munge(obj *github.MungeObject) {
 
 	issue := obj.Issue
 	if !b.blunderbussReassign && issue.Assignee != nil {
-		glog.V(6).Infof("skipping %v: reassign: %v assignee: %v", *issue.Number, b.blunderbussReassign, describeUser(issue.Assignee))
+		glog.V(6).Infof("skipping %v: reassign: %v assignee: %v", *issue.Number, b.blunderbussReassign, github.DescribeUser(issue.Assignee))
 		return
 	}
 
@@ -153,6 +144,6 @@ func (b *BlunderbussMunger) Munge(obj *github.MungeObject) {
 		}
 	}
 	c := chance(potentialOwners[owner], weightSum)
-	glog.Infof("Assigning %v to %v who had a %02.2f%% chance to be assigned (previously assigned to %v)", *issue.Number, owner, c, describeUser(issue.Assignee))
+	glog.Infof("Assigning %v to %v who had a %02.2f%% chance to be assigned (previously assigned to %v)", *issue.Number, owner, c, github.DescribeUser(issue.Assignee))
 	obj.AssignPR(owner)
 }


### PR DESCRIPTION
This is initially from a discussion on kubernetes-dev about the struggle to set the assignee
field in issues. It does not solve the problem of setting this field as the developer intends to
work on an issue, but at least fills it in once the PR is created. Ideas welcome...