### PR TITLE
When building kubernetes from sources, some runtime deps are missing

### DIFF
--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -91,3 +91,11 @@
   sudo: yes
   roles:
     - { role: contiv, contiv_role: netplugin, when: networking == 'contiv' }
+
+# install runtime dependencies
+- hosts: nodes
+  sudo: yes
+  roles:
+  - epilogue
+  tags:
+  - epilogue

--- a/ansible/roles/epilogue/tasks/main.yml
+++ b/ansible/roles/epilogue/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: Install kubernetes runtime dependencies
+  action: "{{ ansible_pkg_mgr }}"
+  args:
+        name: "{{ item }}"
+        state: latest
+  with_items:
+  - socat
+  - tar
+  - git
+  when: source_type == "localBuild" and (ansible_distribution == "Fedora" or ansible_distribution == "RedHat" or ansible_distribution == "CentOS")


### PR DESCRIPTION
When running e2e tests on kubernetes built from sources, some runtime dependencies are missing.

IMHO, this is not actually needed to deploy the cluster. Though, the runtime dependencies are needed to run kubernetes properly. This is relevant only for deployments when k8s is built from sources. If k8s is installed from a distribution packages, missing dependencies are already there.

So far the deps are installed only for Fedora, RHEL and CentOS. Not sure how this is handled for CoreOS or other OSes. 

Fixes: #1087 