### PR TITLE
Ingress controller ux fixes

### DIFF
--- a/ingress/controllers/gce/controller/cluster_manager.go
+++ b/ingress/controllers/gce/controller/cluster_manager.go
@@ -260,7 +260,7 @@ func NewClusterManager(
 		// config and only invoke getGCEClient once, that will not do the right
 		// thing because a nil check against an interface isn't true in golang.
 		cloud = getGCEClient(nil)
-		glog.Infof("Created GCE client without a confi file")
+		glog.Infof("Created GCE client without a config file")
 	}
 
 	// Names are fundamental to the cluster, the uid allocator makes sure names don't collide.

--- a/ingress/controllers/gce/controller/controller.go
+++ b/ingress/controllers/gce/controller/controller.go
@@ -260,31 +260,27 @@ func (lbc *LoadBalancerController) storesSynced() bool {
 }
 
 // sync manages Ingress create/updates/deletes.
-func (lbc *LoadBalancerController) sync(key string) {
+func (lbc *LoadBalancerController) sync(key string) (err error) {
 	if !lbc.hasSynced() {
 		time.Sleep(storeSyncPollPeriod)
-		lbc.ingQueue.requeue(key, fmt.Errorf("Waiting for stores to sync"))
-		return
+		return fmt.Errorf("Waiting for stores to sync")
 	}
 	glog.V(3).Infof("Syncing %v", key)
 
 	paths, err := lbc.ingLister.List()
 	if err != nil {
-		lbc.ingQueue.requeue(key, err)
-		return
+		return err
 	}
 	nodePorts := lbc.tr.toNodePorts(&paths)
 	lbNames := lbc.ingLister.Store.ListKeys()
 	lbs, _ := lbc.ListRuntimeInfo()
 	nodeNames, err := lbc.getReadyNodeNames()
 	if err != nil {
-		lbc.ingQueue.requeue(key, err)
-		return
+		return err
 	}
 	obj, ingExists, err := lbc.ingLister.Store.GetByKey(key)
 	if err != nil {
-		lbc.ingQueue.requeue(key, err)
-		return
+		return err
 	}
 
 	// This performs a 2 phase checkpoint with the cloud:
@@ -299,8 +295,8 @@ func (lbc *LoadBalancerController) sync(key string) {
 	//   don't have an associated Kubernetes Ingress/Service/Endpoint.
 
 	defer func() {
-		if err := lbc.CloudClusterManager.GC(lbNames, nodePorts); err != nil {
-			lbc.ingQueue.requeue(key, err)
+		if deferErr := lbc.CloudClusterManager.GC(lbNames, nodePorts); deferErr != nil {
+			err = fmt.Errorf("Error during sync %v, error during GC %v", err, deferErr)
 		}
 		glog.V(3).Infof("Finished syncing %v", key)
 	}()
@@ -323,16 +319,12 @@ func (lbc *LoadBalancerController) sync(key string) {
 	}
 
 	if !ingExists {
-		if syncError != nil {
-			lbc.ingQueue.requeue(key, err)
-		}
-		return
+		return syncError
 	}
 	// Update the UrlMap of the single loadbalancer that came through the watch.
 	l7, err := lbc.CloudClusterManager.l7Pool.Get(key)
 	if err != nil {
-		lbc.ingQueue.requeue(key, fmt.Errorf("%v, unable to get loadbalancer: %v", syncError, err))
-		return
+		return fmt.Errorf("%v, unable to get loadbalancer: %v", syncError, err)
 	}
 
 	ing := *obj.(*extensions.Ingress)
@@ -345,10 +337,7 @@ func (lbc *LoadBalancerController) sync(key string) {
 		lbc.recorder.Eventf(&ing, api.EventTypeWarning, "Status", err.Error())
 		syncError = fmt.Errorf("%v, update ingress error: %v", syncError, err)
 	}
-	if syncError != nil {
-		lbc.ingQueue.requeue(key, syncError)
-	}
-	return
+	return syncError
 }
 
 // updateIngressStatus updates the IP and annotations of a loadbalancer.
@@ -421,16 +410,15 @@ func (lbc *LoadBalancerController) ListRuntimeInfo() (lbs []*loadbalancers.L7Run
 
 // syncNodes manages the syncing of kubernetes nodes to gce instance groups.
 // The instancegroups are referenced by loadbalancer backends.
-func (lbc *LoadBalancerController) syncNodes(key string) {
+func (lbc *LoadBalancerController) syncNodes(key string) error {
 	nodeNames, err := lbc.getReadyNodeNames()
 	if err != nil {
-		lbc.nodeQueue.requeue(key, err)
-		return
+		return err
 	}
 	if err := lbc.CloudClusterManager.instancePool.Sync(nodeNames); err != nil {
-		lbc.nodeQueue.requeue(key, err)
+		return err
 	}
-	return
+	return nil
 }
 
 func nodeReady(node api.Node) bool {

--- a/ingress/controllers/gce/controller/util_test.go
+++ b/ingress/controllers/gce/controller/util_test.go
@@ -135,7 +135,8 @@ func addPods(lbc *LoadBalancerController, nodePortToHealthCheck map[int64]string
 						ReadinessProbe: &api.Probe{
 							Handler: api.Handler{
 								HTTPGet: &api.HTTPGetAction{
-									Path: u,
+									Scheme: api.URISchemeHTTP,
+									Path:   u,
 									Port: intstr.IntOrString{
 										Type:   intstr.Int,
 										IntVal: 80,

--- a/ingress/controllers/gce/firewalls/firewalls.go
+++ b/ingress/controllers/gce/firewalls/firewalls.go
@@ -76,7 +76,7 @@ func (fr *FirewallRules) Sync(nodePorts []int64, nodeNames []string) error {
 	if requiredPorts.Equal(existingPorts) {
 		return nil
 	}
-	glog.V(3).Infof("Firewall rule already %v exists, updating nodeports %v", name, nodePorts)
+	glog.V(3).Infof("Firewall rule %v already exists, updating nodeports %v", name, nodePorts)
 	return fr.cloud.UpdateFirewall(suffix, "GCE L7 firewall rule", fr.srcRange, nodePorts, nodeNames)
 }
 

--- a/ingress/controllers/gce/instances/instances.go
+++ b/ingress/controllers/gce/instances/instances.go
@@ -101,7 +101,7 @@ func (i *Instances) DeleteInstanceGroup(name string) error {
 		return err
 	}
 	for _, zone := range zones {
-		glog.Infof("deleting instance group %v in zone %v", name, zone)
+		glog.Infof("Deleting instance group %v in zone %v", name, zone)
 		if err := i.cloud.DeleteInstanceGroup(name, zone); err != nil {
 			errs = append(errs, err)
 		}

--- a/ingress/controllers/gce/main.go
+++ b/ingress/controllers/gce/main.go
@@ -58,7 +58,7 @@ const (
 	alphaNumericChar = "0"
 
 	// Current docker image version. Only used in debug logging.
-	imageVersion = "glbc:0.7.0"
+	imageVersion = "glbc:0.7.1"
 
 	// Key used to persist UIDs to configmaps.
 	uidConfigMapName = "ingress-uid"


### PR DESCRIPTION
I don't know if this will make 1.3, will try, if not I'll be pushing it out as a minor release cherrypick. 
These ux fixes actually make a difference:
- doesn't hot loop on failure
- doesn't spam activity log with unnecessary firewall updates
- allows non-gce ingress to coexist in the same cluster
- doesn't adopt complex http readiness probes as health checks (probes with headers/hosts/https)
- allows one to continue running the controller on older clusters as a pod (by fixing GCE client creation)
