### PR TITLE
Introduce a flag to block merges for certain milestones

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -14,6 +14,7 @@ default-return-code
 delete-all-on-quit
 dest-file
 dont-require-e2e-label
+do-not-merge-milestones
 dry-run
 dump-nginx-configuration
 e2e-status-context

--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -15,6 +15,7 @@ spec:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
         - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue,issue-cacher,flake-manager,old-test-getter
+        - --do-not-merge-milestones=,next-candidate,v1.4
         - --dry-run=true
         - --weak-stable-jobs=kubernetes-kubemark-500-gce
         image: gcr.io/google_containers/submit-queue:2016-05-24-86f86cd


### PR DESCRIPTION
This blocks merge for v1.4 and next-candidate. When we open for v1.4 we
should remove `v1.4` from the flags and remove `next-candidate` from all
PRs.