### PR TITLE
Revert "[nginx-ingress-controller]: Avoid sync without a reachable master"

### DIFF
--- a/ingress/controllers/nginx/controller.go
+++ b/ingress/controllers/nginx/controller.go
@@ -420,19 +420,13 @@ func (lbc *loadBalancerController) sync(key string) error {
 		return fmt.Errorf("deferring sync till endpoints controller has synced")
 	}
 
-	// by default no custom configuration configmap
-	cfg := &api.ConfigMap{}
+	var cfg *api.ConfigMap
 
-	if lbc.nxgConfigMap != "" {
-		// Search for custom configmap (defined in main args)
-		var err error
-		ns, name, _ := parseNsName(lbc.nxgConfigMap)
-		cfg, err = lbc.getConfigMap(ns, name)
-		if err != nil {
-			glog.V(3).Infof("unexpected error searching configmap %v: %v", lbc.nxgConfigMap, err)
-			lbc.syncQueue.requeue(key, err)
-			return
-		}
+	ns, name, _ := parseNsName(lbc.nxgConfigMap)
+	cfg, err := lbc.getConfigMap(ns, name)
+	if err != nil {
+		glog.V(3).Infof("unexpected error searching configmap %v: %v", lbc.nxgConfigMap, err)
+		cfg = &api.ConfigMap{}
 	}
 
 	ngxConfig := lbc.nginx.ReadConfig(cfg)

--- a/ingress/controllers/nginx/main.go
+++ b/ingress/controllers/nginx/main.go
@@ -130,13 +130,6 @@ func main() {
 	}
 	glog.Infof("Validated %v as the default backend", *defaultSvc)
 
-	if *nxgConfigMap != "" {
-		_, _, err := parseNsName(*nxgConfigMap)
-		if err != nil {
-			glog.Fatalf("configmap error: %v", err)
-		}
-	}
-
 	lbc, err := newLoadBalancerController(kubeClient, *resyncPeriod, *defaultSvc, *watchNamespace, *nxgConfigMap, *tcpConfigMapName, *udpConfigMapName, runtimePodInfo)
 	if err != nil {
 		glog.Fatalf("%v", err)


### PR DESCRIPTION
Reverts kubernetes/contrib#1233
