### PR TITLE
Mungebot: Inactivity pinger

### DIFF
--- a/mungegithub/Godeps/Godeps.json
+++ b/mungegithub/Godeps/Godeps.json
@@ -30,7 +30,7 @@
 		},
 		{
 			"ImportPath": "github.com/google/go-github/github",
-			"Rev": "63fbbb283ce4913a5ac1b6de7abae50dbf594a04"
+			"Rev": "7ec4e45f77474b3a7b7d9b7ef233a0cc8339ddf3"
 		},
 		{
 			"ImportPath": "github.com/google/go-querystring/query",

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -193,30 +193,32 @@ type analytics struct {
 	cachedAPICount     int       // how many api calls were answered by the local cache
 	apiPerSec          float64
 
-	AddLabels         analytic
-	RemoveLabels      analytic
-	ListCollaborators analytic
-	GetIssue          analytic
-	CloseIssue        analytic
-	CreateIssue       analytic
-	ListIssues        analytic
-	ListIssueEvents   analytic
-	ListCommits       analytic
-	GetCommit         analytic
-	GetCombinedStatus analytic
-	SetStatus         analytic
-	GetPR             analytic
-	AssignPR          analytic
-	ClosePR           analytic
-	OpenPR            analytic
-	GetContents       analytic
-	ListComments      analytic
-	CreateComment     analytic
-	DeleteComment     analytic
-	Merge             analytic
-	GetUser           analytic
-	SetMilestone      analytic
-	ListMilestones    analytic
+	AddLabels          analytic
+	RemoveLabels       analytic
+	ListCollaborators  analytic
+	GetIssue           analytic
+	CloseIssue         analytic
+	CreateIssue        analytic
+	ListIssues         analytic
+	ListIssueEvents    analytic
+	ListReviewComments analytic
+	ReplyReviewComment analytic
+	ListCommits        analytic
+	GetCommit          analytic
+	GetCombinedStatus  analytic
+	SetStatus          analytic
+	GetPR              analytic
+	AssignPR           analytic
+	ClosePR            analytic
+	OpenPR             analytic
+	GetContents        analytic
+	ListComments       analytic
+	CreateComment      analytic
+	DeleteComment      analytic
+	Merge              analytic
+	GetUser            analytic
+	SetMilestone       analytic
+	ListMilestones     analytic
 }
 
 func (a analytics) print() {
@@ -242,6 +244,7 @@ func (a analytics) print() {
 	fmt.Fprintf(w, "ClosePR\t%d\t\n", a.ClosePR.Count)
 	fmt.Fprintf(w, "OpenPR\t%d\t\n", a.OpenPR.Count)
 	fmt.Fprintf(w, "GetContents\t%d\t\n", a.GetContents.Count)
+	fmt.Fprintf(w, "ListReviewComments\t%d\t\n", a.ListReviewComments.Count)
 	fmt.Fprintf(w, "ListComments\t%d\t\n", a.ListComments.Count)
 	fmt.Fprintf(w, "CreateComment\t%d\t\n", a.CreateComment.Count)
 	fmt.Fprintf(w, "DeleteComment\t%d\t\n", a.DeleteComment.Count)
@@ -261,6 +264,7 @@ type MungeObject struct {
 	pr          *github.PullRequest
 	commits     []github.RepositoryCommit
 	events      []github.IssueEvent
+	prComments  []github.PullRequestComment
 	comments    []github.IssueComment
 	Annotations map[string]string //annotations are things you can set yourself.
 }
@@ -1426,6 +1430,59 @@ func (obj *MungeObject) GetPRFixesList() []int {
 		}
 	}
 	return issueNums
+}
+
+// ListReviewComments returns all review (diff) comments for the PR in question
+func (obj *MungeObject) ListReviewComments() ([]github.PullRequestComment, error) {
+	config := obj.config
+	prNum := *obj.Issue.Number
+	allComments := []github.PullRequestComment{}
+
+	if obj.prComments != nil {
+		return obj.prComments, nil
+	}
+
+	listOpts := &github.PullRequestListCommentsOptions{}
+
+	page := 1
+	for {
+		listOpts.ListOptions.Page = page
+		glog.V(8).Infof("Fetching page %d of comments for issue %d", page, prNum)
+		comments, response, err := obj.config.client.PullRequests.ListComments(config.Org, config.Project, prNum, listOpts)
+		config.analytics.ListReviewComments.Call(config, response)
+		if err != nil {
+			return nil, err
+		}
+		allComments = append(allComments, comments...)
+		if response.LastPage == 0 || response.LastPage <= page {
+			break
+		}
+		page++
+	}
+	obj.prComments = allComments
+	return allComments, nil
+}
+
+// ReplyToReviewComment will write `msg` as a response to the specified review comment
+func (obj *MungeObject) ReplyToReviewComment(inReplyTo int, msg string) error {
+	config := obj.config
+	prNum := *obj.Issue.Number
+
+	if !obj.IsPR() {
+		return fmt.Errorf("Issue: %d is not a PR and thus it is impossible to reply to a review comment", *obj.Issue.Number)
+	}
+
+	config.analytics.ReplyReviewComment.Call(config, nil)
+	glog.Infof("Replying to review comment %d of PR %d: %q", inReplyTo, prNum, msg)
+	if config.DryRun {
+		return nil
+	}
+
+	if _, _, err := config.client.PullRequests.CreateComment(config.Org, config.Project, prNum, &github.PullRequestComment{InReplyTo: &inReplyTo, Body: &msg}); err != nil {
+		glog.Errorf("%v", err)
+		return err
+	}
+	return nil
 }
 
 // ListComments returns all comments for the issue/PR in question

--- a/mungegithub/mungers/ping-inactivity.go
+++ b/mungegithub/mungers/ping-inactivity.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	githubapi "github.com/google/go-github/github"
+	"github.com/spf13/cobra"
+	"k8s.io/contrib/mungegithub/features"
+	"k8s.io/contrib/mungegithub/github"
+)
+
+const (
+	maxReviewCommentInactivity = 2 * 7 * 24 * time.Hour
+	maxPrCommentInactivity     = 2 * 7 * 24 * time.Hour
+	highlight                  = "@" + botName
+	ignoreTrigger              = "@" + botName + " ignore inactivity"
+	postponeTrigger            = "@" + botName + " postpone by"
+
+	reviewCommentInactivityMessage = `The comment above looks stale. Could you please take a look?
+
+	You may update the code, reply with "` + ignoreTrigger + `" or with "` + postponeTrigger + ` X day(s)/week(s)/month(s)".`
+
+	prInactivityMessage = `The PR looks stale. Could you please take a look?
+
+	You may reply with "` + ignoreTrigger + `" or with "` + postponeTrigger + ` X day(s)/week(s)/month(s)".`
+)
+
+// InactivityPinger identifies inactive PRs and review comments and pings the appropriate person.
+type InactivityPinger struct{}
+
+func init() {
+	s := InactivityPinger{}
+	RegisterMungerOrDie(s)
+}
+
+// Name is the name usable in --pr-mungers
+func (InactivityPinger) Name() string { return "inactivity-pinger" }
+
+// RequiredFeatures is a slice of 'features' that must be provided
+func (InactivityPinger) RequiredFeatures() []string { return []string{} }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (InactivityPinger) AddFlags(cmd *cobra.Command, config *github.Config) {}
+
+// Initialize will initialize the munger
+func (InactivityPinger) Initialize(*github.Config, *features.Features) error {
+	return nil
+}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (InactivityPinger) Munge(obj *github.MungeObject) {
+	if !obj.IsPR() {
+		return
+	}
+
+	if !handleReviewComments(obj) {
+		handlePR(obj)
+	}
+}
+
+// EachLoop is called at the start of every munge loop
+func (InactivityPinger) EachLoop() error {
+	return nil
+}
+
+func handleReviewComments(obj *github.MungeObject) (notified bool) {
+	pr, err := obj.GetPR()
+	if err != nil {
+		glog.Errorf("unexpected error getting PR %d: %s", *obj.Issue.Number, err)
+	}
+
+	// Collect review comments, sort them by thread and by date.
+	reviewCommentsByThread, err := getSortedReviewCommentsByThread(obj, false)
+	if err != nil {
+		glog.Errorf("unexpected error getting sorted review comments by thread: %s", err)
+		return
+	}
+
+	for thread := range reviewCommentsByThread {
+		threadComments := reviewCommentsByThread[thread]
+
+		// Verify if the thread is active or inactive.
+		// Note that the last comment is used for that, and thus, it also considers the bot
+		// may has written.
+		lastComment := threadComments[len(threadComments)-1]
+		if lastComment.CreatedAt.After(time.Now().Add(-maxReviewCommentInactivity)) {
+			// Thread is active.
+			continue
+		}
+
+		// Verify if the thread should be ignored (explicitely ignored or postponed).
+		ignored := false
+		for _, comment := range threadComments {
+			ignored = strings.Contains(*comment.Body, ignoreTrigger) || isPostponed(*comment.Body, *comment.CreatedAt)
+		}
+		if ignored {
+			glog.V(4).Infof("ignoring PR %d's comment thread %s", *pr.Number, thread)
+			continue
+		}
+
+		// Send a notification.
+		var message string
+		if *lastComment.User.Login != *pr.User.Login {
+			// The last commenter isn't the PR's owner, notify him/her.
+			glog.V(4).Infof("notifying PR %d's owner: %s about comment thread %s due to inactivity", *pr.Number, *pr.User.Login, thread)
+			message = "@" + *pr.User.Login
+		} else {
+			if pr.Assignee == nil {
+				glog.V(4).Infof("desired to notify PR %d's assignee but there isn't", *pr.Number)
+				return
+			}
+
+			// The last commenter is the PR's owner, notify the PR's assignee.
+			glog.V(4).Infof("notifying PR %d's assignee: %s about comment thread %s due to inactivity", *pr.Number, *pr.Assignee.Login, thread)
+			message = "@" + *pr.Assignee.Login
+		}
+		message = message + " " + reviewCommentInactivityMessage
+
+		if err := obj.ReplyToReviewComment(*lastComment.ID, message); err != nil {
+			glog.Errorf("unexpected error replying to review comment: %v", err)
+		}
+
+		notified = true
+	}
+
+	return
+}
+
+func getSortedReviewCommentsByThread(obj *github.MungeObject, keepOutdated bool) (map[string][]githubapi.PullRequestComment, error) {
+	// Get all review comments.
+	prComments, err := obj.ListReviewComments()
+	if err != nil {
+		return nil, err
+	}
+
+	// Assign each comment to a thread.
+	prCommentsByThread := make(map[string][]githubapi.PullRequestComment)
+	for _, prComment := range prComments {
+		if !keepOutdated && prComment.Position == nil {
+			// Ignore outdated diffs.
+			continue
+		}
+
+		thread := *prComment.Path + ":" + (*prComment.DiffHunk)[3:strings.Index(*prComment.DiffHunk, " @@")]
+		prCommentsByThread[thread] = append(prCommentsByThread[thread], prComment)
+	}
+
+	// Sort each thread.
+	for _, threadComments := range prCommentsByThread {
+		sort.Sort(prcByCreatedAt(threadComments))
+	}
+
+	return prCommentsByThread, nil
+}
+
+func handlePR(obj *github.MungeObject) {
+	pr, err := obj.GetPR()
+	if err != nil {
+		glog.Errorf("unexpected error getting PR %d: %s", *obj.Issue.Number, err)
+	}
+
+	// Collect comments, sort them by date.
+	prComments, err := getSortedComments(obj)
+	if err != nil {
+		glog.Errorf("unexpect error getting sorted comments: %s", err)
+		return
+	}
+
+	// Verify if the PR is active or inactive.
+	// Note that the last comment is used for that, and thus, it also considers the bot
+	// may has written.
+	lastComment := prComments[len(prComments)-1]
+	if lastComment.CreatedAt.After(time.Now().Add(-maxPrCommentInactivity)) {
+		// Thread is active.
+		return
+	}
+
+	// Verify if the PR should be ignored (explicitely ignored or postponed).
+	ignored := false
+	for _, comment := range prComments {
+		ignored = strings.Contains(*comment.Body, ignoreTrigger) || isPostponed(*comment.Body, *comment.CreatedAt)
+	}
+	if ignored {
+		glog.V(4).Infof("ignoring PR %d", *pr.Number)
+		return
+	}
+
+	// Send a notification.
+	var message string
+	if *lastComment.User.Login != *pr.User.Login {
+		// The last commenter isn't the PR's owner, notify him/her.
+		glog.V(4).Infof("notifying PR %d's owner: %s due to inactivity", *pr.Number, *pr.User.Login)
+		message = "@" + *pr.User.Login
+	} else {
+		if pr.Assignee == nil {
+			glog.V(4).Infof("desired to notify PR %d's assignee but there isn't", *pr.Number)
+			return
+		}
+
+		// The last commenter is the PR's owner, notify the PR's assignee.
+		glog.V(4).Infof("notifying PR %d's assignee: %s due to inactivity", *pr.Number, *pr.Assignee.Login)
+		message = "@" + *pr.Assignee.Login
+	}
+	message = message + " " + prInactivityMessage
+
+	if err := obj.WriteComment(message); err != nil {
+		glog.Errorf("unexpected error adding comment: %v", err)
+	}
+}
+
+func getSortedComments(obj *github.MungeObject) ([]githubapi.IssueComment, error) {
+	// Get all review comments.
+	prComments, err := obj.ListComments()
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by date.
+	sort.Sort(icByCreatedAt(prComments))
+
+	return prComments, nil
+}
+
+type prcByCreatedAt []githubapi.PullRequestComment
+
+func (s prcByCreatedAt) Len() int           { return len(s) }
+func (s prcByCreatedAt) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s prcByCreatedAt) Less(i, j int) bool { return s[i].CreatedAt.Before(*(s[j].CreatedAt)) }
+
+type icByCreatedAt []githubapi.IssueComment
+
+func (s icByCreatedAt) Len() int           { return len(s) }
+func (s icByCreatedAt) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s icByCreatedAt) Less(i, j int) bool { return s[i].CreatedAt.Before(*(s[j].CreatedAt)) }
+
+func isPostponed(comment string, at time.Time) bool {
+	if !strings.Contains(comment, postponeTrigger) {
+		return false
+	}
+
+	// Tokenize comment.
+	comment = strings.TrimPrefix(comment, postponeTrigger+" ")
+	commentTokens := strings.Split(comment, " ")
+	if len(commentTokens) < 2 {
+		glog.Errorf("could not parse postpone duration in comment: %s: invalid token count", comment)
+		return false
+	}
+
+	// Extract multipler.
+	x, err := strconv.Atoi(commentTokens[0])
+	if err != nil {
+		glog.Errorf("could not parse postpone duration in comment: %s: %s", comment, err)
+		return false
+	}
+
+	// Roughly calculate the postpone duration, given the unit.
+	commentTokens[1] = strings.TrimSuffix(commentTokens[1], ".")
+	commentTokens[1] = strings.TrimSuffix(commentTokens[1], "s")
+	var duration time.Duration
+	switch commentTokens[1] {
+	case "day":
+		duration = time.Duration(x) * 24 * time.Hour
+	case "week":
+		duration = time.Duration(x) * 7 * 24 * time.Hour
+	case "month":
+		duration = time.Duration(x) * 30 * 24 * time.Hour
+	default:
+		glog.Errorf("could not parse postpone duration in comment: %s: unknown unit", comment)
+		return false
+	}
+
+	return time.Now().Before(at.Add(duration))
+}

