### PR TITLE
submit-queue: redo retest logic

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -98,3 +98,5 @@ watch-namespace
 weak-stable-jobs
 whitelist-override-label
 config-file-path
+required-retest-contexts
+retest-body

--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -40,8 +40,8 @@ var (
 	requiredContexts = []string{jenkinsUnitContext, jenkinsE2EContext}
 )
 
-// StaleGreenCI will remove the LGTM flag from an PR which has been
-// updated since the reviewer added LGTM
+// StaleGreenCI will re-run passed tests for LGTM PRs if they are more than
+// 96 hours old.
 type StaleGreenCI struct{}
 
 func init() {

--- a/mungegithub/mungers/stale-green-ci_test.go
+++ b/mungegithub/mungers/stale-green-ci_test.go
@@ -49,6 +49,10 @@ func NowStatus() *github.CombinedStatus {
 	return status
 }
 
+func OldStatus() *github.CombinedStatus {
+	return github_test.Status("mysha", []string{travisContext, jenkinsUnitContext, jenkinsE2EContext}, nil, nil, nil)
+}
+
 func TestOldUnitTestMunge(t *testing.T) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
@@ -60,7 +64,7 @@ func TestOldUnitTestMunge(t *testing.T) {
 		{
 			name:     "Test0",
 			tested:   true,
-			ciStatus: SuccessStatus(), // Ran at time.Unix(0,0)
+			ciStatus: OldStatus(), // Ran at time.Unix(0,0)
 		},
 		{
 			name:     "Test1",


### PR DESCRIPTION
This changes the required status logic a fair bit.

1. All PRs must pass all 'required' contexts at least once
2. Change `e2e-not-required` label name to `retest-not-required`
3. Create 2 types of 'required' contexts:

     `RequiredStatusContexts` and `RequiredRetestContexts`

   All must be success to merge a PR but only RequiredRetestContexts
   must be true twice.
4. Get rid of the custom flags for our unit and e2e tests
5. New flag to tell the bot how to request the requisite retests