### PR TITLE
Cluster-autoscaler: pod relocation hints

### DIFF
--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -109,6 +109,7 @@ func main() {
 	lastScaleUpTime := time.Now()
 	lastScaleDownFailedTrial := time.Now()
 	unneededNodes := make(map[string]time.Time)
+	podLocationHints := make(map[string]string)
 
 	eventBroadcaster := kube_record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
@@ -241,12 +242,13 @@ func main() {
 					updateLastTime("findUnneeded")
 					glog.V(4).Infof("Calculating unneded nodes")
 
-					unneededNodes = FindUnneededNodes(
+					unneededNodes, podLocationHints = FindUnneededNodes(
 						nodes,
 						unneededNodes,
 						*scaleDownUtilizationThreshold,
 						allScheduled,
-						predicateChecker)
+						predicateChecker,
+						podLocationHints)
 
 					updateDuration("findUnneeded", unneededStart)
 
@@ -267,7 +269,10 @@ func main() {
 							unneededNodes,
 							*scaleDownUnneededTime,
 							allScheduled,
-							cloudProvider, kubeClient, predicateChecker)
+							cloudProvider,
+							kubeClient,
+							predicateChecker,
+							podLocationHints)
 
 						updateDuration("scaledown", scaleDownStart)
 

--- a/cluster-autoscaler/scale_down_test.go
+++ b/cluster-autoscaler/scale_down_test.go
@@ -55,16 +55,17 @@ func TestFindUnneededNodes(t *testing.T) {
 	n3 := BuildTestNode("n3", 1000, 10)
 	n4 := BuildTestNode("n4", 10000, 10)
 
-	result := FindUnneededNodes([]*kube_api.Node{n1, n2, n3, n4}, map[string]time.Time{}, 0.35,
-		[]*kube_api.Pod{p1, p2, p3, p4}, simulator.NewTestPredicateChecker())
+	result, hints := FindUnneededNodes([]*kube_api.Node{n1, n2, n3, n4}, map[string]time.Time{}, 0.35,
+		[]*kube_api.Pod{p1, p2, p3, p4}, simulator.NewTestPredicateChecker(), make(map[string]string))
 
 	assert.Equal(t, 1, len(result))
 	addTime, found := result["n2"]
 	assert.True(t, found)
+	assert.Contains(t, hints, p2.Namespace+"/"+p2.Name)
 
 	result["n1"] = time.Now()
-	result2 := FindUnneededNodes([]*kube_api.Node{n1, n2, n3, n4}, result, 0.35,
-		[]*kube_api.Pod{p1, p2, p3, p4}, simulator.NewTestPredicateChecker())
+	result2, hints := FindUnneededNodes([]*kube_api.Node{n1, n2, n3, n4}, result, 0.35,
+		[]*kube_api.Pod{p1, p2, p3, p4}, simulator.NewTestPredicateChecker(), hints)
 
 	assert.Equal(t, 1, len(result2))
 	addTime2, found := result2["n2"]

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -58,11 +58,19 @@ func TestFindPlaceAllOk(t *testing.T) {
 	nodeInfos["n1"].SetNode(node1)
 	nodeInfos["n2"].SetNode(node2)
 
+	oldHints := make(map[string]string)
+	newHints := make(map[string]string)
+
 	err := findPlaceFor(
 		"x",
 		[]*kube_api.Pod{new1, new2},
 		[]*kube_api.Node{node1, node2},
-		nodeInfos, NewTestPredicateChecker())
+		nodeInfos, NewTestPredicateChecker(),
+		oldHints, newHints)
+
+	assert.Len(t, newHints, 2)
+	assert.Contains(t, newHints, new1.Namespace+"/"+new1.Name)
+	assert.Contains(t, newHints, new2.Namespace+"/"+new2.Name)
 	assert.NoError(t, err)
 }
 
@@ -73,20 +81,31 @@ func TestFindPlaceAllBas(t *testing.T) {
 	new3 := BuildTestPod("p4", 700, 500000)
 
 	nodeInfos := map[string]*schedulercache.NodeInfo{
-		"n1": schedulercache.NewNodeInfo(pod1),
-		"n2": schedulercache.NewNodeInfo(),
+		"n1":   schedulercache.NewNodeInfo(pod1),
+		"n2":   schedulercache.NewNodeInfo(),
+		"nbad": schedulercache.NewNodeInfo(),
 	}
+	nodebad := BuildTestNode("nbad", 1000, 2000000)
 	node1 := BuildTestNode("n1", 1000, 2000000)
 	node2 := BuildTestNode("n2", 1000, 2000000)
 	nodeInfos["n1"].SetNode(node1)
 	nodeInfos["n2"].SetNode(node2)
+	nodeInfos["nbad"].SetNode(nodebad)
+
+	oldHints := make(map[string]string)
+	newHints := make(map[string]string)
 
 	err := findPlaceFor(
-		"x",
+		"nbad",
 		[]*kube_api.Pod{new1, new2, new3},
-		[]*kube_api.Node{node1, node2},
-		nodeInfos, NewTestPredicateChecker())
+		[]*kube_api.Node{nodebad, node1, node2},
+		nodeInfos, NewTestPredicateChecker(),
+		oldHints, newHints)
+
 	assert.Error(t, err)
+	assert.True(t, len(newHints) == 2)
+	assert.Contains(t, newHints, new1.Namespace+"/"+new1.Name)
+	assert.Contains(t, newHints, new2.Namespace+"/"+new2.Name)
 }
 
 func TestFindNone(t *testing.T) {
@@ -105,6 +124,8 @@ func TestFindNone(t *testing.T) {
 		"x",
 		[]*kube_api.Pod{},
 		[]*kube_api.Node{node1, node2},
-		nodeInfos, NewTestPredicateChecker())
+		nodeInfos, NewTestPredicateChecker(),
+		make(map[string]string),
+		make(map[string]string))
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Average cluster, for most of the time, remains more or less stable. So pod rescheduling location calculated in scale down 10sec ago are most likely are still valid. This PR makes advantage of this. Benefits:
- Scale down will work MUCH faster
- Scale down will try to put pods on the same nodes which will be important once #1341 goes in. This PR, #1341 and following PRs will allow fine grain utilization/not-needed status resets.

cc: @piosz @jszczepkowski @fgrzadkowski 
