### PR TITLE
Do not update merge rate if we don't run e2e

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -991,7 +991,6 @@ func (sq *SubmitQueue) handleGithubE2EAndMerge() {
 
 func (sq *SubmitQueue) mergePullRequest(obj *github.MungeObject) {
 	obj.MergePR("submit-queue")
-	sq.updateMergeRate()
 	sq.SetMergeStatus(obj, merged)
 }
 
@@ -1050,6 +1049,7 @@ func (sq *SubmitQueue) doGithubE2EAndMerge(obj *github.MungeObject) bool {
 	}
 
 	if obj.HasLabel(e2eNotRequiredLabel) {
+		// Do not update mergeRate when we don't do e2e tests
 		sq.mergePullRequest(obj)
 		return true
 	}
@@ -1100,6 +1100,7 @@ func (sq *SubmitQueue) doGithubE2EAndMerge(obj *github.MungeObject) bool {
 		return true
 	}
 
+	sq.updateMergeRate()
 	sq.mergePullRequest(obj)
 	return true
 }


### PR DESCRIPTION
If we don't run e2e tests, it makes it very easy to merge quickly, and
that makes the merge rate very high. Just do not include non-e2e merges
into the rate so that we keep it relevant.