### PR TITLE
Track issues added/removed/tested

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -125,15 +125,17 @@ type healthRecord struct {
 // information about the sq itself including how fast things are merging and
 // how long since the last merge
 type submitQueueStats struct {
-	StartTime          time.Time
-	LastMergeTime      time.Time
-	MergesSinceRestart int
-	MergeRate          float64
-	RetestsAvoided     int
+	Added              int // Number of items added to the queue since restart
 	FlakesIgnored      int
-
-	// Will be true if we've made at least one complete pass.
-	Initialized bool
+	Initialized        bool // true if we've made at least one complete pass
+	InstantMerges      int  // Number of commits without retests required
+	LastMergeTime      time.Time
+	MergeRate          float64
+	MergesSinceRestart int
+	Removed            int // Number of items dequeued since restart
+	RetestsAvoided     int
+	StartTime          time.Time
+	Tested             int // Number of e2e tests completed
 }
 
 // pull-request that has been tested as successful, but interrupted because head flaked
@@ -184,8 +186,12 @@ type SubmitQueue struct {
 	e2e           e2e.E2ETester
 
 	interruptedObj *submitQueueInterruptedObject
-	retestsAvoided int32
-	flakesIgnored  int32
+	flakesIgnored  int32 // Increments for each merge while 1+ job is flaky
+	instantMerges  int32 // Increments whenever we commit without retesting
+	prsAdded       int32 // Increments whenever an items queues
+	prsRemoved     int32 // Increments whenever an item dequeues
+	prsTested      int32 // Number of prs that completed second testing
+	retestsAvoided int32 // Increments whenever we skip due to head not changing.
 
 	health        submitQueueHealth
 	healthHistory []healthRecord
@@ -900,6 +906,7 @@ func (sq *SubmitQueue) Munge(obj *github.MungeObject) {
 	added := false
 	sq.Lock()
 	if _, ok := sq.githubE2EQueue[*obj.Issue.Number]; !ok {
+		atomic.AddInt32(&sq.prsAdded, 1)
 		added = true
 	}
 	// Add this most-recent object in place of the existing object. It will
@@ -913,6 +920,13 @@ func (sq *SubmitQueue) Munge(obj *github.MungeObject) {
 	}
 
 	return
+}
+
+func (sq *SubmitQueue) deleteQueueItem(obj *github.MungeObject) {
+	if sq.onQueue(obj) {
+		atomic.AddInt32(&sq.prsRemoved, 1)
+	}
+	delete(sq.githubE2EQueue, *obj.Issue.Number)
 }
 
 // If the PR was put in the github e2e queue previously, but now we don't
@@ -938,7 +952,7 @@ func (sq *SubmitQueue) cleanupOldE2E(obj *github.MungeObject, reason string) {
 		if sq.githubE2ERunning != nil && *sq.githubE2ERunning.Issue.Number == *obj.Issue.Number {
 			sq.githubE2ERunning = nil
 		}
-		delete(sq.githubE2EQueue, *obj.Issue.Number)
+		sq.deleteQueueItem(obj)
 	}
 
 }
@@ -1038,7 +1052,7 @@ func (sq *SubmitQueue) handleGithubE2EAndMerge() {
 			// remove it from the map after we finish testing
 			sq.Lock()
 			sq.githubE2ERunning = nil
-			delete(sq.githubE2EQueue, *obj.Issue.Number)
+			sq.deleteQueueItem(obj)
 			sq.Unlock()
 		}
 	}
@@ -1108,6 +1122,7 @@ func (sq *SubmitQueue) doGithubE2EAndMerge(obj *github.MungeObject) bool {
 	}
 
 	if obj.HasLabel(retestNotRequiredLabel) {
+		atomic.AddInt32(&sq.instantMerges, 1)
 		sq.mergePullRequest(obj)
 		return true
 	}
@@ -1129,6 +1144,7 @@ func (sq *SubmitQueue) doGithubE2EAndMerge(obj *github.MungeObject) bool {
 
 		// Wait for the retest to start
 		sq.SetMergeStatus(obj, ghE2EWaitingStart)
+		atomic.AddInt32(&sq.prsTested, 1)
 		err = obj.WaitForPending(sq.RequiredRetestContexts)
 		if err != nil {
 			sq.SetMergeStatus(obj, fmt.Sprintf("Failed waiting for PR to start testing: %v", err))
@@ -1200,13 +1216,17 @@ func (sq *SubmitQueue) serveHealth(res http.ResponseWriter, req *http.Request) {
 
 func (sq *SubmitQueue) serveSQStats(res http.ResponseWriter, req *http.Request) {
 	data := submitQueueStats{
-		StartTime:          sq.startTime,
-		LastMergeTime:      sq.lastMergeTime,
-		MergesSinceRestart: int(atomic.LoadInt32(&sq.totalMerges)),
-		MergeRate:          sq.calcMergeRateWithTail(),
-		RetestsAvoided:     int(atomic.LoadInt32(&sq.retestsAvoided)),
+		Added:              int(atomic.LoadInt32(&sq.prsAdded)),
 		FlakesIgnored:      int(atomic.LoadInt32(&sq.flakesIgnored)),
 		Initialized:        atomic.LoadInt32(&sq.loopStarts) > 1,
+		InstantMerges:      int(atomic.LoadInt32(&sq.instantMerges)),
+		LastMergeTime:      sq.lastMergeTime,
+		MergeRate:          sq.calcMergeRateWithTail(),
+		MergesSinceRestart: int(atomic.LoadInt32(&sq.totalMerges)),
+		Removed:            int(atomic.LoadInt32(&sq.prsRemoved)),
+		RetestsAvoided:     int(atomic.LoadInt32(&sq.retestsAvoided)),
+		StartTime:          sq.startTime,
+		Tested:             int(atomic.LoadInt32(&sq.prsTested)),
 	}
 	sq.serve(sq.marshal(data), res, req)
 }


### PR DESCRIPTION
Added three integers, which increment in the following way:
- `issuesAdded` - whenever an item is added to the queue
- `issuesRemoved` - whenever an item is removed from the queue
- `issuesTested` -- whenever an item is tested

These values will allow us to track how rate we dequeue items. This rate usually differs from both the merge rate (we remove items without merging them) as well as the change in the size of the queue (we can add items as quickly as we remove them).

This also allows us to distinguish how quickly we tend to merge things from how quickly we test things (since we can test things but not merge them if they fail tests).

A couple additional small refactorings:
- Alphabetize `submitQueueStats`
- Encapsulate deleting issues from the queue into `deleteIssue()`

Test version visible at http://146.148.108.121/sq-stats
