### PR TITLE
add gke-serial into the list

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -394,6 +394,7 @@ func (sq *SubmitQueue) AddFlags(cmd *cobra.Command, config *github.Config) {
 		"kubernetes-e2e-gce",
 		"kubernetes-e2e-gce-slow",
 		"kubernetes-e2e-gce-serial",
+		"kubernetes-e2e-gke-serial",
 		"kubernetes-e2e-gke",
 		"kubernetes-e2e-gke-slow",
 		"kubernetes-e2e-gce-scalability",


### PR DESCRIPTION
We just made it green.

I probably won't push this until something causes the merges to stop, since restarts are expensive.