### PR TITLE
Clear sq.interruptedObj no matter what

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -1001,6 +1001,9 @@ func newInterruptedObject(obj *github.MungeObject) *submitQueueInterruptedObject
 
 // Returns true if we can discard the PR from the queue, false if we must keep it for later.
 func (sq *SubmitQueue) doGithubE2EAndMerge(obj *github.MungeObject) bool {
+	interruptedObj := sq.interruptedObj
+	sq.interruptedObj = nil
+
 	err := obj.Refresh()
 	if err != nil {
 		glog.Errorf("%d: unknown err: %v", *obj.Issue.Number, err)
@@ -1018,8 +1021,6 @@ func (sq *SubmitQueue) doGithubE2EAndMerge(obj *github.MungeObject) bool {
 		return true
 	}
 
-	interruptedObj := sq.interruptedObj
-	sq.interruptedObj = nil
 	if interruptedObj != nil {
 		if interruptedObj.hasSHAChanged() {
 			// This PR will have to be rested.
@@ -1059,7 +1060,9 @@ func (sq *SubmitQueue) doGithubE2EAndMerge(obj *github.MungeObject) bool {
 	}
 
 	if !sq.e2eStable(true) {
-		sq.interruptedObj = newInterruptedObject(obj)
+		if sq.validForMerge(obj) {
+			sq.interruptedObj = newInterruptedObject(obj)
+		}
 		sq.SetMergeStatus(obj, e2eFailure)
 		return true
 	}


### PR DESCRIPTION
If the following happens
- PR starts retest
- the whole queue blocks
- PR retests fail

The PR will end up on the 'sq.interruptedObj'. When the global e2e goes
back green
- the interrupted PR will get picked first
- enter doGithubE2EAndMerge()
- fail out of doGithubE2EAndMerge() because sq.validForMerge(obj) fails
- get picked again as the interrupted PR
- goto 2

resolves #1149 
