### PR TITLE
ingress: nginx controller watches referenced tls secrets

### DIFF
--- a/ingress/controllers/nginx/utils.go
+++ b/ingress/controllers/nginx/utils.go
@@ -37,6 +37,11 @@ type StoreToIngressLister struct {
 	cache.Store
 }
 
+// StoreToSecretsLister makes a Store that lists Secrets.
+type StoreToSecretsLister struct {
+	cache.Store
+}
+
 // StoreToConfigmapLister makes a Store that lists Configmap.
 type StoreToConfigmapLister struct {
 	cache.Store


### PR DESCRIPTION
This enables the controller to reload certificates on changes in the secrets.

We are maintaining a list of referenced certificates in secrMetadata to only reload/sync the controller when something in referenced certificates changes.