### PR TITLE
Cluster autoscaler: add handlign for nill mig configs (in case not all l node pools are autoscaled)

### DIFF
--- a/cluster-autoscaler/scale_down.go
+++ b/cluster-autoscaler/scale_down.go
@@ -133,6 +133,11 @@ func ScaleDown(
 				glog.Errorf("Error while checking mig config for instance %v: %v", instance, err)
 				continue
 			}
+			if migConfig == nil {
+				glog.V(4).Infof("Skipping %s - no mig config", node.Name)
+				continue
+			}
+
 			size, err := gceManager.GetMigSize(migConfig)
 			if err != nil {
 				glog.Errorf("Error while checking mig size for instance %v: %v", instance, err)

--- a/cluster-autoscaler/utils.go
+++ b/cluster-autoscaler/utils.go
@@ -276,6 +276,9 @@ func GetNodeInfosForMigs(nodes []*kube_api.Node, gceManager *gce.GceManager, kub
 		if err != nil {
 			return map[string]*schedulercache.NodeInfo{}, err
 		}
+		if migConfig == nil {
+			continue
+		}
 		url := migConfig.Url()
 
 		nodeInfo, err := simulator.BuildNodeInfoForNode(node, kubeClient)


### PR DESCRIPTION
With the previous fix #1282 a possibility for null pointer exceptions/panics was opened as GceManager started to return nills in case of nodes not belonging to an autoscaled mig. This PR fixes the NPE possibilities there and should be included in the release version ASAP.

cc: @piosz @jszczepkowski @fgrzadkowski 
