### PR TITLE
Add /health.svg endpoint to serve a small queue status badge.

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -1,9 +1,8 @@
-ingress/controllers/nginx/README.md:Enables which HTTP codes should be passed for processing with the [error_page directive](http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page)
-ingress/controllers/nginx/README.md:Setting at least one code this also enables [proxy_intercept_errors](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors) (required to process error_page)
 ingress/controllers/nginx/nginx.tmpl:        require("error_page")
 ingress/controllers/nginx/nginx.tmpl:    error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
 ingress/controllers/nginx/nginx/config/config.go:	// enables which HTTP codes should be passed for processing with the error_page directive
 mungegithub/mungers/submit-queue.go:		sq.e2e = &fake_e2e.FakeE2ETester{
 mungegithub/mungers/submit-queue.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"
+mungegithub/mungers/submit-queue_test.go:	e2e := sq.e2e.(*fake_e2e.FakeE2ETester)
 mungegithub/mungers/submit-queue_test.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"
 mungegithub/mungers/submit-queue_test.go:	sq.e2e = &fake_e2e.FakeE2ETester{

--- a/mungegithub/mungers/e2e/fake/fake.go
+++ b/mungegithub/mungers/e2e/fake/fake.go
@@ -25,6 +25,7 @@ import (
 type FakeE2ETester struct {
 	JobNames           []string
 	WeakStableJobNames []string
+	NotStableJobNames  []string
 }
 
 // Flakes returns nil.
@@ -46,6 +47,9 @@ func (e *FakeE2ETester) GetBuildStatus() map[string]e2e.BuildInfo {
 	}
 	for _, name := range e.WeakStableJobNames {
 		out[name] = e2e.BuildInfo{"Stable", "1"}
+	}
+	for _, name := range e.NotStableJobNames {
+		out[name] = e2e.BuildInfo{"Not Stable", "1"}
 	}
 	return out
 }

--- a/mungegithub/mungers/shield/shield.go
+++ b/mungegithub/mungers/shield/shield.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shield
+
+// shield provides a local version of the shields.io service.
+
+import (
+	"bytes"
+	"html/template"
+)
+
+var svg = `<svg xmlns="http://www.w3.org/2000/svg" width="{{.Width}}" height="20">
+<linearGradient id="a" x2="0" y2="100%">
+  <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+  <stop offset="1" stop-opacity=".1"/>
+</linearGradient>
+<rect rx="3" width="100%" height="20" fill="#555"/>
+<g fill="{{.Color}}">
+  <rect rx="3" x="{{.RightStart}}" width="{{.RightWidth}}" height="20"/>
+  <path d="M{{.RightStart}} 0h4v20h-4z"/>
+</g>
+<rect rx="3" width="100%" height="20" fill="url(#a)"/>
+<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+<g fill="#010101" opacity=".3">
+<text x="{{.XposLeft}}" y="15">{{.Subject}}</text>
+<text x="{{.XposRight}}" y="15">{{.Status}}</text>
+</g>
+<text x="{{.XposLeft}}" y="14">{{.Subject}}</text>
+<text x="{{.XposRight}}" y="14">{{.Status}}</text>
+</g>
+</svg>`
+
+var svgTemplate = template.Must(template.New("svg").Parse(svg))
+
+// Make a small SVG badge that looks like `[subject | status]`, with the status
+// text in the given color.
+func Make(subject, status, color string) []byte {
+	// TODO(rmmh): Use better font-size metrics for prettier badges-- estimating
+	// character widths as 6px isn't very accurate.
+	// See also: https://github.com/badges/shields/blob/master/measure-text.js
+	p := struct {
+		Width, RightStart, RightWidth int
+		XposLeft, XposRight           float64
+		Subject, Status               string
+		Color                         string
+	}{
+		Subject:    subject,
+		Status:     status,
+		RightStart: 13 + 6*len(subject),
+		RightWidth: 13 + 6*len(status),
+	}
+	p.Width = p.RightStart + p.RightWidth
+	p.XposLeft = float64(p.RightStart) * 0.5
+	p.XposRight = float64(p.RightStart) + float64(p.RightWidth-2)*0.5
+	switch color {
+	case "brightgreen":
+		p.Color = "#4c1"
+	case "red":
+		p.Color = "#e05d44"
+	default:
+		panic("Invalid color " + color)
+	}
+	var buf bytes.Buffer
+	svgTemplate.Execute(&buf, p)
+	return buf.Bytes()
+}


### PR DESCRIPTION
This is inspired by shields.io, but is served directly.

Future work: show overall health status at a glance (maybe using sparklines?)

![health-good](https://cloud.githubusercontent.com/assets/211868/16134800/32e5f1e2-33d4-11e6-9103-0a925131933b.png)
![health-bad](https://cloud.githubusercontent.com/assets/211868/16134720/a7e70608-33d3-11e6-82db-7456fae62805.png)
