### PR TITLE
cluster-autoscaler: Don't delete nodes with pods with local storage

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -72,6 +72,8 @@ shame-cc
 shame-from
 shame-reply-to
 shame-report-cmd
+skip-nodes-with-system-pods
+skip-nodes-with-local-storage
 source-file
 ssl-ca-cert
 ssl-cert


### PR DESCRIPTION
Don't delete nodes with pods with local storage.

Add flags to control whether we fail on draining nodes with kube-system pods & pods with local storage.

Fixes https://github.com/kubernetes/contrib/issues/1162

@piosz @jszczepkowski 
