### PR TITLE
Autoscaler: Super hacky workaround for GCE provider crashloop

### DIFF
--- a/cluster-autoscaler/Godeps/Godeps.json
+++ b/cluster-autoscaler/Godeps/Godeps.json
@@ -910,8 +910,8 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/gce",
-			"Comment": "v1.3.0-alpha.4-830-g8a29f67",
-			"Rev": "8a29f67fc1a3c6e107ce0d70a8e643b99b765e0a"
+			"Comment": "v1.3.0-alpha.4-830-g8a29f67 (MANUALLY MODIFIED)",
+			"Rev": "8a29f67fc1a3c6e107ce0d70a8e643b99b765e0a-dirty"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller",

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
@@ -91,12 +91,13 @@ type GCECloud struct {
 
 type Config struct {
 	Global struct {
-		TokenURL    string   `gcfg:"token-url"`
-		TokenBody   string   `gcfg:"token-body"`
-		ProjectID   string   `gcfg:"project-id"`
-		NetworkName string   `gcfg:"network-name"`
-		NodeTags    []string `gcfg:"node-tags"`
-		Multizone   bool     `gcfg:"multizone"`
+		TokenURL           string   `gcfg:"token-url"`
+		TokenBody          string   `gcfg:"token-body"`
+		ProjectID          string   `gcfg:"project-id"`
+		NetworkName        string   `gcfg:"network-name"`
+		NodeTags           []string `gcfg:"node-tags"`
+		NodeInstancePrefix string   `gcfg:"node-instance-prefix"` // Ignored. (Manual vendor/ patch.)
+		Multizone          bool     `gcfg:"multizone"`
 	}
 }
 


### PR DESCRIPTION
Fix to https://github.com/kubernetes/kubernetes/issues/27821. Borrows the necessary piece of https://github.com/kubernetes/kubernetes/pull/27741 to parse the `gce.conf`.

Also opened https://github.com/kubernetes/contrib/issues/1251 to fix Godeps correctly.

Forgive me.
