### PR TITLE
Switch graph to use svg instead of png

### DIFF
--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -171,7 +171,7 @@
               <p>Health percents are the fraction of the time that a given job is stable for the last day, or since the submit queue restarted ({{ cntl.sqStats.StartTime | date:'medium'}})</span>, whichever is shorter. The <a href="http://storage.googleapis.com/kubernetes-test-history/static/index.html"><strong>24-Hour Test Report</strong></a> shows more detail, along with a list of flaky and broken tests in merge-blocking jobs.
               </p>
               <p>
-                <img src="http://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.png" style="max-width: 100%"/>
+                <img src="http://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg" style="max-width: 100%"/>
               </p>
             </md-tab-body>
           </md-tab>
@@ -242,7 +242,7 @@
                     <h2 class="md-toolbar-tools">Health chart for the past week</h2>
                   </md-toolbar>
                   <md-content class="md-padding">
-                    <span><img src="http://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.png" style="max-width: 100%"/></span>
+                    <span><img src="http://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg" style="max-width: 100%"/></span>
                   </md-content>
                 </md-tab>
               </md-tabs>


### PR DESCRIPTION
http://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg exists (and the .png's content type is actually svg)
