### PR TITLE
Add trailing slashes to nginx-alpha ingress config

### DIFF
--- a/ingress/controllers/nginx-alpha/README.md
+++ b/ingress/controllers/nginx-alpha/README.md
@@ -87,18 +87,18 @@ spec:
   - host: foo.bar.com
     http:
       paths:
-      - path: /foo
+      - path: /foo/
         backend:
           serviceName: echoheaders-x
           servicePort: 80
   - host: bar.baz.com
     http:
       paths:
-      - path: /bar
+      - path: /bar/
         backend:
           serviceName: echoheaders-y
           servicePort: 80
-      - path: /foo
+      - path: /foo/
         backend:
           serviceName: echoheaders-x
           servicePort: 80

--- a/ingress/controllers/nginx-alpha/controller.go
+++ b/ingress/controllers/nginx-alpha/controller.go
@@ -48,7 +48,7 @@ http {
 {{ range $path := $rule.HTTP.Paths }}
     location {{$path.Path}} {
       proxy_set_header Host $host;
-      proxy_pass http://{{$path.Backend.ServiceName}}.{{$ing.Namespace}}.svc.cluster.local:{{$path.Backend.ServicePort}};
+      proxy_pass http://{{$path.Backend.ServiceName}}.{{$ing.Namespace}}.svc.cluster.local:{{$path.Backend.ServicePort}}/;
     }{{end}}
   }{{end}}{{end}}
 }`


### PR DESCRIPTION
This address most of #1266. Does not account for failure to add trailing slashes to ingress resource.