--- a/mungegithub/vendor/github.com/google/go-github/LICENSE
+++ b/mungegithub/vendor/github.com/google/go-github/LICENSE
@@ -29,8 +29,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------
 
 Some documentation is taken from the GitHub Developer site
-<http://developer.github.com/>, which is available under a Creative Commons
-Attribution 3.0 License:
+<http://developer.github.com/>, which is available under the following Creative
+Commons Attribution 3.0 License.  This applies only to the go-github source
+code and would not apply to any compiled binaries.
 
 THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
 COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY

--- a/mungegithub/vendor/github.com/google/go-github/github/activity.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/activity.go
@@ -12,3 +12,58 @@ package github
 type ActivityService struct {
 	client *Client
 }
+
+// FeedLink represents a link to a related resource.
+type FeedLink struct {
+	HRef *string `json:"href,omitempty"`
+	Type *string `json:"type,omitempty"`
+}
+
+// Feeds represents timeline resources in Atom format.
+type Feeds struct {
+	TimelineURL                 *string  `json:"timeline_url,omitempty"`
+	UserURL                     *string  `json:"user_url,omitempty"`
+	CurrentUserPublicURL        *string  `json:"current_user_public_url,omitempty"`
+	CurrentUserURL              *string  `json:"current_user_url,omitempty"`
+	CurrentUserActorURL         *string  `json:"current_user_actor_url,omitempty"`
+	CurrentUserOrganizationURL  *string  `json:"current_user_organization_url,omitempty"`
+	CurrentUserOrganizationURLs []string `json:"current_user_organization_urls,omitempty"`
+	Links                       *struct {
+		Timeline                 *FeedLink  `json:"timeline,omitempty"`
+		User                     *FeedLink  `json:"user,omitempty"`
+		CurrentUserPublic        *FeedLink  `json:"current_user_public,omitempty"`
+		CurrentUser              *FeedLink  `json:"current_user,omitempty"`
+		CurrentUserActor         *FeedLink  `json:"current_user_actor,omitempty"`
+		CurrentUserOrganization  *FeedLink  `json:"current_user_organization,omitempty"`
+		CurrentUserOrganizations []FeedLink `json:"current_user_organizations,omitempty"`
+	} `json:"_links,omitempty"`
+}
+
+// ListFeeds lists all the feeds available to the authenticated user.
+//
+// GitHub provides several timeline resources in Atom format:
+//     Timeline: The GitHub global public timeline
+//     User: The public timeline for any user, using URI template
+//     Current user public: The public timeline for the authenticated user
+//     Current user: The private timeline for the authenticated user
+//     Current user actor: The private timeline for activity created by the
+//         authenticated user
+//     Current user organizations: The private timeline for the organizations
+//         the authenticated user is a member of.
+//
+// Note: Private feeds are only returned when authenticating via Basic Auth
+// since current feed URIs use the older, non revocable auth tokens.
+func (s *ActivityService) ListFeeds() (*Feeds, *Response, error) {
+	req, err := s.client.NewRequest("GET", "feeds", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f := &Feeds{}
+	resp, err := s.client.Do(req, f)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return f, resp, nil
+}

--- a/mungegithub/vendor/github.com/google/go-github/github/activity_events.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/activity_events.go
@@ -27,77 +27,59 @@ func (e Event) String() string {
 	return Stringify(e)
 }
 
-// Payload returns the parsed event payload. For recognized event types
-// (PushEvent), a value of the corresponding struct type will be returned.
+// Payload returns the parsed event payload. For recognized event types,
+// a value of the corresponding struct type will be returned.
 func (e *Event) Payload() (payload interface{}) {
 	switch *e.Type {
+	case "CommitCommentEvent":
+		payload = &CommitCommentEvent{}
+	case "CreateEvent":
+		payload = &CreateEvent{}
+	case "DeleteEvent":
+		payload = &DeleteEvent{}
+	case "DeploymentEvent":
+		payload = &DeploymentEvent{}
+	case "DeploymentStatusEvent":
+		payload = &DeploymentStatusEvent{}
+	case "ForkEvent":
+		payload = &ForkEvent{}
+	case "GollumEvent":
+		payload = &GollumEvent{}
+	case "IssueActivityEvent":
+		payload = &IssueActivityEvent{}
+	case "IssueCommentEvent":
+		payload = &IssueCommentEvent{}
+	case "IssuesEvent":
+		payload = &IssuesEvent{}
+	case "MemberEvent":
+		payload = &MemberEvent{}
+	case "MembershipEvent":
+		payload = &MembershipEvent{}
+	case "PageBuildEvent":
+		payload = &PageBuildEvent{}
+	case "PublicEvent":
+		payload = &PublicEvent{}
+	case "PullRequestEvent":
+		payload = &PullRequestEvent{}
+	case "PullRequestReviewCommentEvent":
+		payload = &PullRequestReviewCommentEvent{}
 	case "PushEvent":
 		payload = &PushEvent{}
+	case "ReleaseEvent":
+		payload = &ReleaseEvent{}
+	case "RepositoryEvent":
+		payload = &RepositoryEvent{}
+	case "StatusEvent":
+		payload = &StatusEvent{}
+	case "TeamAddEvent":
+		payload = &TeamAddEvent{}
+	case "WatchEvent":
+		payload = &WatchEvent{}
 	}
 	if err := json.Unmarshal(*e.RawPayload, &payload); err != nil {
 		panic(err.Error())
 	}
 	return payload
-}
-
-// PushEvent represents a git push to a GitHub repository.
-//
-// GitHub API docs: http://developer.github.com/v3/activity/events/types/#pushevent
-type PushEvent struct {
-	PushID  *int              `json:"push_id,omitempty"`
-	Head    *string           `json:"head,omitempty"`
-	Ref     *string           `json:"ref,omitempty"`
-	Size    *int              `json:"size,omitempty"`
-	Commits []PushEventCommit `json:"commits,omitempty"`
-	Repo    *Repository       `json:"repository,omitempty"`
-}
-
-func (p PushEvent) String() string {
-	return Stringify(p)
-}
-
-// PushEventCommit represents a git commit in a GitHub PushEvent.
-type PushEventCommit struct {
-	SHA      *string       `json:"sha,omitempty"`
-	Message  *string       `json:"message,omitempty"`
-	Author   *CommitAuthor `json:"author,omitempty"`
-	URL      *string       `json:"url,omitempty"`
-	Distinct *bool         `json:"distinct,omitempty"`
-	Added    []string      `json:"added,omitempty"`
-	Removed  []string      `json:"removed,omitempty"`
-	Modified []string      `json:"modified,omitempty"`
-}
-
-func (p PushEventCommit) String() string {
-	return Stringify(p)
-}
-
-//PullRequestEvent represents the payload delivered by PullRequestEvent webhook
-type PullRequestEvent struct {
-	Action      *string      `json:"action,omitempty"`
-	Number      *int         `json:"number,omitempty"`
-	PullRequest *PullRequest `json:"pull_request,omitempty"`
-	Repo        *Repository  `json:"repository,omitempty"`
-	Sender      *User        `json:"sender,omitempty"`
-}
-
-// IssueActivityEvent represents the payload delivered by Issue webhook
-type IssueActivityEvent struct {
-	Action *string     `json:"action,omitempty"`
-	Issue  *Issue      `json:"issue,omitempty"`
-	Repo   *Repository `json:"repository,omitempty"`
-	Sender *User       `json:"sender,omitempty"`
-}
-
-// IssueCommentEvent represents the payload delivered by IssueComment webhook
-//
-// This webhook also gets fired for comments on pull requests
-type IssueCommentEvent struct {
-	Action  *string       `json:"action,omitempty"`
-	Issue   *Issue        `json:"issue,omitempty"`
-	Comment *IssueComment `json:"comment,omitempty"`
-	Repo    *Repository   `json:"repository,omitempty"`
-	Sender  *User         `json:"sender,omitempty"`
 }
 
 // ListEvents drinks from the firehose of all public events across GitHub.

--- a/mungegithub/vendor/github.com/google/go-github/github/activity_star.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/activity_star.go
@@ -13,10 +13,16 @@ type StarredRepository struct {
 	Repository *Repository `json:"repo,omitempty"`
 }
 
+// Stargazer represents a user that has starred a repository.
+type Stargazer struct {
+	StarredAt *Timestamp `json:"starred_at,omitempty"`
+	User      *User      `json:"user,omitempty"`
+}
+
 // ListStargazers lists people who have starred the specified repo.
 //
 // GitHub API Docs: https://developer.github.com/v3/activity/starring/#list-stargazers
-func (s *ActivityService) ListStargazers(owner, repo string, opt *ListOptions) ([]User, *Response, error) {
+func (s *ActivityService) ListStargazers(owner, repo string, opt *ListOptions) ([]Stargazer, *Response, error) {
 	u := fmt.Sprintf("repos/%s/%s/stargazers", owner, repo)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -28,7 +34,10 @@ func (s *ActivityService) ListStargazers(owner, repo string, opt *ListOptions) (
 		return nil, nil, err
 	}
 
-	stargazers := new([]User)
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeStarringPreview)
+
+	stargazers := new([]Stargazer)
 	resp, err := s.client.Do(req, stargazers)
 	if err != nil {
 		return nil, resp, err

--- a/mungegithub/vendor/github.com/google/go-github/github/authorizations.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/authorizations.go
@@ -1,0 +1,320 @@
+// Copyright 2015 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Scope models a GitHub authorization scope.
+//
+// GitHub API docs:https://developer.github.com/v3/oauth/#scopes
+type Scope string
+
+// This is the set of scopes for GitHub API V3
+const (
+	ScopeNone           Scope = "(no scope)" // REVISIT: is this actually returned, or just a documentation artifact?
+	ScopeUser           Scope = "user"
+	ScopeUserEmail      Scope = "user:email"
+	ScopeUserFollow     Scope = "user:follow"
+	ScopePublicRepo     Scope = "public_repo"
+	ScopeRepo           Scope = "repo"
+	ScopeRepoDeployment Scope = "repo_deployment"
+	ScopeRepoStatus     Scope = "repo:status"
+	ScopeDeleteRepo     Scope = "delete_repo"
+	ScopeNotifications  Scope = "notifications"
+	ScopeGist           Scope = "gist"
+	ScopeReadRepoHook   Scope = "read:repo_hook"
+	ScopeWriteRepoHook  Scope = "write:repo_hook"
+	ScopeAdminRepoHook  Scope = "admin:repo_hook"
+	ScopeAdminOrgHook   Scope = "admin:org_hook"
+	ScopeReadOrg        Scope = "read:org"
+	ScopeWriteOrg       Scope = "write:org"
+	ScopeAdminOrg       Scope = "admin:org"
+	ScopeReadPublicKey  Scope = "read:public_key"
+	ScopeWritePublicKey Scope = "write:public_key"
+	ScopeAdminPublicKey Scope = "admin:public_key"
+)
+
+// AuthorizationsService handles communication with the authorization related
+// methods of the GitHub API.
+//
+// This service requires HTTP Basic Authentication; it cannot be accessed using
+// an OAuth token.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/
+type AuthorizationsService struct {
+	client *Client
+}
+
+// Authorization represents an individual GitHub authorization.
+type Authorization struct {
+	ID             *int              `json:"id,omitempty"`
+	URL            *string           `json:"url,omitempty"`
+	Scopes         []Scope           `json:"scopes,omitempty"`
+	Token          *string           `json:"token,omitempty"`
+	TokenLastEight *string           `json:"token_last_eight,omitempty"`
+	HashedToken    *string           `json:"hashed_token,omitempty"`
+	App            *AuthorizationApp `json:"app,omitempty"`
+	Note           *string           `json:"note,omitempty"`
+	NoteURL        *string           `json:"note_url,omitempty"`
+	UpdateAt       *Timestamp        `json:"updated_at,omitempty"`
+	CreatedAt      *Timestamp        `json:"created_at,omitempty"`
+	Fingerprint    *string           `json:"fingerprint,omitempty"`
+
+	// User is only populated by the Check and Reset methods.
+	User *User `json:"user,omitempty"`
+}
+
+func (a Authorization) String() string {
+	return Stringify(a)
+}
+
+// AuthorizationApp represents an individual GitHub app (in the context of authorization).
+type AuthorizationApp struct {
+	URL      *string `json:"url,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	ClientID *string `json:"client_id,omitempty"`
+}
+
+func (a AuthorizationApp) String() string {
+	return Stringify(a)
+}
+
+// AuthorizationRequest represents a request to create an authorization.
+type AuthorizationRequest struct {
+	Scopes       []Scope `json:"scopes,omitempty"`
+	Note         *string `json:"note,omitempty"`
+	NoteURL      *string `json:"note_url,omitempty"`
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+	Fingerprint  *string `json:"fingerprint,omitempty"`
+}
+
+func (a AuthorizationRequest) String() string {
+	return Stringify(a)
+}
+
+// AuthorizationUpdateRequest represents a request to update an authorization.
+//
+// Note that for any one update, you must only provide one of the "scopes"
+// fields.  That is, you may provide only one of "Scopes", or "AddScopes", or
+// "RemoveScopes".
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization
+type AuthorizationUpdateRequest struct {
+	Scopes       []string `json:"scopes,omitempty"`
+	AddScopes    []string `json:"add_scopes,omitempty"`
+	RemoveScopes []string `json:"remove_scopes,omitempty"`
+	Note         *string  `json:"note,omitempty"`
+	NoteURL      *string  `json:"note_url,omitempty"`
+	Fingerprint  *string  `json:"fingerprint,omitempty"`
+}
+
+func (a AuthorizationUpdateRequest) String() string {
+	return Stringify(a)
+}
+
+// List the authorizations for the authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations
+func (s *AuthorizationsService) List(opt *ListOptions) ([]Authorization, *Response, error) {
+	u := "authorizations"
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	auths := new([]Authorization)
+	resp, err := s.client.Do(req, auths)
+	if err != nil {
+		return nil, resp, err
+	}
+	return *auths, resp, err
+}
+
+// Get a single authorization.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization
+func (s *AuthorizationsService) Get(id int) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("authorizations/%d", id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+	return a, resp, err
+}
+
+// Create a new authorization for the specified OAuth application.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
+func (s *AuthorizationsService) Create(auth *AuthorizationRequest) (*Authorization, *Response, error) {
+	u := "authorizations"
+
+	req, err := s.client.NewRequest("POST", u, auth)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+	return a, resp, err
+}
+
+// GetOrCreateForApp creates a new authorization for the specified OAuth
+// application, only if an authorization for that application doesn’t already
+// exist for the user.
+//
+// If a new token is created, the HTTP status code will be "201 Created", and
+// the returned Authorization.Token field will be populated. If an existing
+// token is returned, the status code will be "200 OK" and the
+// Authorization.Token field will be empty.
+//
+// clientID is the OAuth Client ID with which to create the token.
+//
+// GitHub API docs:
+// - https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app
+// - https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint
+func (s *AuthorizationsService) GetOrCreateForApp(clientID string, auth *AuthorizationRequest) (*Authorization, *Response, error) {
+	var u string
+	if auth.Fingerprint == nil || *auth.Fingerprint == "" {
+		u = fmt.Sprintf("authorizations/clients/%v", clientID)
+	} else {
+		u = fmt.Sprintf("authorizations/clients/%v/%v", clientID, *auth.Fingerprint)
+	}
+
+	req, err := s.client.NewRequest("PUT", u, auth)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// Edit a single authorization.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization
+func (s *AuthorizationsService) Edit(id int, auth *AuthorizationUpdateRequest) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("authorizations/%d", id)
+
+	req, err := s.client.NewRequest("PATCH", u, auth)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// Delete a single authorization.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#delete-an-authorization
+func (s *AuthorizationsService) Delete(id int) (*Response, error) {
+	u := fmt.Sprintf("authorizations/%d", id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Check if an OAuth token is valid for a specific app.
+//
+// Note that this operation requires the use of BasicAuth, but where the
+// username is the OAuth application clientID, and the password is its
+// clientSecret. Invalid tokens will return a 404 Not Found.
+//
+// The returned Authorization.User field will be populated.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#check-an-authorization
+func (s *AuthorizationsService) Check(clientID string, token string) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("applications/%v/tokens/%v", clientID, token)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// Reset is used to reset a valid OAuth token without end user involvement.
+// Applications must save the "token" property in the response, because changes
+// take effect immediately.
+//
+// Note that this operation requires the use of BasicAuth, but where the
+// username is the OAuth application clientID, and the password is its
+// clientSecret. Invalid tokens will return a 404 Not Found.
+//
+// The returned Authorization.User field will be populated.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization
+func (s *AuthorizationsService) Reset(clientID string, token string) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("applications/%v/tokens/%v", clientID, token)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// Revoke an authorization for an application.
+//
+// Note that this operation requires the use of BasicAuth, but where the
+// username is the OAuth application clientID, and the password is its
+// clientSecret. Invalid tokens will return a 404 Not Found.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application
+func (s *AuthorizationsService) Revoke(clientID string, token string) (*Response, error) {
+	u := fmt.Sprintf("applications/%v/tokens/%v", clientID, token)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/mungegithub/vendor/github.com/google/go-github/github/doc.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/doc.go
@@ -59,11 +59,18 @@ limited to 60 requests per hour, while authenticated clients can make up to
 that are not issued on behalf of a user, use the
 UnauthenticatedRateLimitedTransport.
 
-The Rate field on a client tracks the rate limit information based on the most
+The Rate method on a client returns the rate limit information based on the most
 recent API call.  This is updated on every call, but may be out of date if it's
 been some time since the last API call and other clients have made subsequent
-requests since then.  You can always call RateLimit() directly to get the most
+requests since then.  You can always call RateLimits() directly to get the most
 up-to-date rate limit data for the client.
+
+To detect an API rate limit error, you can check if its type is *github.RateLimitError:
+
+	repos, _, err := client.Repositories.List("", nil)
+	if _, ok := err.(*github.RateLimitError); ok {
+		log.Println("hit rate limit")
+	}
 
 Learn more about GitHub rate limiting at
 http://developer.github.com/v3/#rate-limiting.

--- a/mungegithub/vendor/github.com/google/go-github/github/event_types.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/event_types.go
@@ -1,0 +1,460 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// These event types are shared between the Events API and used as Webhook payloads.
+
+package github
+
+// CommitCommentEvent is triggered when a commit comment is created.
+// The Webhook event name is "commit_comment".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#commitcommentevent
+type CommitCommentEvent struct {
+	Comment *RepositoryComment `json:"comment,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Action *string     `json:"action,omitempty"`
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// CreateEvent represents a created repository, branch, or tag.
+// The Webhook event name is "create".
+//
+// Note: webhooks will not receive this event for created repositories.
+// Additionally, webhooks will not receive this event for tags if more
+// than three tags are pushed at once.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#createevent
+type CreateEvent struct {
+	Ref *string `json:"ref,omitempty"`
+	// RefType is the object that was created. Possible values are: "repository", "branch", "tag".
+	RefType      *string `json:"ref_type,omitempty"`
+	MasterBranch *string `json:"master_branch,omitempty"`
+	Description  *string `json:"description,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	PusherType *string     `json:"pusher_type,omitempty"`
+	Repo       *Repository `json:"repository,omitempty"`
+	Sender     *User       `json:"sender,omitempty"`
+}
+
+// DeleteEvent represents a deleted branch or tag.
+// The Webhook event name is "delete".
+//
+// Note: webhooks will not receive this event for tags if more than three tags
+// are deleted at once.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#deleteevent
+type DeleteEvent struct {
+	Ref *string `json:"ref,omitempty"`
+	// RefType is the object that was deleted. Possible values are: "branch", "tag".
+	RefType *string `json:"ref_type,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	PusherType *string     `json:"pusher_type,omitempty"`
+	Repo       *Repository `json:"repository,omitempty"`
+	Sender     *User       `json:"sender,omitempty"`
+}
+
+// DeploymentEvent represents a deployment.
+// The Webhook event name is "deployment".
+//
+// Events of this type are not visible in timelines, they are only used to trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#deploymentevent
+type DeploymentEvent struct {
+	Deployment *Deployment `json:"deployment,omitempty"`
+	Repo       *Repository `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Sender *User `json:"sender,omitempty"`
+}
+
+// DeploymentStatusEvent represents a deployment status.
+// The Webhook event name is "deployment_status".
+//
+// Events of this type are not visible in timelines, they are only used to trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#deploymentstatusevent
+type DeploymentStatusEvent struct {
+	Deployment       *Deployment       `json:"deployment,omitempty"`
+	DeploymentStatus *DeploymentStatus `json:"deployment_status,omitempty"`
+	Repo             *Repository       `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Sender *User `json:"sender,omitempty"`
+}
+
+// ForkEvent is triggered when a user forks a repository.
+// The Webhook event name is "fork".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#forkevent
+type ForkEvent struct {
+	// Forkee is the created repository.
+	Forkee *Repository `json:"forkee,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// Page represents a single Wiki page.
+type Page struct {
+	PageName *string `json:"page_name,omitempty"`
+	Title    *string `json:"title,omitempty"`
+	Summary  *string `json:"summary,omitempty"`
+	Action   *string `json:"action,omitempty"`
+	SHA      *string `json:"sha,omitempty"`
+	HTMLURL  *string `json:"html_url,omitempty"`
+}
+
+// GollumEvent is triggered when a Wiki page is created or updated.
+// The Webhook event name is "gollum".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#gollumevent
+type GollumEvent struct {
+	Pages []*Page `json:"pages,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// DEPRECATED: IssueActivityEvent represents the payload delivered by Issue webhook
+// Use IssuesEvent instead.
+type IssueActivityEvent struct {
+	Action *string `json:"action,omitempty"`
+	Issue  *Issue  `json:"issue,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// EditChange represents the changes when an issue, pull request, or comment has
+// been edited.
+type EditChange struct {
+	Title *struct {
+		From *string `json:"from,omitempty"`
+	} `json:"title,omitempty"`
+	Body *struct {
+		From *string `json:"from,omitempty"`
+	} `json:"body,omitempty"`
+}
+
+// IssueCommentEvent is triggered when an issue comment is created on an issue
+// or pull request.
+// The Webhook event name is "issue_comment".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#issuecommentevent
+type IssueCommentEvent struct {
+	// Action is the action that was performed on the comment.
+	// Possible values are: "created", "edited", "deleted".
+	Action  *string       `json:"action,omitempty"`
+	Issue   *Issue        `json:"issue,omitempty"`
+	Comment *IssueComment `json:"comment,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Changes *EditChange `json:"changes,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+	Sender  *User       `json:"sender,omitempty"`
+}
+
+// IssuesEvent is triggered when an issue is assigned, unassigned, labeled,
+// unlabeled, opened, closed, or reopened.
+// The Webhook event name is "issues".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#issuesevent
+type IssuesEvent struct {
+	// Action is the action that was performed. Possible values are: "assigned",
+	// "unassigned", "labeled", "unlabeled", "opened", "closed", "reopened", "edited".
+	Action   *string `json:"action,omitempty"`
+	Issue    *Issue  `json:"issue,omitempty"`
+	Assignee *User   `json:"assignee,omitempty"`
+	Label    *Label  `json:"label,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Changes *EditChange `json:"changes,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+	Sender  *User       `json:"sender,omitempty"`
+}
+
+// MemberEvent is triggered when a user is added as a collaborator to a repository.
+// The Webhook event name is "member".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#memberevent
+type MemberEvent struct {
+	// Action is the action that was performed. Possible value is: "added".
+	Action *string `json:"action,omitempty"`
+	Member *User   `json:"member,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// MembershipEvent is triggered when a user is added or removed from a team.
+// The Webhook event name is "membership".
+//
+// Events of this type are not visible in timelines, they are only used to
+// trigger organization webhooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#membershipevent
+type MembershipEvent struct {
+	// Action is the action that was performed. Possible values are: "added", "removed".
+	Action *string `json:"action,omitempty"`
+	// Scope is the scope of the membership. Possible value is: "team".
+	Scope  *string `json:"scope,omitempty"`
+	Member *User   `json:"member,omitempty"`
+	Team   *Team   `json:"team,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Org    *Organization `json:"organization,omitempty"`
+	Sender *User         `json:"sender,omitempty"`
+}
+
+// PageBuildEvent represents an attempted build of a GitHub Pages site, whether
+// successful or not.
+// The Webhook event name is "page_build".
+//
+// This event is triggered on push to a GitHub Pages enabled branch (gh-pages
+// for project pages, master for user and organization pages).
+//
+// Events of this type are not visible in timelines, they are only used to trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#pagebuildevent
+type PageBuildEvent struct {
+	Build *PagesBuild `json:"build,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	ID     *int        `json:"id,omitempty"`
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// PublicEvent is triggered when a private repository is open sourced.
+// According to GitHub: "Without a doubt: the best GitHub event."
+// The Webhook event name is "public".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#publicevent
+type PublicEvent struct {
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// PullRequestEvent is triggered when a pull request is assigned, unassigned,
+// labeled, unlabeled, opened, closed, reopened, or synchronized.
+// The Webhook event name is "pull_request".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#pullrequestevent
+type PullRequestEvent struct {
+	// Action is the action that was performed. Possible values are: "assigned",
+	// "unassigned", "labeled", "unlabeled", "opened", "closed", or "reopened",
+	// "synchronize", "edited". If the action is "closed" and the merged key is false,
+	// the pull request was closed with unmerged commits. If the action is "closed"
+	// and the merged key is true, the pull request was merged.
+	Action      *string      `json:"action,omitempty"`
+	Number      *int         `json:"number,omitempty"`
+	PullRequest *PullRequest `json:"pull_request,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Changes *EditChange `json:"changes,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+	Sender  *User       `json:"sender,omitempty"`
+}
+
+// PullRequestReviewCommentEvent is triggered when a comment is created on a
+// portion of the unified diff of a pull request.
+// The Webhook event name is "pull_request_review_comment".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#pullrequestreviewcommentevent
+type PullRequestReviewCommentEvent struct {
+	// Action is the action that was performed on the comment.
+	// Possible values are: "created", "edited", "deleted".
+	Action      *string             `json:"action,omitempty"`
+	PullRequest *PullRequest        `json:"pull_request,omitempty"`
+	Comment     *PullRequestComment `json:"comment,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Changes *EditChange `json:"changes,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+	Sender  *User       `json:"sender,omitempty"`
+}
+
+// PushEvent represents a git push to a GitHub repository.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/types/#pushevent
+type PushEvent struct {
+	PushID       *int                 `json:"push_id,omitempty"`
+	Head         *string              `json:"head,omitempty"`
+	Ref          *string              `json:"ref,omitempty"`
+	Size         *int                 `json:"size,omitempty"`
+	Commits      []PushEventCommit    `json:"commits,omitempty"`
+	Repo         *PushEventRepository `json:"repository,omitempty"`
+	Before       *string              `json:"before,omitempty"`
+	DistinctSize *int                 `json:"distinct_size,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	After      *string          `json:"after,omitempty"`
+	Created    *bool            `json:"created,omitempty"`
+	Deleted    *bool            `json:"deleted,omitempty"`
+	Forced     *bool            `json:"forced,omitempty"`
+	BaseRef    *string          `json:"base_ref,omitempty"`
+	Compare    *string          `json:"compare,omitempty"`
+	HeadCommit *PushEventCommit `json:"head_commit,omitempty"`
+	Pusher     *User            `json:"pusher,omitempty"`
+	Sender     *User            `json:"sender,omitempty"`
+}
+
+func (p PushEvent) String() string {
+	return Stringify(p)
+}
+
+// PushEventCommit represents a git commit in a GitHub PushEvent.
+type PushEventCommit struct {
+	SHA       *string       `json:"sha,omitempty"`
+	Message   *string       `json:"message,omitempty"`
+	Author    *CommitAuthor `json:"author,omitempty"`
+	Committer *CommitAuthor `json:"committer,omitempty"`
+	URL       *string       `json:"url,omitempty"`
+	Distinct  *bool         `json:"distinct,omitempty"`
+	Added     []string      `json:"added,omitempty"`
+	Removed   []string      `json:"removed,omitempty"`
+	Modified  []string      `json:"modified,omitempty"`
+}
+
+func (p PushEventCommit) String() string {
+	return Stringify(p)
+}
+
+// PushEventRepository represents the repo object in a PushEvent payload
+type PushEventRepository struct {
+	ID              *int                `json:"id,omitempty"`
+	Name            *string             `json:"name,omitempty"`
+	FullName        *string             `json:"full_name,omitempty"`
+	Owner           *PushEventRepoOwner `json:"owner,omitempty"`
+	Private         *bool               `json:"private,omitempty"`
+	Description     *string             `json:"description,omitempty"`
+	Fork            *bool               `json:"fork,omitempty"`
+	CreatedAt       *Timestamp          `json:"created_at,omitempty"`
+	PushedAt        *Timestamp          `json:"pushed_at,omitempty"`
+	UpdatedAt       *Timestamp          `json:"updated_at,omitempty"`
+	Homepage        *string             `json:"homepage,omitempty"`
+	Size            *int                `json:"size,omitempty"`
+	StargazersCount *int                `json:"stargazers_count,omitempty"`
+	WatchersCount   *int                `json:"watchers_count,omitempty"`
+	Language        *string             `json:"language,omitempty"`
+	HasIssues       *bool               `json:"has_issues,omitempty"`
+	HasDownloads    *bool               `json:"has_downloads,omitempty"`
+	HasWiki         *bool               `json:"has_wiki,omitempty"`
+	HasPages        *bool               `json:"has_pages,omitempty"`
+	ForksCount      *int                `json:"forks_count,omitempty"`
+	OpenIssuesCount *int                `json:"open_issues_count,omitempty"`
+	DefaultBranch   *string             `json:"default_branch,omitempty"`
+	MasterBranch    *string             `json:"master_branch,omitempty"`
+	Organization    *string             `json:"organization,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	URL     *string `json:"url,omitempty"`
+	HTMLURL *string `json:"html_url,omitempty"`
+}
+
+// PushEventRepoOwner is a basic reporesntation of user/org in a PushEvent payload
+type PushEventRepoOwner struct {
+	Name  *string `json:"name,omitempty"`
+	Email *string `json:"email,omitempty"`
+}
+
+// ReleaseEvent is triggered when a release is published.
+// The Webhook event name is "release".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#releaseevent
+type ReleaseEvent struct {
+	// Action is the action that was performed. Possible value is: "published".
+	Action  *string            `json:"action,omitempty"`
+	Release *RepositoryRelease `json:"release,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// RepositoryEvent is triggered when a repository is created.
+// The Webhook event name is "repository".
+//
+// Events of this type are not visible in timelines, they are only used to
+// trigger organization webhooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#repositoryevent
+type RepositoryEvent struct {
+	// Action is the action that was performed. Possible values are: "created", "deleted",
+	// "publicized", "privatized".
+	Action *string     `json:"action,omitempty"`
+	Repo   *Repository `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Org    *Organization `json:"organization,omitempty"`
+	Sender *User         `json:"sender,omitempty"`
+}
+
+// StatusEvent is triggered when the status of a Git commit changes.
+// The Webhook event name is "status".
+//
+// Events of this type are not visible in timelines, they are only used to
+// trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#statusevent
+type StatusEvent struct {
+	SHA *string `json:"sha,omitempty"`
+	// State is the new state. Possible values are: "pending", "success", "failure", "error".
+	State       *string   `json:"state,omitempty"`
+	Description *string   `json:"description,omitempty"`
+	TargetURL   *string   `json:"target_url,omitempty"`
+	Branches    []*Branch `json:"branches,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	ID        *int             `json:"id,omitempty"`
+	Name      *string          `json:"name,omitempty"`
+	Context   *string          `json:"context,omitempty"`
+	Commit    *PushEventCommit `json:"commit,omitempty"`
+	CreatedAt *Timestamp       `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp       `json:"updated_at,omitempty"`
+	Repo      *Repository      `json:"repository,omitempty"`
+	Sender    *User            `json:"sender,omitempty"`
+}
+
+// TeamAddEvent is triggered when a repository is added to a team.
+// The Webhook event name is "team_add".
+//
+// Events of this type are not visible in timelines. These events are only used
+// to trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#teamaddevent
+type TeamAddEvent struct {
+	Team *Team       `json:"team,omitempty"`
+	Repo *Repository `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Org    *Organization `json:"organization,omitempty"`
+	Sender *User         `json:"sender,omitempty"`
+}
+
+// WatchEvent is related to starring a repository, not watching. See this API
+// blog post for an explanation: https://developer.github.com/changes/2012-09-05-watcher-api/
+//
+// The event’s actor is the user who starred a repository, and the event’s
+// repository is the repository that was starred.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#watchevent
+type WatchEvent struct {
+	// Action is the action that was performed. Possible value is: "started".
+	Action *string `json:"action,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}

--- a/mungegithub/vendor/github.com/google/go-github/github/git_blobs.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/git_blobs.go
@@ -33,7 +33,7 @@ func (s *GitService) GetBlob(owner string, repo string, sha string) (*Blob, *Res
 
 // CreateBlob creates a blob object.
 //
-// GitHub API docs: http://developer.github.com/v3/git/blobs/#create-a-blob
+// GitHub API docs: https://developer.github.com/v3/git/blobs/#create-a-blob
 func (s *GitService) CreateBlob(owner string, repo string, blob *Blob) (*Blob, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/git/blobs", owner, repo)
 	req, err := s.client.NewRequest("POST", u, blob)

--- a/mungegithub/vendor/github.com/google/go-github/github/git_commits.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/git_commits.go
@@ -37,6 +37,9 @@ type CommitAuthor struct {
 	Date  *time.Time `json:"date,omitempty"`
 	Name  *string    `json:"name,omitempty"`
 	Email *string    `json:"email,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Login *string `json:"username,omitempty"` // Renamed for go-github consistency.
 }
 
 func (c CommitAuthor) String() string {

--- a/mungegithub/vendor/github.com/google/go-github/github/github.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/github.go
@@ -24,6 +24,11 @@ import (
 )
 
 const (
+	// StatusUnprocessableEntity is the status code returned when sending a request with invalid fields.
+	StatusUnprocessableEntity = 422
+)
+
+const (
 	libraryVersion = "0.1"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
@@ -36,6 +41,7 @@ const (
 
 	mediaTypeV3      = "application/vnd.github.v3+json"
 	defaultMediaType = "application/octet-stream"
+	mediaTypeV3SHA   = "application/vnd.github.v3.sha"
 
 	// Media Type values to access preview APIs
 
@@ -51,12 +57,29 @@ const (
 
 	// https://developer.github.com/changes/2015-11-11-protected-branches-api/
 	mediaTypeProtectedBranchesPreview = "application/vnd.github.loki-preview+json"
+
+	// https://developer.github.com/changes/2016-02-11-issue-locking-api/
+	mediaTypeIssueLockingPreview = "application/vnd.github.the-key-preview+json"
+
+	// https://help.github.com/enterprise/2.4/admin/guides/migrations/exporting-the-github-com-organization-s-repositories/
+	mediaTypeMigrationsPreview = "application/vnd.github.wyandotte-preview+json"
+
+	// https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/
+	mediaTypeDeploymentStatusPreview = "application/vnd.github.ant-man-preview+json"
+
+	// https://developer.github.com/changes/2016-02-19-source-import-preview-api/
+	mediaTypeImportPreview = "application/vnd.github.barred-rock-preview"
+
+	// https://developer.github.com/changes/2016-05-12-reactions-api-preview/
+	mediaTypeReactionsPreview = "application/vnd.github.squirrel-girl-preview"
 )
 
 // A Client manages communication with the GitHub API.
 type Client struct {
 	// HTTP client used to communicate with the API.
 	client *http.Client
+	// clientMu protects the client during calls that modify the CheckRedirect func.
+	clientMu sync.Mutex
 
 	// Base URL for API requests.  Defaults to the public GitHub API, but can be
 	// set to a domain endpoint to use with GitHub Enterprise.  BaseURL should
@@ -69,21 +92,25 @@ type Client struct {
 	// User agent used when communicating with the GitHub API.
 	UserAgent string
 
-	rateMu sync.Mutex
-	rate   Rate
+	rateMu     sync.Mutex
+	rateLimits [categories]Rate // Rate limits for the client as determined by the most recent API calls.
+	mostRecent rateLimitCategory
 
 	// Services used for talking to different parts of the GitHub API.
-	Activity      *ActivityService
-	Gists         *GistsService
-	Git           *GitService
-	Gitignores    *GitignoresService
-	Issues        *IssuesService
-	Organizations *OrganizationsService
-	PullRequests  *PullRequestsService
-	Repositories  *RepositoriesService
-	Search        *SearchService
-	Users         *UsersService
-	Licenses      *LicensesService
+	Activity       *ActivityService
+	Authorizations *AuthorizationsService
+	Gists          *GistsService
+	Git            *GitService
+	Gitignores     *GitignoresService
+	Issues         *IssuesService
+	Organizations  *OrganizationsService
+	PullRequests   *PullRequestsService
+	Repositories   *RepositoriesService
+	Search         *SearchService
+	Users          *UsersService
+	Licenses       *LicensesService
+	Migrations     *MigrationService
+	Reactions      *ReactionsService
 }
 
 // ListOptions specifies the optional parameters to various List methods that
@@ -136,6 +163,7 @@ func NewClient(httpClient *http.Client) *Client {
 
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent, UploadURL: uploadURL}
 	c.Activity = &ActivityService{client: c}
+	c.Authorizations = &AuthorizationsService{client: c}
 	c.Gists = &GistsService{client: c}
 	c.Git = &GitService{client: c}
 	c.Gitignores = &GitignoresService{client: c}
@@ -146,6 +174,8 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Search = &SearchService{client: c}
 	c.Users = &UsersService{client: c}
 	c.Licenses = &LicensesService{client: c}
+	c.Migrations = &MigrationService{client: c}
+	c.Reactions = &ReactionsService{client: c}
 	return c
 }
 
@@ -231,12 +261,12 @@ type Response struct {
 func newResponse(r *http.Response) *Response {
 	response := &Response{Response: r}
 	response.populatePageValues()
-	response.populateRate()
+	response.Rate = parseRate(r)
 	return response
 }
 
 // populatePageValues parses the HTTP Link response headers and populates the
-// various pagination link values in the Reponse.
+// various pagination link values in the Response.
 func (r *Response) populatePageValues() {
 	if links, ok := r.Response.Header["Link"]; ok && len(links) > 0 {
 		for _, link := range strings.Split(links[0], ",") {
@@ -279,28 +309,32 @@ func (r *Response) populatePageValues() {
 	}
 }
 
-// populateRate parses the rate related headers and populates the response Rate.
-func (r *Response) populateRate() {
+// parseRate parses the rate related headers.
+func parseRate(r *http.Response) Rate {
+	var rate Rate
 	if limit := r.Header.Get(headerRateLimit); limit != "" {
-		r.Rate.Limit, _ = strconv.Atoi(limit)
+		rate.Limit, _ = strconv.Atoi(limit)
 	}
 	if remaining := r.Header.Get(headerRateRemaining); remaining != "" {
-		r.Rate.Remaining, _ = strconv.Atoi(remaining)
+		rate.Remaining, _ = strconv.Atoi(remaining)
 	}
 	if reset := r.Header.Get(headerRateReset); reset != "" {
 		if v, _ := strconv.ParseInt(reset, 10, 64); v != 0 {
-			r.Rate.Reset = Timestamp{time.Unix(v, 0)}
+			rate.Reset = Timestamp{time.Unix(v, 0)}
 		}
 	}
+	return rate
 }
 
 // Rate specifies the current rate limit for the client as determined by the
 // most recent API call.  If the client is used in a multi-user application,
-// this rate may not always be up-to-date.  Call RateLimits() to check the
-// current rate.
+// this rate may not always be up-to-date.
+//
+// Deprecated: Use the Response.Rate returned from most recent API call instead.
+// Call RateLimits() to check the current rate.
 func (c *Client) Rate() Rate {
 	c.rateMu.Lock()
-	rate := c.rate
+	rate := c.rateLimits[c.mostRecent]
 	c.rateMu.Unlock()
 	return rate
 }
@@ -309,19 +343,32 @@ func (c *Client) Rate() Rate {
 // JSON decoded and stored in the value pointed to by v, or returned as an
 // error if an API error has occurred.  If v implements the io.Writer
 // interface, the raw response body will be written to v, without attempting to
-// first decode it.
+// first decode it.  If rate limit is exceeded and reset time is in the future,
+// Do returns *RateLimitError immediately without making a network API call.
 func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
+	rateLimitCategory := category(req.URL.Path)
+
+	// If we've hit rate limit, don't make further requests before Reset time.
+	if err := c.checkRateLimitBeforeDo(req, rateLimitCategory); err != nil {
+		return nil, err
+	}
+
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+		io.CopyN(ioutil.Discard, resp.Body, 512)
+		resp.Body.Close()
+	}()
 
 	response := newResponse(resp)
 
 	c.rateMu.Lock()
-	c.rate = response.Rate
+	c.rateLimits[rateLimitCategory] = response.Rate
+	c.mostRecent = rateLimitCategory
 	c.rateMu.Unlock()
 
 	err = CheckResponse(resp)
@@ -341,7 +388,35 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 			}
 		}
 	}
+
 	return response, err
+}
+
+// checkRateLimitBeforeDo does not make any network calls, but uses existing knowledge from
+// current client state in order to quickly check if *RateLimitError can be immediately returned
+// from Client.Do, and if so, returns it so that Client.Do can skip making a network API call unneccessarily.
+// Otherwise it returns nil, and Client.Do should proceed normally.
+func (c *Client) checkRateLimitBeforeDo(req *http.Request, rateLimitCategory rateLimitCategory) error {
+	c.rateMu.Lock()
+	rate := c.rateLimits[rateLimitCategory]
+	c.rateMu.Unlock()
+	if !rate.Reset.Time.IsZero() && rate.Remaining == 0 && time.Now().Before(rate.Reset.Time) {
+		// Create a fake response.
+		resp := &http.Response{
+			Status:     http.StatusText(http.StatusForbidden),
+			StatusCode: http.StatusForbidden,
+			Request:    req,
+			Header:     make(http.Header),
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}
+		return &RateLimitError{
+			Rate:     rate,
+			Response: resp,
+			Message:  fmt.Sprintf("API rate limit of %v still exceeded until %v, not making remote request.", rate.Limit, rate.Reset.Time),
+		}
+	}
+
+	return nil
 }
 
 /*
@@ -353,6 +428,13 @@ type ErrorResponse struct {
 	Response *http.Response // HTTP response that caused this error
 	Message  string         `json:"message"` // error message
 	Errors   []Error        `json:"errors"`  // more detail on individual errors
+	// Block is only populated on certain types of errors such as code 451.
+	// See https://developer.github.com/changes/2016-03-17-the-451-status-code-is-now-supported/
+	// for more information.
+	Block *struct {
+		Reason    string     `json:"reason,omitempty"`
+		CreatedAt *Timestamp `json:"created_at,omitempty"`
+	} `json:"block,omitempty"`
 }
 
 func (r *ErrorResponse) Error() string {
@@ -367,6 +449,20 @@ func (r *ErrorResponse) Error() string {
 type TwoFactorAuthError ErrorResponse
 
 func (r *TwoFactorAuthError) Error() string { return (*ErrorResponse)(r).Error() }
+
+// RateLimitError occurs when GitHub returns 403 Forbidden response with a rate limit
+// remaining value of 0, and error message starts with "API rate limit exceeded for ".
+type RateLimitError struct {
+	Rate     Rate           // Rate specifies last known rate limit for the client
+	Response *http.Response // HTTP response that caused this error
+	Message  string         `json:"message"` // error message
+}
+
+func (r *RateLimitError) Error() string {
+	return fmt.Sprintf("%v %v: %d %v; rate reset in %v",
+		r.Response.Request.Method, sanitizeURL(r.Response.Request.URL),
+		r.Response.StatusCode, r.Message, r.Rate.Reset.Time.Sub(time.Now()))
+}
 
 // sanitizeURL redacts the client_secret parameter from the URL which may be
 // exposed to the user, specifically in the ErrorResponse error message.
@@ -413,6 +509,9 @@ func (e *Error) Error() string {
 // the 200 range.  API error responses are expected to have either no response
 // body, or a JSON response body that maps to ErrorResponse.  Any other
 // response body will be silently ignored.
+//
+// The error type will be *RateLimitError for rate limit exceeded errors,
+// and *TwoFactorAuthError for two-factor authentication errors.
 func CheckResponse(r *http.Response) error {
 	if c := r.StatusCode; 200 <= c && c <= 299 {
 		return nil
@@ -422,10 +521,18 @@ func CheckResponse(r *http.Response) error {
 	if err == nil && data != nil {
 		json.Unmarshal(data, errorResponse)
 	}
-	if r.StatusCode == http.StatusUnauthorized && strings.HasPrefix(r.Header.Get(headerOTP), "required") {
+	switch {
+	case r.StatusCode == http.StatusUnauthorized && strings.HasPrefix(r.Header.Get(headerOTP), "required"):
 		return (*TwoFactorAuthError)(errorResponse)
+	case r.StatusCode == http.StatusForbidden && r.Header.Get(headerRateRemaining) == "0" && strings.HasPrefix(errorResponse.Message, "API rate limit exceeded for "):
+		return &RateLimitError{
+			Rate:     parseRate(r),
+			Response: errorResponse.Response,
+			Message:  errorResponse.Message,
+		}
+	default:
+		return errorResponse
 	}
-	return errorResponse
 }
 
 // parseBoolResponse determines the boolean result from a GitHub API response.
@@ -468,6 +575,8 @@ type RateLimits struct {
 	// The rate limit for non-search API requests.  Unauthenticated
 	// requests are limited to 60 per hour.  Authenticated requests are
 	// limited to 5,000 per hour.
+	//
+	// GitHub API docs: https://developer.github.com/v3/#rate-limiting
 	Core *Rate `json:"core"`
 
 	// The rate limit for search API requests.  Unauthenticated requests
@@ -482,7 +591,26 @@ func (r RateLimits) String() string {
 	return Stringify(r)
 }
 
-// RateLimit is deprecated.  Use RateLimits instead.
+type rateLimitCategory uint8
+
+const (
+	coreCategory rateLimitCategory = iota
+	searchCategory
+
+	categories // An array of this length will be able to contain all rate limit categories.
+)
+
+// category returns the rate limit category of the endpoint, determined by Request.URL.Path.
+func category(path string) rateLimitCategory {
+	switch {
+	default:
+		return coreCategory
+	case strings.HasPrefix(path, "/search/"):
+		return searchCategory
+	}
+}
+
+// Deprecated: RateLimit is deprecated, use RateLimits instead.
 func (c *Client) RateLimit() (*Rate, *Response, error) {
 	limits, resp, err := c.RateLimits()
 	if limits == nil {
@@ -505,6 +633,17 @@ func (c *Client) RateLimits() (*RateLimits, *Response, error) {
 	resp, err := c.Do(req, response)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if response.Resources != nil {
+		c.rateMu.Lock()
+		if response.Resources.Core != nil {
+			c.rateLimits[coreCategory] = *response.Resources.Core
+		}
+		if response.Resources.Search != nil {
+			c.rateLimits[searchCategory] = *response.Resources.Search
+		}
+		c.rateMu.Unlock()
 	}
 
 	return response.Resources, resp, err
@@ -629,25 +768,12 @@ func cloneRequest(r *http.Request) *http.Request {
 
 // Bool is a helper routine that allocates a new bool value
 // to store v and returns a pointer to it.
-func Bool(v bool) *bool {
-	p := new(bool)
-	*p = v
-	return p
-}
+func Bool(v bool) *bool { return &v }
 
-// Int is a helper routine that allocates a new int32 value
-// to store v and returns a pointer to it, but unlike Int32
-// its argument value is an int.
-func Int(v int) *int {
-	p := new(int)
-	*p = v
-	return p
-}
+// Int is a helper routine that allocates a new int value
+// to store v and returns a pointer to it.
+func Int(v int) *int { return &v }
 
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
-func String(v string) *string {
-	p := new(string)
-	*p = v
-	return p
-}
+func String(v string) *string { return &v }

--- a/mungegithub/vendor/github.com/google/go-github/github/issues.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/issues.go
@@ -35,6 +35,8 @@ type Issue struct {
 	HTMLURL          *string           `json:"html_url,omitempty"`
 	Milestone        *Milestone        `json:"milestone,omitempty"`
 	PullRequestLinks *PullRequestLinks `json:"pull_request,omitempty"`
+	Repository       *Repository       `json:"repository,omitempty"`
+	Reactions        *Reactions        `json:"reactions,omitempty"`
 
 	// TextMatches is only populated from search results that request text matches
 	// See: search.go and https://developer.github.com/v3/search/#text-match-metadata
@@ -130,6 +132,9 @@ func (s *IssuesService) listIssues(u string, opt *IssueListOptions) ([]Issue, *R
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	issues := new([]Issue)
 	resp, err := s.client.Do(req, issues)
 	if err != nil {
@@ -194,6 +199,9 @@ func (s *IssuesService) ListByRepo(owner string, repo string, opt *IssueListByRe
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	issues := new([]Issue)
 	resp, err := s.client.Do(req, issues)
 	if err != nil {
@@ -212,6 +220,9 @@ func (s *IssuesService) Get(owner string, repo string, number int) (*Issue, *Res
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	issue := new(Issue)
 	resp, err := s.client.Do(req, issue)
@@ -258,4 +269,36 @@ func (s *IssuesService) Edit(owner string, repo string, number int, issue *Issue
 	}
 
 	return i, resp, err
+}
+
+// Lock an issue's conversation.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/#lock-an-issue
+func (s *IssuesService) Lock(owner string, repo string, number int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/lock", owner, repo, number)
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIssueLockingPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// Unlock an issue's conversation.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/#unlock-an-issue
+func (s *IssuesService) Unlock(owner string, repo string, number int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/lock", owner, repo, number)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIssueLockingPreview)
+
+	return s.client.Do(req, nil)
 }

--- a/mungegithub/vendor/github.com/google/go-github/github/issues_comments.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/issues_comments.go
@@ -15,6 +15,7 @@ type IssueComment struct {
 	ID        *int       `json:"id,omitempty"`
 	Body      *string    `json:"body,omitempty"`
 	User      *User      `json:"user,omitempty"`
+	Reactions *Reactions `json:"reactions,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 	URL       *string    `json:"url,omitempty"`
@@ -61,6 +62,10 @@ func (s *IssuesService) ListComments(owner string, repo string, number int, opt 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	comments := new([]IssueComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
@@ -80,6 +85,10 @@ func (s *IssuesService) GetComment(owner string, repo string, id int) (*IssueCom
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	comment := new(IssueComment)
 	resp, err := s.client.Do(req, comment)
 	if err != nil {

--- a/mungegithub/vendor/github.com/google/go-github/github/issues_milestones.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/issues_milestones.go
@@ -13,6 +13,9 @@ import (
 // Milestone represents a Github repository milestone.
 type Milestone struct {
 	URL          *string    `json:"url,omitempty"`
+	HTMLURL      *string    `json:"html_url,omitempty"`
+	LabelsURL    *string    `json:"labels_url,omitempty"`
+	ID           *int       `json:"id,omitempty"`
 	Number       *int       `json:"number,omitempty"`
 	State        *string    `json:"state,omitempty"`
 	Title        *string    `json:"title,omitempty"`
@@ -22,6 +25,7 @@ type Milestone struct {
 	ClosedIssues *int       `json:"closed_issues,omitempty"`
 	CreatedAt    *time.Time `json:"created_at,omitempty"`
 	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
+	ClosedAt     *time.Time `json:"closed_at,omitempty"`
 	DueOn        *time.Time `json:"due_on,omitempty"`
 }
 

--- a/mungegithub/vendor/github.com/google/go-github/github/migrations.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/migrations.go
@@ -1,0 +1,225 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// MigrationService provides access to the migration related functions
+// in the GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/
+type MigrationService struct {
+	client *Client
+}
+
+// Migration represents a GitHub migration (archival).
+type Migration struct {
+	ID   *int    `json:"id,omitempty"`
+	GUID *string `json:"guid,omitempty"`
+	// State is the current state of a migration.
+	// Possible values are:
+	//     "pending" which means the migration hasn't started yet,
+	//     "exporting" which means the migration is in progress,
+	//     "exported" which means the migration finished successfully, or
+	//     "failed" which means the migration failed.
+	State *string `json:"state,omitempty"`
+	// LockRepositories indicates whether repositories are locked (to prevent
+	// manipulation) while migrating data.
+	LockRepositories *bool `json:"lock_repositories,omitempty"`
+	// ExcludeAttachments indicates whether attachments should be excluded from
+	// the migration (to reduce migration archive file size).
+	ExcludeAttachments *bool         `json:"exclude_attachments,omitempty"`
+	URL                *string       `json:"url,omitempty"`
+	CreatedAt          *string       `json:"created_at,omitempty"`
+	UpdatedAt          *string       `json:"updated_at,omitempty"`
+	Repositories       []*Repository `json:"repositories,omitempty"`
+}
+
+func (m Migration) String() string {
+	return Stringify(m)
+}
+
+// MigrationOptions specifies the optional parameters to Migration methods.
+type MigrationOptions struct {
+	// LockRepositories indicates whether repositories should be locked (to prevent
+	// manipulation) while migrating data.
+	LockRepositories bool
+
+	// ExcludeAttachments indicates whether attachments should be excluded from
+	// the migration (to reduce migration archive file size).
+	ExcludeAttachments bool
+}
+
+// startMigration represents the body of a StartMigration request.
+type startMigration struct {
+	// Repositories is a slice of repository names to migrate.
+	Repositories []string `json:"repositories,omitempty"`
+
+	// LockRepositories indicates whether repositories should be locked (to prevent
+	// manipulation) while migrating data.
+	LockRepositories *bool `json:"lock_repositories,omitempty"`
+
+	// ExcludeAttachments indicates whether attachments should be excluded from
+	// the migration (to reduce migration archive file size).
+	ExcludeAttachments *bool `json:"exclude_attachments,omitempty"`
+}
+
+// StartMigration starts the generation of a migration archive.
+// repos is a slice of repository names to migrate.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#start-a-migration
+func (s *MigrationService) StartMigration(org string, repos []string, opt *MigrationOptions) (*Migration, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations", org)
+
+	body := &startMigration{Repositories: repos}
+	if opt != nil {
+		body.LockRepositories = Bool(opt.LockRepositories)
+		body.ExcludeAttachments = Bool(opt.ExcludeAttachments)
+	}
+
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	m := &Migration{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListMigrations lists the most recent migrations.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#get-a-list-of-migrations
+func (s *MigrationService) ListMigrations(org string) ([]*Migration, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations", org)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	var m []*Migration
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// MigrationStatus gets the status of a specific migration archive.
+// id is the migration ID.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#get-the-status-of-a-migration
+func (s *MigrationService) MigrationStatus(org string, id int) (*Migration, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations/%v", org, id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	m := &Migration{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// MigrationArchiveURL fetches a migration archive URL.
+// id is the migration ID.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#download-a-migration-archive
+func (s *MigrationService) MigrationArchiveURL(org string, id int) (url string, err error) {
+	u := fmt.Sprintf("orgs/%v/migrations/%v/archive", org, id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	s.client.clientMu.Lock()
+	defer s.client.clientMu.Unlock()
+
+	// Disable the redirect mechanism because AWS fails if the GitHub auth token is provided.
+	var loc string
+	saveRedirect := s.client.client.CheckRedirect
+	s.client.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		loc = req.URL.String()
+		return errors.New("disable redirect")
+	}
+	defer func() { s.client.client.CheckRedirect = saveRedirect }()
+
+	_, err = s.client.Do(req, nil) // expect error from disable redirect
+	if err == nil {
+		return "", errors.New("expected redirect, none provided")
+	}
+	if !strings.Contains(err.Error(), "disable redirect") {
+		return "", err
+	}
+	return loc, nil
+}
+
+// DeleteMigration deletes a previous migration archive.
+// id is the migration ID.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#delete-a-migration-archive
+func (s *MigrationService) DeleteMigration(org string, id int) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations/%v/archive", org, id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// UnlockRepo unlocks a repository that was locked for migration.
+// id is the migration ID.
+// You should unlock each migrated repository and delete them when the migration
+// is complete and you no longer need the source data.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#unlock-a-repository
+func (s *MigrationService) UnlockRepo(org string, id int, repo string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations/%v/repos/%v/lock", org, id, repo)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/mungegithub/vendor/github.com/google/go-github/github/migrations_source_import.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/migrations_source_import.go
@@ -1,0 +1,326 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Import represents a repository import request.
+type Import struct {
+	// The URL of the originating repository.
+	VCSURL *string `json:"vcs_url,omitempty"`
+	// The originating VCS type. Can be one of 'subversion', 'git',
+	// 'mercurial', or 'tfvc'. Without this parameter, the import job will
+	// take additional time to detect the VCS type before beginning the
+	// import. This detection step will be reflected in the response.
+	VCS *string `json:"vcs,omitempty"`
+	// VCSUsername and VCSPassword are only used for StartImport calls that
+	// are importing a password-protected repository.
+	VCSUsername *string `json:"vcs_username,omitempty"`
+	VCSPassword *string `json:"vcs_password,omitempty"`
+	// For a tfvc import, the name of the project that is being imported.
+	TFVCProject *string `json:"tfvc_project,omitempty"`
+
+	// LFS related fields that may be preset in the Import Progress response
+
+	// Describes whether the import has been opted in or out of using Git
+	// LFS. The value can be 'opt_in', 'opt_out', or 'undecided' if no
+	// action has been taken.
+	UseLFS *string `json:"use_lfs,omitempty"`
+	// Describes whether files larger than 100MB were found during the
+	// importing step.
+	HasLargeFiles *bool `json:"has_large_files,omitempty"`
+	// The total size in gigabytes of files larger than 100MB found in the
+	// originating repository.
+	LargeFilesSize *int `json:"large_files_size,omitempty"`
+	// The total number of files larger than 100MB found in the originating
+	// repository. To see a list of these files, call LargeFiles.
+	LargeFilesCount *int `json:"large_files_count,omitempty"`
+
+	// Identifies the current status of an import.  An import that does not
+	// have errors will progress through these steps:
+	//
+	//     detecting - the "detection" step of the import is in progress
+	//         because the request did not include a VCS parameter. The
+	//         import is identifying the type of source control present at
+	//         the URL.
+	//     importing - the "raw" step of the import is in progress. This is
+	//         where commit data is fetched from the original repository.
+	//         The import progress response will include CommitCount (the
+	//         total number of raw commits that will be imported) and
+	//         Percent (0 - 100, the current progress through the import).
+	//     mapping - the "rewrite" step of the import is in progress. This
+	//         is where SVN branches are converted to Git branches, and
+	//         where author updates are applied. The import progress
+	//         response does not include progress information.
+	//     pushing - the "push" step of the import is in progress. This is
+	//         where the importer updates the repository on GitHub. The
+	//         import progress response will include PushPercent, which is
+	//         the percent value reported by git push when it is "Writing
+	//         objects".
+	//     complete - the import is complete, and the repository is ready
+	//         on GitHub.
+	//
+	// If there are problems, you will see one of these in the status field:
+	//
+	//     auth_failed - the import requires authentication in order to
+	//         connect to the original repository. Make an UpdateImport
+	//         request, and include VCSUsername and VCSPassword.
+	//     error - the import encountered an error. The import progress
+	//         response will include the FailedStep and an error message.
+	//         Contact GitHub support for more information.
+	//     detection_needs_auth - the importer requires authentication for
+	//         the originating repository to continue detection. Make an
+	//         UpdatImport request, and include VCSUsername and
+	//         VCSPassword.
+	//     detection_found_nothing - the importer didn't recognize any
+	//         source control at the URL.
+	//     detection_found_multiple - the importer found several projects
+	//         or repositories at the provided URL. When this is the case,
+	//         the Import Progress response will also include a
+	//         ProjectChoices field with the possible project choices as
+	//         values. Make an UpdateImport request, and include VCS and
+	//         (if applicable) TFVCProject.
+	Status        *string `json:"status,omitempty"`
+	CommitCount   *int    `json:"commit_count,omitempty"`
+	StatusText    *string `json:"status_text,omitempty"`
+	AuthorsCount  *int    `json:"authors_count,omitempty"`
+	Percent       *int    `json:"percent,omitempty"`
+	PushPercent   *int    `json:"push_percent,omitempty"`
+	URL           *string `json:"url,omitempty"`
+	HTMLURL       *string `json:"html_url,omitempty"`
+	AuthorsURL    *string `json:"authors_url,omitempty"`
+	RepositoryURL *string `json:"repository_url,omitempty"`
+	Message       *string `json:"message,omitempty"`
+	FailedStep    *string `json:"failed_step,omitempty"`
+
+	// Human readable display name, provided when the Import appears as
+	// part of ProjectChoices.
+	HumanName *string `json:"human_name,omitempty"`
+
+	// When the importer finds several projects or repositories at the
+	// provided URLs, this will identify the available choices.  Call
+	// UpdateImport with the selected Import value.
+	ProjectChoices []Import `json:"project_choices,omitempty"`
+}
+
+func (i Import) String() string {
+	return Stringify(i)
+}
+
+// SourceImportAuthor identifies an author imported from a source repository.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-commit-authors
+type SourceImportAuthor struct {
+	ID         *int    `json:"id,omitempty"`
+	RemoteID   *string `json:"remote_id,omitempty"`
+	RemoteName *string `json:"remote_name,omitempty"`
+	Email      *string `json:"email,omitempty"`
+	Name       *string `json:"name,omitempty"`
+	URL        *string `json:"url,omitempty"`
+	ImportURL  *string `json:"import_url,omitempty"`
+}
+
+func (a SourceImportAuthor) String() string {
+	return Stringify(a)
+}
+
+// LargeFile identifies a file larger than 100MB found during a repository import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-large-files
+type LargeFile struct {
+	RefName *string `json:"ref_name,omitempty"`
+	Path    *string `json:"path,omitempty"`
+	OID     *string `json:"oid,omitempty"`
+	Size    *int    `json:"size,omitempty"`
+}
+
+func (f LargeFile) String() string {
+	return Stringify(f)
+}
+
+// StartImport initiates a repository import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#start-an-import
+func (s *MigrationService) StartImport(owner, repo string, in *Import) (*Import, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	req, err := s.client.NewRequest("PUT", u, in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(Import)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// QueryImport queries for the status and progress of an ongoing repository import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-import-progress
+func (s *MigrationService) ImportProgress(owner, repo string) (*Import, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(Import)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// UpdateImport initiates a repository import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#update-existing-import
+func (s *MigrationService) UpdateImport(owner, repo string, in *Import) (*Import, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	req, err := s.client.NewRequest("PATCH", u, in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(Import)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// CommitAuthors gets the authors mapped from the original repository.
+//
+// Each type of source control system represents authors in a different way.
+// For example, a Git commit author has a display name and an email address,
+// but a Subversion commit author just has a username. The GitHub Importer will
+// make the author information valid, but the author might not be correct. For
+// example, it will change the bare Subversion username "hubot" into something
+// like "hubot <hubot@12341234-abab-fefe-8787-fedcba987654>".
+//
+// This method and MapCommitAuthor allow you to provide correct Git author
+// information.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-commit-authors
+func (s *MigrationService) CommitAuthors(owner, repo string) ([]SourceImportAuthor, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import/authors", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	authors := new([]SourceImportAuthor)
+	resp, err := s.client.Do(req, authors)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *authors, resp, err
+}
+
+// MapCommitAuthor updates an author's identity for the import. Your
+// application can continue updating authors any time before you push new
+// commits to the repository.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#map-a-commit-author
+func (s *MigrationService) MapCommitAuthor(owner, repo string, id int, author *SourceImportAuthor) (*SourceImportAuthor, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import/authors/%v", owner, repo, id)
+	req, err := s.client.NewRequest("PATCH", u, author)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(SourceImportAuthor)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// SetLFSPreference sets whether imported repositories should use Git LFS for
+// files larger than 100MB.  Only the UseLFS field on the provided Import is
+// used.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#set-git-lfs-preference
+func (s *MigrationService) SetLFSPreference(owner, repo string, in *Import) (*Import, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import/lfs", owner, repo)
+	req, err := s.client.NewRequest("PATCH", u, in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(Import)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// LargeFiles lists files larger than 100MB found during the import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-large-files
+func (s *MigrationService) LargeFiles(owner, repo string) ([]LargeFile, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import/large_files", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	files := new([]LargeFile)
+	resp, err := s.client.Do(req, files)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *files, resp, err
+}
+
+// CancelImport stops an import for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#cancel-an-import
+func (s *MigrationService) CancelImport(owner, repo string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/mungegithub/vendor/github.com/google/go-github/github/orgs.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/orgs.go
@@ -68,6 +68,39 @@ func (p Plan) String() string {
 	return Stringify(p)
 }
 
+// OrganizationsListOptions specifies the optional parameters to the
+// OrganizationsService.ListAll method.
+type OrganizationsListOptions struct {
+	// Since filters Organizations by ID.
+	Since int `url:"since,omitempty"`
+}
+
+// ListAll lists all organizations, in the order that they were created on GitHub.
+//
+// Note: Pagination is powered exclusively by the since parameter. To continue
+// listing the next set of organizations, use the ID of the last-returned organization
+// as the opts.Since parameter for the next call.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/#list-all-organizations
+func (s *OrganizationsService) ListAll(opt *OrganizationsListOptions) ([]Organization, *Response, error) {
+	u, err := addOptions("organizations", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	orgs := []Organization{}
+	resp, err := s.client.Do(req, &orgs)
+	if err != nil {
+		return nil, resp, err
+	}
+	return orgs, resp, err
+}
+
 // List the organizations for a user.  Passing the empty string will list
 // organizations for the authenticated user.
 //

--- a/mungegithub/vendor/github.com/google/go-github/github/orgs_teams.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/orgs_teams.go
@@ -10,10 +10,11 @@ import "fmt"
 // Team represents a team within a GitHub organization.  Teams are used to
 // manage access to an organization's repositories.
 type Team struct {
-	ID   *int    `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
-	URL  *string `json:"url,omitempty"`
-	Slug *string `json:"slug,omitempty"`
+	ID          *int    `json:"id,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	URL         *string `json:"url,omitempty"`
+	Slug        *string `json:"slug,omitempty"`
 
 	// Permission is deprecated when creating or editing a team in an org
 	// using the new GitHub permission model.  It no longer identifies the
@@ -29,9 +30,11 @@ type Team struct {
 	// Default is "secret".
 	Privacy *string `json:"privacy,omitempty"`
 
-	MembersCount *int          `json:"members_count,omitempty"`
-	ReposCount   *int          `json:"repos_count,omitempty"`
-	Organization *Organization `json:"organization,omitempty"`
+	MembersCount    *int          `json:"members_count,omitempty"`
+	ReposCount      *int          `json:"repos_count,omitempty"`
+	Organization    *Organization `json:"organization,omitempty"`
+	MembersURL      *string       `json:"members_url,omitempty"`
+	RepositoriesURL *string       `json:"repositories_url,omitempty"`
 }
 
 func (t Team) String() string {

--- a/mungegithub/vendor/github.com/google/go-github/github/pulls.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/pulls.go
@@ -43,6 +43,7 @@ type PullRequest struct {
 	StatusesURL  *string    `json:"statuses_url,omitempty"`
 	DiffURL      *string    `json:"diff_url,omitempty"`
 	PatchURL     *string    `json:"patch_url,omitempty"`
+	Assignee     *User      `json:"assignee,omitempty"` // probably only in webhooks
 
 	Head *PullRequestBranch `json:"head,omitempty"`
 	Base *PullRequestBranch `json:"base,omitempty"`

--- a/mungegithub/vendor/github.com/google/go-github/github/pulls_comments.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/pulls_comments.go
@@ -13,6 +13,7 @@ import (
 // PullRequestComment represents a comment left on a pull request.
 type PullRequestComment struct {
 	ID               *int       `json:"id,omitempty"`
+	InReplyTo        *int       `json:"in_reply_to,omitempty"`
 	Body             *string    `json:"body,omitempty"`
 	Path             *string    `json:"path,omitempty"`
 	DiffHunk         *string    `json:"diff_hunk,omitempty"`
@@ -21,8 +22,12 @@ type PullRequestComment struct {
 	CommitID         *string    `json:"commit_id,omitempty"`
 	OriginalCommitID *string    `json:"original_commit_id,omitempty"`
 	User             *User      `json:"user,omitempty"`
+	Reactions        *Reactions `json:"reactions,omitempty"`
 	CreatedAt        *time.Time `json:"created_at,omitempty"`
 	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
+	URL              *string    `json:"url,omitempty"`
+	HTMLURL          *string    `json:"html_url,omitempty"`
+	PullRequestURL   *string    `json:"pull_request_url,omitempty"`
 }
 
 func (p PullRequestComment) String() string {
@@ -66,6 +71,9 @@ func (s *PullRequestsService) ListComments(owner string, repo string, number int
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	comments := new([]PullRequestComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
@@ -84,6 +92,9 @@ func (s *PullRequestsService) GetComment(owner string, repo string, number int) 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	comment := new(PullRequestComment)
 	resp, err := s.client.Do(req, comment)

--- a/mungegithub/vendor/github.com/google/go-github/github/reactions.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/reactions.go
@@ -1,0 +1,272 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// ReactionsService provides access to the reactions-related functions in the
+// GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/
+type ReactionsService struct {
+	client *Client
+}
+
+// Reaction represents a GitHub reaction.
+type Reaction struct {
+	// ID is the Reaction ID.
+	ID     *int `json:"id,omitempty"`
+	UserID *int `json:"user_id,omitempty"`
+	// Content is the type of reaction.
+	// Possible values are:
+	//     "+1", "-1", "laugh", "confused", "heart", "hooray".
+	Content *string `json:"content,omitempty"`
+}
+
+// Reactions represents a summary of GitHub reactions.
+type Reactions struct {
+	TotalCount *int    `json:"total_count,omitempty"`
+	PlusOne    *int    `json:"+1,omitempty"`
+	MinusOne   *int    `json:"-1,omitempty"`
+	Laugh      *int    `json:"laugh,omitempty"`
+	Confused   *int    `json:"confused,omitempty"`
+	Heart      *int    `json:"heart,omitempty"`
+	Hooray     *int    `json:"hooray,omitempty"`
+	URL        *string `json:"url,omitempty"`
+}
+
+func (r Reaction) String() string {
+	return Stringify(r)
+}
+
+// ListCommentReactions lists the reactions for a commit comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
+func (s *ReactionsService) ListCommentReactions(owner, repo string, id int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreateCommentReaction creates a reaction for a commit comment.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
+func (s ReactionsService) CreateCommentReaction(owner, repo string, id int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListIssueReactions lists the reactions for an issue.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue
+func (s *ReactionsService) ListIssueReactions(owner, repo string, number int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreateIssueReaction creates a reaction for an issue.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
+func (s ReactionsService) CreateIssueReaction(owner, repo string, number int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListIssueCommentReactions lists the reactions for an issue comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
+func (s *ReactionsService) ListIssueCommentReactions(owner, repo string, id int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreateIssueCommentReaction creates a reaction for an issue comment.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
+func (s ReactionsService) CreateIssueCommentReaction(owner, repo string, id int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListPullRequestCommentReactions lists the reactions for a pull request review comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
+func (s *ReactionsService) ListPullRequestCommentReactions(owner, repo string, id int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreatePullRequestCommentReaction creates a reaction for a pull request review comment.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
+func (s ReactionsService) CreatePullRequestCommentReaction(owner, repo string, id int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// DeleteReaction deletes a reaction.
+//
+// GitHub API docs: https://developer.github.com/v3/reaction/reactions/#delete-a-reaction-archive
+func (s *ReactionsService) DeleteReaction(id int) (*Response, error) {
+	u := fmt.Sprintf("/reactions/%v", id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/mungegithub/vendor/github.com/google/go-github/github/repos_comments.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/repos_comments.go
@@ -17,6 +17,7 @@ type RepositoryComment struct {
 	ID        *int       `json:"id,omitempty"`
 	CommitID  *string    `json:"commit_id,omitempty"`
 	User      *User      `json:"user,omitempty"`
+	Reactions *Reactions `json:"reactions,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
@@ -46,6 +47,9 @@ func (s *RepositoriesService) ListComments(owner, repo string, opt *ListOptions)
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	comments := new([]RepositoryComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
@@ -69,6 +73,9 @@ func (s *RepositoriesService) ListCommitComments(owner, repo, sha string, opt *L
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	comments := new([]RepositoryComment)
 	resp, err := s.client.Do(req, comments)
@@ -108,6 +115,9 @@ func (s *RepositoriesService) GetComment(owner, repo string, id int) (*Repositor
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	c := new(RepositoryComment)
 	resp, err := s.client.Do(req, c)

--- a/mungegithub/vendor/github.com/google/go-github/github/repos_commits.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/repos_commits.go
@@ -6,6 +6,7 @@
 package github
 
 import (
+	"bytes"
 	"fmt"
 	"time"
 )
@@ -144,6 +145,32 @@ func (s *RepositoriesService) GetCommit(owner, repo, sha string) (*RepositoryCom
 	}
 
 	return commit, resp, err
+}
+
+// GetCommitSHA1 gets the SHA-1 of a commit reference.  If a last-known SHA1 is
+// supplied and no new commits have occurred, a 304 Unmodified response is returned.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference
+func (s *RepositoriesService) GetCommitSHA1(owner, repo, ref, lastSHA string) (string, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, ref)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	if lastSHA != "" {
+		req.Header.Set("If-None-Match", `"`+lastSHA+`"`)
+	}
+
+	req.Header.Set("Accept", mediaTypeV3SHA)
+
+	var buf bytes.Buffer
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return "", resp, err
+	}
+
+	return buf.String(), resp, err
 }
 
 // CompareCommits compares a range of commits with each other.

--- a/mungegithub/vendor/github.com/google/go-github/github/repos_contents.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/repos_contents.go
@@ -21,11 +21,14 @@ import (
 
 // RepositoryContent represents a file or directory in a github repository.
 type RepositoryContent struct {
-	Type        *string `json:"type,omitempty"`
-	Encoding    *string `json:"encoding,omitempty"`
-	Size        *int    `json:"size,omitempty"`
-	Name        *string `json:"name,omitempty"`
-	Path        *string `json:"path,omitempty"`
+	Type     *string `json:"type,omitempty"`
+	Encoding *string `json:"encoding,omitempty"`
+	Size     *int    `json:"size,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Path     *string `json:"path,omitempty"`
+	// Content contains the actual file content, which may be encoded.
+	// Callers should call GetContent which will decode the content if
+	// necessary.
 	Content     *string `json:"content,omitempty"`
 	SHA         *string `json:"sha,omitempty"`
 	URL         *string `json:"url,omitempty"`
@@ -43,7 +46,7 @@ type RepositoryContentResponse struct {
 // RepositoryContentFileOptions specifies optional parameters for CreateFile, UpdateFile, and DeleteFile.
 type RepositoryContentFileOptions struct {
 	Message   *string       `json:"message,omitempty"`
-	Content   []byte        `json:"content,omitempty"`
+	Content   []byte        `json:"content,omitempty"` // unencoded
 	SHA       *string       `json:"sha,omitempty"`
 	Branch    *string       `json:"branch,omitempty"`
 	Author    *CommitAuthor `json:"author,omitempty"`
@@ -56,11 +59,14 @@ type RepositoryContentGetOptions struct {
 	Ref string `url:"ref,omitempty"`
 }
 
+// String converts RepositoryContent to a string. It's primarily for testing.
 func (r RepositoryContent) String() string {
 	return Stringify(r)
 }
 
 // Decode decodes the file content if it is base64 encoded.
+//
+// Deprecated: Use GetContent instead.
 func (r *RepositoryContent) Decode() ([]byte, error) {
 	if *r.Encoding != "base64" {
 		return nil, errors.New("cannot decode non-base64")
@@ -70,6 +76,27 @@ func (r *RepositoryContent) Decode() ([]byte, error) {
 		return nil, err
 	}
 	return o, nil
+}
+
+// GetContent returns the content of r, decoding it if necessary.
+func (r *RepositoryContent) GetContent() (string, error) {
+	var encoding string
+	if r.Encoding != nil {
+		encoding = *r.Encoding
+	}
+
+	switch encoding {
+	case "base64":
+		c, err := base64.StdEncoding.DecodeString(*r.Content)
+		return string(c), err
+	case "":
+		if r.Content == nil {
+			return "", nil
+		}
+		return *r.Content, nil
+	default:
+		return "", fmt.Errorf("unsupported content encoding: %v", encoding)
+	}
 }
 
 // GetReadme gets the Readme file for the repository.
@@ -127,9 +154,9 @@ func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt
 // value and the other will be nil.
 //
 // GitHub API docs: http://developer.github.com/v3/repos/contents/#get-contents
-func (s *RepositoriesService) GetContents(owner, repo, path string, opt *RepositoryContentGetOptions) (fileContent *RepositoryContent,
-	directoryContent []*RepositoryContent, resp *Response, err error) {
-	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path)
+func (s *RepositoriesService) GetContents(owner, repo, path string, opt *RepositoryContentGetOptions) (fileContent *RepositoryContent, directoryContent []*RepositoryContent, resp *Response, err error) {
+	escapedPath := (&url.URL{Path: path}).String()
+	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, escapedPath)
 	u, err = addOptions(u, opt)
 	if err != nil {
 		return nil, nil, nil, err

--- a/mungegithub/vendor/github.com/google/go-github/github/repos_deployments.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/repos_deployments.go
@@ -12,28 +12,32 @@ import (
 
 // Deployment represents a deployment in a repo
 type Deployment struct {
-	URL         *string         `json:"url,omitempty"`
-	ID          *int            `json:"id,omitempty"`
-	SHA         *string         `json:"sha,omitempty"`
-	Ref         *string         `json:"ref,omitempty"`
-	Task        *string         `json:"task,omitempty"`
-	Payload     json.RawMessage `json:"payload,omitempty"`
-	Environment *string         `json:"environment,omitempty"`
-	Description *string         `json:"description,omitempty"`
-	Creator     *User           `json:"creator,omitempty"`
-	CreatedAt   *Timestamp      `json:"created_at,omitempty"`
-	UpdatedAt   *Timestamp      `json:"pushed_at,omitempty"`
+	URL           *string         `json:"url,omitempty"`
+	ID            *int            `json:"id,omitempty"`
+	SHA           *string         `json:"sha,omitempty"`
+	Ref           *string         `json:"ref,omitempty"`
+	Task          *string         `json:"task,omitempty"`
+	Payload       json.RawMessage `json:"payload,omitempty"`
+	Environment   *string         `json:"environment,omitempty"`
+	Description   *string         `json:"description,omitempty"`
+	Creator       *User           `json:"creator,omitempty"`
+	CreatedAt     *Timestamp      `json:"created_at,omitempty"`
+	UpdatedAt     *Timestamp      `json:"pushed_at,omitempty"`
+	StatusesURL   *string         `json:"statuses_url,omitempty"`
+	RepositoryURL *string         `json:"repository_url,omitempty"`
 }
 
 // DeploymentRequest represents a deployment request
 type DeploymentRequest struct {
-	Ref              *string   `json:"ref,omitempty"`
-	Task             *string   `json:"task,omitempty"`
-	AutoMerge        *bool     `json:"auto_merge,omitempty"`
-	RequiredContexts *[]string `json:"required_contexts,omitempty"`
-	Payload          *string   `json:"payload,omitempty"`
-	Environment      *string   `json:"environment,omitempty"`
-	Description      *string   `json:"description,omitempty"`
+	Ref                   *string   `json:"ref,omitempty"`
+	Task                  *string   `json:"task,omitempty"`
+	AutoMerge             *bool     `json:"auto_merge,omitempty"`
+	RequiredContexts      *[]string `json:"required_contexts,omitempty"`
+	Payload               *string   `json:"payload,omitempty"`
+	Environment           *string   `json:"environment,omitempty"`
+	Description           *string   `json:"description,omitempty"`
+	TransientEnvironment  *bool     `json:"transient_environment,omitempty"`
+	ProductionEnvironment *bool     `json:"production_environment,omitempty"`
 }
 
 // DeploymentsListOptions specifies the optional parameters to the
@@ -89,6 +93,9 @@ func (s *RepositoriesService) CreateDeployment(owner, repo string, request *Depl
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when deployment support fully launches
+	req.Header.Set("Accept", mediaTypeDeploymentStatusPreview)
+
 	d := new(Deployment)
 	resp, err := s.client.Do(req, d)
 	if err != nil {
@@ -101,20 +108,27 @@ func (s *RepositoriesService) CreateDeployment(owner, repo string, request *Depl
 // DeploymentStatus represents the status of a
 // particular deployment.
 type DeploymentStatus struct {
-	ID          *int       `json:"id,omitempty"`
-	State       *string    `json:"state,omitempty"`
-	Creator     *User      `json:"creator,omitempty"`
-	Description *string    `json:"description,omitempty"`
-	TargetURL   *string    `json:"target_url,omitempty"`
-	CreatedAt   *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt   *Timestamp `json:"pushed_at,omitempty"`
+	ID *int `json:"id,omitempty"`
+	// State is the deployment state.
+	// Possible values are: "pending", "success", "failure", "error", "inactive".
+	State         *string    `json:"state,omitempty"`
+	Creator       *User      `json:"creator,omitempty"`
+	Description   *string    `json:"description,omitempty"`
+	TargetURL     *string    `json:"target_url,omitempty"`
+	CreatedAt     *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt     *Timestamp `json:"pushed_at,omitempty"`
+	DeploymentURL *string    `json:"deployment_url,omitempty"`
+	RepositoryURL *string    `json:"repository_url,omitempty"`
 }
 
 // DeploymentStatusRequest represents a deployment request
 type DeploymentStatusRequest struct {
-	State       *string `json:"state,omitempty"`
-	TargetURL   *string `json:"target_url,omitempty"`
-	Description *string `json:"description,omitempty"`
+	State          *string `json:"state,omitempty"`
+	TargetURL      *string `json:"target_url,omitempty"` // Deprecated. Use LogURL instead.
+	LogURL         *string `json:"log_url,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	EnvironmentURL *string `json:"environment_url,omitempty"`
+	AutoInactive   *bool   `json:"auto_inactive,omitempty"`
 }
 
 // ListDeploymentStatuses lists the statuses of a given deployment of a repository.
@@ -151,6 +165,9 @@ func (s *RepositoriesService) CreateDeploymentStatus(owner, repo string, deploym
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when deployment support fully launches
+	req.Header.Set("Accept", mediaTypeDeploymentStatusPreview)
 
 	d := new(DeploymentStatus)
 	resp, err := s.client.Do(req, d)

--- a/mungegithub/vendor/github.com/google/go-github/github/repos_hooks.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/repos_hooks.go
@@ -29,6 +29,7 @@ type WebHookPayload struct {
 	Pusher     *User           `json:"pusher,omitempty"`
 	Ref        *string         `json:"ref,omitempty"`
 	Repo       *Repository     `json:"repository,omitempty"`
+	Sender     *User           `json:"sender,omitempty"`
 }
 
 func (w WebHookPayload) String() string {

--- a/mungegithub/vendor/github.com/google/go-github/github/repos_releases.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/repos_releases.go
@@ -10,8 +10,10 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // RepositoryRelease represents a GitHub release in a repository.
@@ -32,6 +34,7 @@ type RepositoryRelease struct {
 	UploadURL       *string        `json:"upload_url,omitempty"`
 	ZipballURL      *string        `json:"zipball_url,omitempty"`
 	TarballURL      *string        `json:"tarball_url,omitempty"`
+	Author          *CommitAuthor  `json:"author,omitempty"`
 }
 
 func (r RepositoryRelease) String() string {
@@ -212,27 +215,48 @@ func (s *RepositoriesService) GetReleaseAsset(owner, repo string, id int) (*Rele
 	return asset, resp, err
 }
 
-// DownloadReleaseAsset downloads a release asset.
+// DownloadReleaseAsset downloads a release asset or returns a redirect URL.
 //
 // DownloadReleaseAsset returns an io.ReadCloser that reads the contents of the
 // specified release asset. It is the caller's responsibility to close the ReadCloser.
+// If a redirect is returned, the redirect URL will be returned as a string instead
+// of the io.ReadCloser. Exactly one of rc and redirectURL will be zero.
 //
 // GitHub API docs : http://developer.github.com/v3/repos/releases/#get-a-single-release-asset
-func (s *RepositoriesService) DownloadReleaseAsset(owner, repo string, id int) (io.ReadCloser, error) {
+func (s *RepositoriesService) DownloadReleaseAsset(owner, repo string, id int) (rc io.ReadCloser, redirectURL string, err error) {
 	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	req.Header.Set("Accept", defaultMediaType)
 
+	s.client.clientMu.Lock()
+	defer s.client.clientMu.Unlock()
+
+	var loc string
+	saveRedirect := s.client.client.CheckRedirect
+	s.client.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		loc = req.URL.String()
+		return errors.New("disable redirect")
+	}
+	defer func() { s.client.client.CheckRedirect = saveRedirect }()
+
 	resp, err := s.client.client.Do(req)
 	if err != nil {
-		return nil, err
+		if !strings.Contains(err.Error(), "disable redirect") {
+			return nil, "", err
+		}
+		return nil, loc, nil
 	}
 
-	return resp.Body, nil
+	if err := CheckResponse(resp); err != nil {
+		resp.Body.Close()
+		return nil, "", err
+	}
+
+	return resp.Body, "", nil
 }
 
 // EditReleaseAsset edits a repository release asset.

--- a/mungegithub/vendor/github.com/google/go-github/github/repos_stats.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/repos_stats.go
@@ -102,7 +102,7 @@ func (s *RepositoriesService) ListCommitActivity(owner, repo string) ([]WeeklyCo
 
 // ListCodeFrequency returns a weekly aggregate of the number of additions and
 // deletions pushed to a repository.  Returned WeeklyStats will contain
-// additiona and deletions, but not total commits.
+// additions and deletions, but not total commits.
 //
 // GitHub API Docs: https://developer.github.com/v3/repos/statistics/#code-frequency
 func (s *RepositoriesService) ListCodeFrequency(owner, repo string) ([]WeeklyStats, *Response, error) {
@@ -175,7 +175,7 @@ func (s *RepositoriesService) ListParticipation(owner, repo string) (*Repository
 	return participation, resp, err
 }
 
-// PunchCard respresents the number of commits made during a given hour of a
+// PunchCard represents the number of commits made during a given hour of a
 // day of thew eek.
 type PunchCard struct {
 	Day     *int // Day of the week (0-6: =Sunday - Saturday).

--- a/mungegithub/vendor/github.com/google/go-github/github/repos_statuses.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/repos_statuses.go
@@ -86,7 +86,7 @@ func (s *RepositoriesService) CreateStatus(owner, repo, ref string, status *Repo
 // CombinedStatus represents the combined status of a repository at a particular reference.
 type CombinedStatus struct {
 	// State is the combined state of the repository.  Possible values are:
-	// failture, pending, or success.
+	// failure, pending, or success.
 	State *string `json:"state,omitempty"`
 
 	Name       *string      `json:"name,omitempty"`

--- a/mungegithub/vendor/github.com/google/go-github/github/search.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/search.go
@@ -148,7 +148,7 @@ func (s *SearchService) search(searchType string, query string, opt *SearchOptio
 		return nil, err
 	}
 
-	if opt.TextMatch {
+	if opt != nil && opt.TextMatch {
 		// Accept header defaults to "application/vnd.github.v3+json"
 		// We change it here to fetch back text-match metadata
 		req.Header.Set("Accept", "application/vnd.github.v3.text-match+json")

--- a/mungegithub/vendor/github.com/google/go-github/github/users.go
+++ b/mungegithub/vendor/github.com/google/go-github/github/users.go
@@ -35,6 +35,7 @@ type User struct {
 	Following         *int       `json:"following,omitempty"`
 	CreatedAt         *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt         *Timestamp `json:"updated_at,omitempty"`
+	SuspendedAt       *Timestamp `json:"suspended_at,omitempty"`
 	Type              *string    `json:"type,omitempty"`
 	SiteAdmin         *bool      `json:"site_admin,omitempty"`
 	TotalPrivateRepos *int       `json:"total_private_repos,omitempty"`
@@ -92,6 +93,25 @@ func (s *UsersService) Get(user string) (*User, *Response, error) {
 	}
 
 	return uResp, resp, err
+}
+
+// GetByID fetches a user.
+//
+// Note: GetByID uses the undocumented GitHub API endpoint /user/:id.
+func (s *UsersService) GetByID(id int) (*User, *Response, error) {
+	u := fmt.Sprintf("user/%d", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	user := new(User)
+	resp, err := s.client.Do(req, user)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return user, resp, err
 }
 
 // Edit the authenticated user.


### PR DESCRIPTION
Hi,

That is a first draft intended to improve the mungebot by implementing two specific points from #869:

> - Ping the PR due to lack of inactivity, notifying either the PR author or the assignee, depending on who last touched the PR (keep track of whose court it's in)
> - Create a way to postpone the next ping for a fixed amount of time (day, week, month, next release cycle)

This new munger comments PRs when:
- No answer has been given for 2 weeks on the PR
- No answer has been given for 2 weeks on any review (code) comment that aren't outdated.

Depending on who commented last, the added comment will either mention (@) the PR assignee or the PR owner.

The next ping can be postponed or cancelled by commenting back:
- `@k8s-merge-robot ignore inactivity`
- `@k8s-merge-robot postpone by X day(s)/week(s)/month(s)`
