### PR TITLE
assign-fixes: label issues with has-pr-posted and add a comment

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -641,7 +641,7 @@ func (obj *MungeObject) HasLabels(names []string) bool {
 	return true
 }
 
-// LabelSet returns the name of all of he labels applied to the object as a
+// LabelSet returns the name of all of the labels applied to the object as a
 // kubernetes string set.
 func (obj *MungeObject) LabelSet() sets.String {
 	out := sets.NewString()
@@ -857,7 +857,8 @@ func (obj *MungeObject) Priority() int {
 // MungeFunction is the type that must be implemented and passed to ForEachIssueDo
 type MungeFunction func(*MungeObject) error
 
-func (config *Config) fetchAllCollaborators() ([]github.User, error) {
+// FetchAllCollaborators will return a list of users that have RW access to the repo
+func (config *Config) FetchAllCollaborators() ([]github.User, error) {
 	page := 1
 	var result []github.User
 	for {
@@ -875,36 +876,6 @@ func (config *Config) fetchAllCollaborators() ([]github.User, error) {
 		page++
 	}
 	return result, nil
-}
-
-// UsersWithAccess returns two sets of users. The first set are users with push
-// access. The second set is the specific set of user with pull access. If the
-// repo is public all users will have pull access, but some with have it
-// explicitly
-func (config *Config) UsersWithAccess() ([]github.User, []github.User, error) {
-	pushUsers := []github.User{}
-	pullUsers := []github.User{}
-
-	users, err := config.fetchAllCollaborators()
-	if err != nil {
-		glog.Errorf("%v", err)
-		return nil, nil, err
-	}
-
-	for _, user := range users {
-		if user.Permissions == nil || user.Login == nil {
-			err := fmt.Errorf("found a user with nil Permissions or Login")
-			glog.Errorf("%v", err)
-			return nil, nil, err
-		}
-		perms := *user.Permissions
-		if perms["push"] {
-			pushUsers = append(pushUsers, user)
-		} else if perms["pull"] {
-			pullUsers = append(pullUsers, user)
-		}
-	}
-	return pushUsers, pullUsers, nil
 }
 
 // GetUser will return information about the github user with the given login name

--- a/mungegithub/github/github_test.go
+++ b/mungegithub/github/github_test.go
@@ -535,3 +535,38 @@ this pr Fixes #23 and FIXES #45 but not fixxx #99`,
 		server.Close()
 	}
 }
+
+func TestFetchAllCollaborators(t *testing.T) {
+	tests := []struct {
+		users []github.User
+	}{
+		{
+			users: []github.User{},
+		},
+		{
+			users: []github.User{*github_test.User("asalkeld"), *github_test.User("eparis")},
+		},
+	}
+
+	for testNum, test := range tests {
+		client, server, _ := github_test.InitServerWithCollaborators(t, nil, nil, nil, nil, nil, nil, test.users)
+		config := &Config{}
+		config.Org = "o"
+		config.Project = "r"
+		config.SetClient(client)
+
+		list, err := config.FetchAllCollaborators()
+		if err != nil {
+			t.Fatalf("%d: unable to fetch Collaborators", testNum)
+		}
+		if len(test.users) != len(list) {
+			t.Errorf("%d: len(users) not equal, expected: %v but got: %v", testNum, test.users, list)
+		}
+		for i, n := range test.users {
+			if *n.Login != *list[i].Login {
+				t.Errorf("%d: expected user: %v but got user: %v", testNum, n, list[i])
+			}
+		}
+		server.Close()
+	}
+}

--- a/mungegithub/mungers/assign-fixes.go
+++ b/mungegithub/mungers/assign-fixes.go
@@ -17,8 +17,12 @@ limitations under the License.
 package mungers
 
 import (
+	"fmt"
+	"regexp"
+
 	"k8s.io/contrib/mungegithub/features"
 	"k8s.io/contrib/mungegithub/github"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -27,10 +31,18 @@ import (
 // AssignFixesMunger will assign issues to users based on the config file
 // provided by --assignfixes-config.
 type AssignFixesMunger struct {
-	config              *github.Config
-	features            *features.Features
-	assignfixesReassign bool
+	config        *github.Config
+	features      *features.Features
+	collaborators sets.String
 }
+
+const (
+	hasPRPosted = "has-pr-posted"
+)
+
+var (
+	claimMatcher = regexp.MustCompile(`(?:Assigned to|Claimed by) @(\w+)`)
+)
 
 func init() {
 	assignfixes := &AssignFixesMunger{}
@@ -47,6 +59,15 @@ func (a *AssignFixesMunger) RequiredFeatures() []string { return []string{} }
 func (a *AssignFixesMunger) Initialize(config *github.Config, features *features.Features) error {
 	a.features = features
 	a.config = config
+	a.collaborators = sets.String{}
+	users, err := config.FetchAllCollaborators()
+	if err != nil {
+		return err
+	}
+	for _, user := range users {
+		a.collaborators.Insert(github.DescribeUser(&user))
+	}
+
 	return nil
 }
 
@@ -55,7 +76,68 @@ func (a *AssignFixesMunger) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (a *AssignFixesMunger) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().BoolVar(&a.assignfixesReassign, "fixes-issue-reassign", false, "Assign fixes Issues even if they're already assigned")
+}
+
+func issueHasMarkFrom(issueObj *github.MungeObject, isCollaborator bool, prOwner string) (bool, error) {
+	comments, err := issueObj.ListComments()
+	if err != nil {
+		glog.Errorf("unexpected error getting comments: %v", err)
+		return true, nil
+	}
+
+	// This allows for the case of someone adding a PR to an old issue that previously
+	// had a different claimee/assignee.
+	lastClaimedBy := ""
+	for ix := range comments {
+		comment := &comments[ix]
+		matches := claimMatcher.FindAllStringSubmatch(comment.String(), -1)
+		if matches == nil {
+			continue
+		}
+		for _, match := range matches {
+			if match[1] != lastClaimedBy {
+				lastClaimedBy = match[1]
+			}
+		}
+	}
+	return (lastClaimedBy == prOwner), nil
+}
+
+func markIssueWith(issueObj *github.MungeObject, isCollaborator bool, prOwner string) {
+	hasMark, err := issueHasMarkFrom(issueObj, isCollaborator, prOwner)
+	if err != nil {
+		return
+	}
+	if !hasMark {
+		var text string
+		if isCollaborator {
+			text = fmt.Sprintf("Assigned to @%v (by mungegithub:assign-fixes)\n", prOwner)
+		} else {
+			text = fmt.Sprintf("Claimed by @%v (by mungegithub:assign-fixes)\n", prOwner)
+		}
+		err := issueObj.WriteComment(text)
+		if err != nil {
+			glog.Errorf("unexpected error adding comment: %v", err)
+		}
+	}
+}
+
+func (a *AssignFixesMunger) markIssue(issueObj *github.MungeObject, prOwner string) {
+	if !issueObj.HasLabel(hasPRPosted) {
+		issueObj.AddLabel(hasPRPosted)
+	}
+
+	if !a.collaborators.Has(prOwner) {
+		markIssueWith(issueObj, false, prOwner)
+		return
+	}
+
+	if github.DescribeUser(issueObj.Issue.Assignee) == prOwner {
+		return
+	}
+
+	markIssueWith(issueObj, true, prOwner)
+	issueObj.AssignPR(prOwner)
 }
 
 // Munge is the workhorse the will actually make updates to the PR
@@ -82,14 +164,6 @@ func (a *AssignFixesMunger) Munge(obj *github.MungeObject) {
 			glog.Infof("Couldn't get issue %v", fixesNum)
 			continue
 		}
-		issue := issueObj.Issue
-		if !a.assignfixesReassign && issue.Assignee != nil {
-			glog.V(6).Infof("skipping %v: reassign: %v assignee: %v", *issue.Number, a.assignfixesReassign, github.DescribeUser(issue.Assignee))
-			continue
-		}
-		glog.Infof("Assigning %v to %v (previously assigned to %v)", *issue.Number, prOwner, github.DescribeUser(issue.Assignee))
-		// although it says "AssignPR" it's more generic than that and is really just an issue.
-		issueObj.AssignPR(prOwner)
+		a.markIssue(issueObj, prOwner)
 	}
-
 }

--- a/mungegithub/mungers/assign-fixes_test.go
+++ b/mungegithub/mungers/assign-fixes_test.go
@@ -40,58 +40,63 @@ func TestAssignFixes(t *testing.T) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	tests := []struct {
-		name        string
-		assignee    string
-		pr          *github.PullRequest
-		prIssue     *github.Issue
-		prBody      string
-		fixesIssue  *github.Issue
-		comments    []github.IssueComment
-		expectClaim bool
+		name           string
+		assignee       string
+		expectAssignee string
+		pr             *github.PullRequest
+		prIssue        *github.Issue
+		prBody         string
+		fixesIssue     *github.Issue
+		comments       []github.IssueComment
+		expectClaim    bool
 	}{
 		{
-			name:       "fixes an issue, with comment",
-			assignee:   "eparis",
-			pr:         github_test.PullRequest("eparis", false, true, true),
-			prIssue:    github_test.Issue("eparis", 7779, []string{}, true),
-			prBody:     "does stuff and fixes #8889.",
-			fixesIssue: github_test.Issue("jill", 8889, []string{}, true),
+			name:           "fixes an issue, with comment and contributor change",
+			assignee:       "eparis",
+			expectAssignee: "eparis",
+			pr:             github_test.PullRequest("eparis", false, true, true),
+			prIssue:        github_test.Issue("eparis", 7779, []string{}, true),
+			prBody:         "does stuff and fixes #8889.",
+			fixesIssue:     github_test.Issue("jill", 8889, []string{}, true),
 			comments: []github.IssueComment{
 				comment(8889, "bla \nbla"),
 				comment(8889, "food for all")},
 			expectClaim: true,
 		},
 		{
-			name:       "fixes an issue, no comment",
-			assignee:   "eparis",
-			pr:         github_test.PullRequest("eparis", false, true, true),
-			prIssue:    github_test.Issue("eparis", 7779, []string{}, true),
-			prBody:     "does stuff and fixes #8889.",
-			fixesIssue: github_test.Issue("eparis", 8889, []string{}, true),
+			name:           "fixes an issue, no comment",
+			assignee:       "eparis",
+			expectAssignee: "eparis",
+			pr:             github_test.PullRequest("eparis", false, true, true),
+			prIssue:        github_test.Issue("eparis", 7779, []string{}, true),
+			prBody:         "does stuff and fixes #8889.",
+			fixesIssue:     github_test.Issue("eparis", 8889, []string{}, true),
 			comments: []github.IssueComment{
 				comment(8889, "bla \nbla"),
 				comment(8889, "Assigned to @eparis")},
 			expectClaim: false,
 		},
 		{
-			name:       "fixes an issue, no comment",
-			assignee:   "asalkeld",
-			pr:         github_test.PullRequest("asalkeld", false, true, true),
-			prIssue:    github_test.Issue("asalkeld", 7779, []string{}, true),
-			prBody:     "does stuff and fixes #8889.",
-			fixesIssue: github_test.Issue("jill", 8889, []string{}, true),
+			name:           "fixes an issue, no comment",
+			assignee:       "asalkeld",
+			expectAssignee: "k8s-almost-a-contributor",
+			pr:             github_test.PullRequest("asalkeld", false, true, true),
+			prIssue:        github_test.Issue("eparis", 7779, []string{}, true),
+			prBody:         "does stuff and fixes #8889.",
+			fixesIssue:     github_test.Issue("jill", 8889, []string{}, true),
 			comments: []github.IssueComment{
 				comment(8889, "bla \nbla"),
 				comment(8889, "food for all\nClaimed by @asalkeld")},
 			expectClaim: false,
 		},
 		{
-			name:       "fixes an issue, with comment",
-			assignee:   "asalkeld",
-			pr:         github_test.PullRequest("asalkeld", false, true, true),
-			prIssue:    github_test.Issue("asalkeld", 7779, []string{}, true),
-			prBody:     "does stuff and fixes #8889.",
-			fixesIssue: github_test.Issue("jill", 8889, []string{}, true),
+			name:           "fixes an issue, with comment and contributor",
+			assignee:       "asalkeld",
+			expectAssignee: "k8s-almost-a-contributor",
+			pr:             github_test.PullRequest("asalkeld", false, true, true),
+			prIssue:        github_test.Issue("eparis", 7779, []string{}, true),
+			prBody:         "does stuff and fixes #8889.",
+			fixesIssue:     github_test.Issue("jill", 8889, []string{}, true),
 			comments: []github.IssueComment{
 				comment(8889, "Claimed by @jonny"),
 				comment(8889, "food for all\nClaimed by @asalkeld"),
@@ -123,18 +128,12 @@ func TestAssignFixes(t *testing.T) {
 				if err != nil {
 					fmt.Println("error:", err)
 				}
-				if ip.Assignee != test.assignee {
-					t.Errorf("Patching the incorrect Assignee %v instead of %v", ip.Assignee, test.assignee)
+				if ip.Assignee != test.expectAssignee {
+					t.Errorf("Patching the incorrect Assignee %v instead of %v", ip.Assignee, test.expectAssignee)
 				}
 			}
 			w.WriteHeader(http.StatusOK)
 			w.Write(data)
-		})
-		mux.HandleFunc(fmt.Sprintf("/repos/o/r/issues/8889/labels"), func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != "POST" {
-				t.Errorf("Unexpected method: expected: POST got: %s", r.Method)
-			}
-			w.WriteHeader(http.StatusOK)
 		})
 		mux.HandleFunc(fmt.Sprintf("/repos/o/r/issues/8889/comments"), func(w http.ResponseWriter, r *http.Request) {
 			if !(r.Method == "GET" || (r.Method == "POST" && test.expectClaim)) {

--- a/mungegithub/mungers/assign-fixes_test.go
+++ b/mungegithub/mungers/assign-fixes_test.go
@@ -40,25 +40,69 @@ func TestAssignFixes(t *testing.T) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	tests := []struct {
-		name       string
-		assignee   string
-		pr         *github.PullRequest
-		prIssue    *github.Issue
-		prBody     string
-		fixesIssue *github.Issue
+		name        string
+		assignee    string
+		pr          *github.PullRequest
+		prIssue     *github.Issue
+		prBody      string
+		fixesIssue  *github.Issue
+		comments    []github.IssueComment
+		expectClaim bool
 	}{
 		{
-			name:       "fixes an issue",
-			assignee:   "dev45",
-			pr:         github_test.PullRequest("dev45", false, true, true),
-			prIssue:    github_test.Issue("fred", 7779, []string{}, true),
+			name:       "fixes an issue, with comment",
+			assignee:   "eparis",
+			pr:         github_test.PullRequest("eparis", false, true, true),
+			prIssue:    github_test.Issue("eparis", 7779, []string{}, true),
 			prBody:     "does stuff and fixes #8889.",
 			fixesIssue: github_test.Issue("jill", 8889, []string{}, true),
+			comments: []github.IssueComment{
+				comment(8889, "bla \nbla"),
+				comment(8889, "food for all")},
+			expectClaim: true,
+		},
+		{
+			name:       "fixes an issue, no comment",
+			assignee:   "eparis",
+			pr:         github_test.PullRequest("eparis", false, true, true),
+			prIssue:    github_test.Issue("eparis", 7779, []string{}, true),
+			prBody:     "does stuff and fixes #8889.",
+			fixesIssue: github_test.Issue("eparis", 8889, []string{}, true),
+			comments: []github.IssueComment{
+				comment(8889, "bla \nbla"),
+				comment(8889, "Assigned to @eparis")},
+			expectClaim: false,
+		},
+		{
+			name:       "fixes an issue, no comment",
+			assignee:   "asalkeld",
+			pr:         github_test.PullRequest("asalkeld", false, true, true),
+			prIssue:    github_test.Issue("asalkeld", 7779, []string{}, true),
+			prBody:     "does stuff and fixes #8889.",
+			fixesIssue: github_test.Issue("jill", 8889, []string{}, true),
+			comments: []github.IssueComment{
+				comment(8889, "bla \nbla"),
+				comment(8889, "food for all\nClaimed by @asalkeld")},
+			expectClaim: false,
+		},
+		{
+			name:       "fixes an issue, with comment",
+			assignee:   "asalkeld",
+			pr:         github_test.PullRequest("asalkeld", false, true, true),
+			prIssue:    github_test.Issue("asalkeld", 7779, []string{}, true),
+			prBody:     "does stuff and fixes #8889.",
+			fixesIssue: github_test.Issue("jill", 8889, []string{}, true),
+			comments: []github.IssueComment{
+				comment(8889, "Claimed by @jonny"),
+				comment(8889, "food for all\nClaimed by @asalkeld"),
+				comment(8889, "Claimed by @lazy.dude")},
+			expectClaim: true,
 		},
 	}
+	collaborators := []github.User{*github_test.User("eparis")}
 	for _, test := range tests {
 		test.prIssue.Body = &test.prBody
-		client, server, mux := github_test.InitServer(t, test.prIssue, test.pr, nil, nil, nil, nil)
+		client, server, mux := github_test.InitServerWithCollaborators(t, test.prIssue, test.pr, nil, nil, nil, nil, collaborators)
 		path := fmt.Sprintf("/repos/o/r/issues/%d", *test.fixesIssue.Number)
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 			data, err := json.Marshal(test.fixesIssue)
@@ -85,6 +129,22 @@ func TestAssignFixes(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusOK)
 			w.Write(data)
+		})
+		mux.HandleFunc(fmt.Sprintf("/repos/o/r/issues/8889/labels"), func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "POST" {
+				t.Errorf("Unexpected method: expected: POST got: %s", r.Method)
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+		mux.HandleFunc(fmt.Sprintf("/repos/o/r/issues/8889/comments"), func(w http.ResponseWriter, r *http.Request) {
+			if !(r.Method == "GET" || (r.Method == "POST" && test.expectClaim)) {
+				t.Errorf("Unexpected method: expected: GET/POST got: %s", r.Method)
+			}
+			w.WriteHeader(http.StatusOK)
+			if r.Method == "GET" {
+				data, _ := json.Marshal(test.comments)
+				w.Write(data)
+			}
 		})
 
 		config := &github_util.Config{}

--- a/mungegithub/mungers/comment-deleter-jenkins_test.go
+++ b/mungegithub/mungers/comment-deleter-jenkins_test.go
@@ -82,7 +82,7 @@ func TestIsJenkinsTestComment(t *testing.T) {
 }
 
 func comment(id int, body string) githubapi.IssueComment {
-	return github_test.Comment(id, jenkinsBotName, time.Now(), passComment)
+	return github_test.Comment(id, jenkinsBotName, time.Now(), body)
 }
 
 func TestJenkinsStaleComments(t *testing.T) {

--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         command:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
-        - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue,issue-cacher,flake-manager,old-test-getter
+        - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue,issue-cacher,flake-manager,old-test-getter,assign-fixes
         - --dry-run=true
         - --weak-stable-jobs=kubernetes-kubemark-500-gce
         - --required-contexts="Jenkins GCE Node e2e"


### PR DESCRIPTION
1. only assign issues to collaborators
2. add a label has-pr-posted to make searching for issues easier
3. leave a comment (only once) with the author of the PR
4. remove UsersWithAccess as it is not used

fixes #1161

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1179)

<!-- Reviewable:end -->
