### PR TITLE
Enable the assign-fixes githubmunger

### DIFF
--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         command:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
-        - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue,issue-cacher,flake-manager,old-test-getter
+        - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue,issue-cacher,flake-manager,old-test-getter,assign-fixes
         - --do-not-merge-milestones=,next-candidate,v1.4
         - --dry-run=true
         - --weak-stable-jobs=kubernetes-kubemark-500-gce


### PR DESCRIPTION
The code for this munger has just been merged, this just enables it.

https://github.com/kubernetes/contrib/blob/master/mungegithub/mungers/assign-fixes.go

This munger will search for "fixes #<num>" in a PR message text and assign the referenced issues to the owner of the PR.
