### PR TITLE
[ubuntu-slim]: Remove locales

### DIFF
--- a/images/ubuntu-slim/Dockerfile.build
+++ b/images/ubuntu-slim/Dockerfile.build
@@ -1,8 +1,13 @@
 FROM ubuntu:16.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get dist-upgrade -y
+COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
+
+RUN apt-get update \
+    && apt-get dist-upgrade -y
+
+COPY runlevel /sbin/runlevel
 
 # hold required packages to avoid breaking the installation of packages
 RUN apt-mark hold apt gnupg adduser passwd libsemanage1
@@ -17,8 +22,6 @@ RUN echo "Yes, do as I say!" | apt-get purge \
     tzdata
 
 RUN apt-get autoremove -y
-
-COPY runlevel /sbin/runlevel
 
 RUN sed -i 's/bash/sh/g' /etc/passwd
 
@@ -42,4 +45,6 @@ RUN apt-get clean -y && \
         ~/.bashrc \
         /etc/systemd \
         /lib/lsb \
-        /lib/udev
+        /lib/udev \
+        /usr/lib/x86_64-linux-gnu/gconv/IBM* \
+        /usr/lib/x86_64-linux-gnu/gconv/EBC*

--- a/images/ubuntu-slim/Makefile
+++ b/images/ubuntu-slim/Makefile
@@ -1,11 +1,12 @@
 all: push
 
-TAG ?= 0.2
+TAG ?= 0.3
 PREFIX ?= gcr.io/google_containers/ubuntu-slim
 BUILD_IMAGE ?= ubuntu-build
 TAR_FILE ?= rootfs.tar
 
 container:
+	rm -f $(TAR_FILE)
 	docker build -t $(BUILD_IMAGE) -f Dockerfile.build .
 	docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE)
 	docker export $(BUILD_IMAGE) > $(TAR_FILE)
@@ -18,4 +19,4 @@ push: container
 clean:
 	docker rmi -f $(PREFIX):$(TAG)
 	docker rmi -f $(BUILD_IMAGE)
-	rm $(TAR_FILE)
+	rm -f $(TAR_FILE)

--- a/images/ubuntu-slim/README.md
+++ b/images/ubuntu-slim/README.md
@@ -1,7 +1,7 @@
 
 Small Ubuntu 16.04 docker image
 
-The size of this image is ~60MB (less than half than `ubuntu:16.04).
+The size of this image is ~47MB (less than half than `ubuntu:16.04).
 This is possible by the removal of packages that are not required in a container:
 - dmsetup
 - e2fsprogs

--- a/images/ubuntu-slim/excludes
+++ b/images/ubuntu-slim/excludes
@@ -1,0 +1,10 @@
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/man/*
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/en_US*
+path-include /usr/share/locale/locale.alias
+path-exclude /usr/share/i18n/locales/*
+path-include /usr/share/i18n/locales/en_US*


### PR DESCRIPTION
This update reduces the size of the image in 12MB

```
gcr.io/google_containers/ubuntu-slim  0.3   6e333e89d38c   9 hours ago 47.33 MB
gcr.io/google_containers/ubuntu-slim  0.2   010be51edff2   5 weeks ago 59.37 MB
```