### PR TITLE
Add 1-minute expiration to badge (Github's proxy has 1 year expiry).

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -1308,6 +1308,7 @@ func (sq *SubmitQueue) getHealthSVG() []byte {
 
 func (sq *SubmitQueue) serveHealthSVG(res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Content-type", "image/svg+xml")
+	res.Header().Set("Cache-Control", "max-age=60")
 	res.WriteHeader(http.StatusOK)
 	res.Write(sq.getHealthSVG())
 }


### PR DESCRIPTION
If the cache-control header is missing, Github's HTTPS proxy defaults to 1 year expiration, which is NOT what we want: https://github.com/atmos/camo/blob/master/server.js#L129