### PR TITLE
submit-queue: update the 'details' link in github

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -677,7 +677,7 @@ func (sq *SubmitQueue) SetMergeStatus(obj *github.MungeObject, reason string) {
 	status := obj.GetStatus(sqContext)
 	if status == nil || *status.Description != reason {
 		state := reasonToState(reason)
-		url := fmt.Sprintf("http://submit-queue.k8s.io/#?prDisplay=%d&historyDisplay=%d", *obj.Issue.Number, *obj.Issue.Number)
+		url := fmt.Sprintf("http://submit-queue.k8s.io/#/prs/?prDisplay=%d&historyDisplay=%d", *obj.Issue.Number, *obj.Issue.Number)
 		_ = obj.SetStatus(state, url, reason, sqContext)
 	}
 


### PR DESCRIPTION
We were sending people to the front page of the submit-queue. But then
we changed the front page to be the queue instead of the 'all PRs'.

While this link it's particularly useful, at least seeing your PR most
of the time is better than not...

fixes #1271 
