### PR TITLE
resolves the "this module requires key=value”

### DIFF
--- a/ansible/roles/flannel/tasks/ubuntu.yml
+++ b/ansible/roles/flannel/tasks/ubuntu.yml
@@ -1,12 +1,13 @@
 ---
 - name: Ubuntu | Configure Docker to use Flannel network
-  lineinfile: dest="{{ docker_config_dir }}/docker" state=present
-              line="{{ item.line }}"
-              regexp="{{ item.regexp }}"
+  lineinfile:
+       dest: "{{ docker_config_dir }}/docker"
+       state: present
+       line: "{{ item.line }}"
+       regexp: "{{ item.regexp }}"
   with_items:
     - { line: '. /run/flannel/subnet.env', regexp: '. /run/flannel/subnet.env' }
-    - { line: 'DOCKER_OPTS="--bip ${FLANNEL_SUBNET} --mtu ${FLANNEL_MTU}"',
-        regexp: '^DOCKER_OPTS=' }
+    - { line: 'DOCKER_OPTS="--bip ${FLANNEL_SUBNET} --mtu ${FLANNEL_MTU}"',regexp: '^DOCKER_OPTS=' }
   when: ansible_distribution_major_version|int < 15
   notify:
     - restart flannel


### PR DESCRIPTION
replace = with : to resolve the error 
this module requires key=value arguments” when key=value args supplied

resolves #1221 