### PR TITLE
[ingress] bump makefile and rc specifications to v0.62 for a new build

### DIFF
--- a/ingress/controllers/nginx/Makefile
+++ b/ingress/controllers/nginx/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any release builds
-TAG = 0.61
+TAG = 0.62
 PREFIX = gcr.io/google_containers/nginx-ingress-controller
 
 REPO_INFO=$(shell git config --get remote.origin.url)

--- a/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
+++ b/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60      
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
+++ b/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60      
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
+++ b/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60      
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/default/rc-default.yaml
+++ b/ingress/controllers/nginx/examples/default/rc-default.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60      
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/full/rc-full.yaml
+++ b/ingress/controllers/nginx/examples/full/rc-full.yaml
@@ -21,7 +21,7 @@ spec:
         secret:
           secretName: dhparam-example
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
+++ b/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
+++ b/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60      
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
+++ b/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60      
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/udp/rc-udp.yaml
+++ b/ingress/controllers/nginx/examples/udp/rc-udp.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60      
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/rc.yaml
+++ b/ingress/controllers/nginx/rc.yaml
@@ -68,7 +68,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.61
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.62
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
Closes #1027. The following files are version bumped, with my understanding that a new build of the nginx-ingress-controller image will be auto-built from this merge. Merging this will allow for #898 to make it's way into the official image.