### PR TITLE
added domain name replacement for kleenestar. subdomain

### DIFF
--- a/ingress/controllers/nginx/nginx/template.go
+++ b/ingress/controllers/nginx/nginx/template.go
@@ -61,6 +61,14 @@ func (ngx *Manager) loadTemplate() {
 
 func (ngx *Manager) writeCfg(cfg config.Configuration, ingressCfg IngressConfig) (bool, error) {
 	conf := make(map[string]interface{})
+	//replace ^kleenestar\. with *.
+	r := regexp.MustCompile("^kleenestar\\.")
+	for i := 0; i < len(ingressCfg.Servers); i++ {
+		s := ingressCfg.Servers[i]
+		old := s.Name
+		s.Name = r.ReplaceAllString(s.Name, "*.")
+		glog.Infof("replacing [%v] with [%v]", old, s.Name)
+	}
 	conf["upstreams"] = ingressCfg.Upstreams
 	conf["servers"] = ingressCfg.Servers
 	conf["tcpUpstreams"] = ingressCfg.TCPUpstreams


### PR DESCRIPTION
i set up a loop that looks for domains that start with kleenestar. Then replaces that prefix with *. on the nginx side. This is a intermediate solution while we try to fix the validation problem with ingress denying \* wild cards. 

issue link: https://github.com/kubernetes/contrib/issues/799

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1223)

<!-- Reviewable:end -->
