### PR TITLE
Enable operating on microvalues in addong resizer

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -25,7 +25,7 @@
 OUT_DIR = build
 PACKAGE = k8s.io/contrib/addon-resizer
 PREFIX = gcr.io/google_containers
-TAG = 1.2
+TAG = 1.3
 
 # Rules for building the real image for deployment to gcr.io
 

--- a/addon-resizer/nanny/estimator_test.go
+++ b/addon-resizer/nanny/estimator_test.go
@@ -85,6 +85,15 @@ var (
 			},
 		},
 	}
+	lessThanMilliEstimator = LinearEstimator{
+		Resources: []Resource{
+			{
+				Base:         resource.MustParse("0.3"),
+				ExtraPerNode: resource.MustParse("0.5m"),
+				Name:         "cpu",
+			},
+		},
+	}
 	emptyEstimator = LinearEstimator{
 		Resources: []Resource{},
 	}
@@ -145,6 +154,9 @@ var (
 		"cpu":    resource.MustParse("3.3"),
 		"memory": resource.MustParse("33Mi"),
 	}
+	threeNodeLessThanMilliResources = api.ResourceList{
+		"cpu": resource.MustParse("0.3015"),
+	}
 	noResources = api.ResourceList{}
 
 	sixteenNodeResources = api.ResourceList{
@@ -191,6 +203,7 @@ func TestEstimateResources(t *testing.T) {
 		{noMemoryEstimator, 3, threeNodeNoMemoryResources, threeNodeNoMemoryResources},
 		{noStorageEstimator, 0, noStorageBaseResources, noStorageBaseResources},
 		{noStorageEstimator, 3, threeNodeNoStorageResources, threeNodeNoStorageResources},
+		{lessThanMilliEstimator, 3, threeNodeLessThanMilliResources, threeNodeLessThanMilliResources},
 		{emptyEstimator, 0, noResources, noResources},
 		{emptyEstimator, 3, noResources, noResources},
 		{exponentialEstimator, 0, sixteenNodeResources, sixteenNodeResources},

--- a/addon-resizer/nanny/estimator_test.go
+++ b/addon-resizer/nanny/estimator_test.go
@@ -118,6 +118,16 @@ var (
 		},
 		ScaleFactor: 1.5,
 	}
+	exponentialLessThanMilliEstimator = ExponentialEstimator{
+		Resources: []Resource{
+			{
+				Base:         resource.MustParse("0.3"),
+				ExtraPerNode: resource.MustParse("0.5m"),
+				Name:         "cpu",
+			},
+		},
+		ScaleFactor: 1.5,
+	}
 
 	baseResources = api.ResourceList{
 		"cpu":     resource.MustParse("0.3"),
@@ -156,6 +166,9 @@ var (
 	}
 	threeNodeLessThanMilliResources = api.ResourceList{
 		"cpu": resource.MustParse("0.3015"),
+	}
+	threeNodeLessThanMilliExpResources = api.ResourceList{
+		"cpu": resource.MustParse("0.308"),
 	}
 	noResources = api.ResourceList{}
 
@@ -213,6 +226,7 @@ func TestEstimateResources(t *testing.T) {
 		{exponentialEstimator, 17, twentyFourNodeResources, twentyFourNodeResources},
 		{exponentialEstimator, 20, twentyFourNodeResources, twentyFourNodeResources},
 		{exponentialEstimator, 24, twentyFourNodeResources, twentyFourNodeResources},
+		{exponentialLessThanMilliEstimator, 3, threeNodeLessThanMilliExpResources, threeNodeLessThanMilliExpResources},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Since we want to enable passing values smaller than e.g. 1 millicore per node, we need a solution other  than operating on MilliValues.

@gmarek 
