### PR TITLE
[nginx-ingress-controller]: Add support for dynamic TLS records and spdy

### DIFF
--- a/ingress/controllers/nginx/Dockerfile
+++ b/ingress/controllers/nginx/Dockerfile
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/nginx-slim:0.7
+FROM gcr.io/google_containers/nginx-slim:0.8
 
 RUN apt-get update && apt-get install -y \
   diffutils \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
-
-# Download of GeoIP databases
-RUN curl -sSL -o /etc/nginx/GeoIP.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz \
-  && curl -sSL -o /etc/nginx/GeoLiteCity.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz \
-  && gunzip /etc/nginx/GeoIP.dat.gz \
-  && gunzip /etc/nginx/GeoLiteCity.dat.gz
 
 COPY nginx-ingress-controller /
 COPY nginx.tmpl /etc/nginx/template/nginx.tmpl

--- a/ingress/controllers/nginx/nginx.tmpl
+++ b/ingress/controllers/nginx/nginx.tmpl
@@ -145,6 +145,10 @@ http {
     ssl_dhparam {{ .sslDHParam }};
     {{ end }}
 
+    {{- if not $cfg.enableDynamicTlsRecords }}
+    ssl_dyn_rec_size_lo 0;
+    {{ end }}
+
     {{- if .customErrors }}
     # Custom error pages
     proxy_intercept_errors on;
@@ -178,7 +182,7 @@ http {
     server {
         server_name {{ $server.Name }};
         listen 80{{ if $cfg.useProxyProtocol }} proxy_protocol{{ end }};
-        {{ if $server.SSL }}listen 443 {{ if $cfg.useProxyProtocol }}proxy_protocol{{ end }} ssl {{ if $cfg.useHttp2 }}http2{{ end }};
+        {{ if $server.SSL }}listen 443 {{ if $cfg.useProxyProtocol }}proxy_protocol{{ end }} ssl {{ if $cfg.enableSpdy }}spdy{{ end }} {{ if $cfg.useHttp2 }}http2{{ end }};
         {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
         # PEM sha: {{ $server.SSLPemChecksum }}        
         ssl_certificate {{ $server.SSLCertificate }};

--- a/ingress/controllers/nginx/nginx/config/config.go
+++ b/ingress/controllers/nginx/nginx/config/config.go
@@ -78,6 +78,16 @@ type Configuration struct {
 	// Sets the maximum allowed size of the client request body
 	BodySize string `structs:"body-size,omitempty"`
 
+	// EnableDynamicTLSRecords enables dynamic TLS record sizes
+	// https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency
+	// By default this is enabled
+	EnableDynamicTLSRecords bool `structs:"enable-dynamic-tls-records"`
+
+	// EnableSPDY enables spdy and use ALPN and NPN to advertise the availability of the two protocols
+	// https://blog.cloudflare.com/open-sourcing-our-nginx-http-2-spdy-code
+	// By default this is enabled
+	EnableSPDY bool `structs:"enable-spdy"`
+
 	// EnableStickySessions enabled sticky sessions using cookies
 	// https://bitbucket.org/nginx-goodies/nginx-sticky-module-ng
 	// By default this is disabled
@@ -251,9 +261,11 @@ type Configuration struct {
 // in the file default-conf.json
 func NewDefault() Configuration {
 	cfg := Configuration{
-		BodySize:      bodySize,
-		ErrorLogLevel: errorLevel,
-		HSTS:          true,
+		BodySize:                bodySize,
+		EnableDynamicTLSRecords: true,
+		EnableSPDY:              true,
+		ErrorLogLevel:           errorLevel,
+		HSTS:                    true,
 		HSTSIncludeSubdomains:    true,
 		HSTSMaxAge:               hstsMaxAge,
 		GzipTypes:                gzipTypes,


### PR DESCRIPTION
requires #1236 