### PR TITLE
Introduce a flag to block merges for certain milestones

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -13,6 +13,7 @@ default-return-code
 delete-all-on-quit
 dest-file
 dont-require-e2e-label
+do-not-merge-milestones
 dry-run
 e2e-status-context
 election-namespace

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -157,6 +157,7 @@ type SubmitQueue struct {
 	E2EStatusContext       string
 	UnitStatusContext      string
 	RequiredStatusContexts []string
+	doNotMergeMilestones   []string
 
 	// additionalUserWhitelist are non-committer users believed safe
 	additionalUserWhitelist *sets.String
@@ -399,6 +400,7 @@ func (sq *SubmitQueue) AddFlags(cmd *cobra.Command, config *github.Config) {
 	cmd.Flags().StringVar(&sq.E2EStatusContext, "e2e-status-context", jenkinsE2EContext, "The name of the github status context for the e2e PR Builder")
 	cmd.Flags().StringVar(&sq.UnitStatusContext, "unit-status-context", jenkinsUnitContext, "The name of the github status context for the unit PR Builder")
 	cmd.Flags().BoolVar(&sq.FakeE2E, "fake-e2e", false, "Whether to use a fake for testing E2E stability.")
+	cmd.Flags().StringSliceVar(&sq.doNotMergeMilestones, "do-not-merge-milestones", []string{}, "List of milestones which, when applied, will cause the PR to not be merged")
 	sq.addWhitelistCommand(cmd, config)
 }
 
@@ -552,6 +554,8 @@ func reasonToState(reason string) string {
 	switch reason {
 	case merged:
 		return "success"
+	case mergedByHand:
+		return "success"
 	case e2eFailure:
 		return "success"
 	case ghE2EQueued:
@@ -699,10 +703,12 @@ const (
 	e2eFailure              = "The e2e tests are failing. The entire submit queue is blocked."
 	e2eRecover              = "The e2e tests started passing. The submit queue is unblocked."
 	merged                  = "MERGED!"
+	mergedByHand            = "MERGED! (by hand outside of submit queue)"
 	ghE2EQueued             = "Queued to run github e2e tests a second time."
 	ghE2EWaitingStart       = "Requested and waiting for github e2e test to start running a second time."
 	ghE2ERunning            = "Running github e2e tests a second time."
 	ghE2EFailed             = "Second github e2e run failed."
+	unmergeableMilestone    = "Milestone is for a future release and cannot be merged"
 )
 
 func (sq *SubmitQueue) requiredStatusContexts(obj *github.MungeObject) []string {
@@ -734,8 +740,18 @@ func (sq *SubmitQueue) validForMerge(obj *github.MungeObject) bool {
 		sq.SetMergeStatus(obj, unknown)
 		return false
 	} else if m {
-		sq.SetMergeStatus(obj, merged)
+		sq.SetMergeStatus(obj, mergedByHand)
 		return false
+	}
+
+	if milestone := obj.Issue.Milestone; milestone != nil && milestone.Title != nil {
+		title := *milestone.Title
+		for _, blocked := range sq.doNotMergeMilestones {
+			if title == blocked {
+				sq.SetMergeStatus(obj, unmergeableMilestone)
+				return false
+			}
+		}
 	}
 
 	userSet := sq.userWhitelist
@@ -1157,6 +1173,7 @@ func (sq *SubmitQueue) serveMergeInfo(res http.ResponseWriter, req *http.Request
 		out.WriteString("</ul>")
 		out.WriteString(fmt.Sprintf("%s</li>", exceptStr))
 	}
+	out.WriteString(fmt.Sprintf("<li>The PR cannot have any of the following milestones: %v</li>", sq.doNotMergeMilestones))
 	out.WriteString(fmt.Sprintf("<li>The PR either needs the label %q or the creator of the PR must be in the 'Users' list seen on the 'Info' tab.</li>", okToMergeLabel))
 	out.WriteString(fmt.Sprintf(`<li>The PR must have the %q label</li>`, lgtmLabel))
 	out.WriteString(fmt.Sprintf("<li>The PR must not have been updated since the %q label was applied</li>", lgtmLabel))

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -49,8 +49,11 @@ func stringPtr(val string) *string { return &val }
 func boolPtr(val bool) *bool       { return &val }
 func intPtr(val int) *int          { return &val }
 
-const noWhitelistUser = "UserNotInWhitelist"
-const whitelistUser = "WhitelistUser"
+const (
+	noWhitelistUser     = "UserNotInWhitelist"
+	whitelistUser       = "WhitelistUser"
+	doNotMergeMilestone = "some-milestone-you-should-not-merge"
+)
 
 func ValidPR() *github.PullRequest {
 	return github_test.PullRequest(whitelistUser, false, true, true)
@@ -85,6 +88,15 @@ func NoOKToMergeIssue() *github.Issue {
 
 func DoNotMergeIssue() *github.Issue {
 	return github_test.Issue(whitelistUser, 1, []string{claYesLabel, lgtmLabel, doNotMergeLabel}, true)
+}
+
+func DoNotMergeMilestoneIssue() *github.Issue {
+	issue := github_test.Issue(whitelistUser, 1, []string{claYesLabel, lgtmLabel, doNotMergeLabel}, true)
+	milestone := &github.Milestone{
+		Title: stringPtr(doNotMergeMilestone),
+	}
+	issue.Milestone = milestone
+	return issue
 }
 
 func NoCLAIssue() *github.Issue {
@@ -201,6 +213,8 @@ func getTestSQ(startThreads bool, config *github_util.Config, server *httptest.S
 
 	sq.health.StartTime = sq.clock.Now()
 	sq.healthHistory = make([]healthRecord, 0)
+
+	sq.doNotMergeMilestones = []string{doNotMergeMilestone}
 
 	sq.e2e = &fake_e2e.FakeE2ETester{
 		JobNames:           sq.JobNames,
@@ -511,7 +525,7 @@ func TestSubmitQueue(t *testing.T) {
 			weakResults:     map[int]utils.FinishedFile{LastBuildNumber(): SuccessGCS()},
 			// The test should never run, but if it does, make sure it fails
 			mergeAfterQueued: true,
-			reason:           merged,
+			reason:           mergedByHand,
 			state:            "success",
 		},
 		// Should merge even though github ci failed because of dont-require-e2e
@@ -753,6 +767,23 @@ func TestSubmitQueue(t *testing.T) {
 			e2ePass:         true,
 			unitPass:        true,
 			reason:          noMerge,
+			state:           "pending",
+		},
+		// Should fail because the 'do-not-merge-milestone' is set.
+		{
+			name:            "Do Not Merge Milestone Set",
+			pr:              ValidPR(),
+			issue:           DoNotMergeMilestoneIssue(),
+			events:          NewLGTMEvents(),
+			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus:        SuccessStatus(),
+			jenkinsJob:      SuccessJenkins(),
+			lastBuildNumber: LastBuildNumber(),
+			gcsResult:       SuccessGCS(),
+			weakResults:     map[int]utils.FinishedFile{LastBuildNumber(): SuccessGCS()},
+			e2ePass:         true,
+			unitPass:        true,
+			reason:          unmergeableMilestone,
 			state:           "pending",
 		},
 		// // Should pass even though last 'weakStable' build failed, as it wasn't "strong" failure

--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -15,6 +15,7 @@ spec:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
         - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue,issue-cacher,flake-manager
+        - --do-not-merge-milestones=next-candidate,v1.4
         - --dry-run=true
         - --weak-stable-jobs=kubernetes-kubemark-500-gce
         image: gcr.io/google_containers/submit-queue:2016-05-24-86f86cd


### PR DESCRIPTION
This blocks merge for v1.4 and next-candidate. When we open for v1.4 we
should remove `v1.4` from the flags and remove `next-candidate` from all
PRs.
