### PR TITLE
nginx-ingress-controller: Use DefaultClientConfig to create clientConfig

### DIFF
--- a/ingress/controllers/nginx/main.go
+++ b/ingress/controllers/nginx/main.go
@@ -90,8 +90,8 @@ var (
 func main() {
 	var kubeClient *unversioned.Client
 	flags.AddGoFlagSet(flag.CommandLine)
-	flags.Parse(os.Args)
 	clientConfig := kubectl_util.DefaultClientConfig(flags)
+	flags.Parse(os.Args)
 
 	glog.Infof("Using build: %v - %v", gitRepo, version)
 
@@ -104,16 +104,11 @@ func main() {
 		glog.Fatalf("Please specify --default-backend-service")
 	}
 
-	var err error
-	if *inCluster {
-		kubeClient, err = unversioned.NewInCluster()
-	} else {
-		config, connErr := clientConfig.ClientConfig()
-		if connErr != nil {
-			glog.Fatalf("error connecting to the client: %v", err)
-		}
-		kubeClient, err = unversioned.New(config)
+	config, connErr := clientConfig.ClientConfig()
+	if connErr != nil {
+		glog.Fatalf("error connecting to the client: %v", connErr)
 	}
+	kubeClient, err := unversioned.New(config)
 	if err != nil {
 		glog.Fatalf("failed to create client: %v", err)
 	}


### PR DESCRIPTION
This PR use the configuration generated from DefaultClientConfig, instead of trying to generate one so that the server URL and credentials can be specified from the command line.

The runtime pod detection haven't been improved, and probably will fail if you use remote server. To workaround this, use `--running-in-cluster=false` and manually load a load balancer service configuration.

An image with this PR is available at [willwill/nginx-ingress-controller](https://hub.docker.com/r/willwill/nginx-ingress-controller/) on Docker Hub.