### PR TITLE
Adding federation e2e to non blocking test suite

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -395,6 +395,7 @@ func (sq *SubmitQueue) AddFlags(cmd *cobra.Command, config *github.Config) {
 		"kubernetes-e2e-gke-subnet",
 		"kubernetes-e2e-gke-test",
 		"kubernetes-e2e-gce-examples",
+		"kubernetes-e2e-gce-federation",
 	}, "Comma separated list of jobs that don't block merges, but will have status reported and issues filed.")
 	cmd.Flags().StringSliceVar(&sq.BlockingJobNames, "jenkins-jobs", []string{
 		"kubelet-gce-e2e-ci",


### PR DESCRIPTION
Adding federation e2e test suite to the list of tracked tests so that we at least have issues filed while we wait for https://github.com/kubernetes/contrib/pull/1198.

cc @lavalamp 
