### PR TITLE
ansible: upgrade default kube version to 1.2.4

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of Kubernetes binaries
-kube_version: 1.2.2
+kube_version: 1.2.4
 
 # The port that the Kubernetes apiserver component listens on.
 kube_master_api_port: 443


### PR DESCRIPTION
I followed @elemoine 's suggestion and raised the default kube version to the latest release

CoreOS upgrade from 1.2.2 and from scratch works fine locally