### PR TITLE
Atomic clone and updates for git-sync

### DIFF
--- a/git-sync/README.md
+++ b/git-sync/README.md
@@ -4,13 +4,17 @@ git-sync is a command that pull a git repository to a local directory.
 
 It can be used to source a container volume with the content of a git repo.
 
+In order to ensure that the git repository content is cloned and updated atomically, you cannot use a volume root directory as the directory for your local repository. 
+
+The local repository is created in a subdirectory of /git, with the subdirectory name specified by GIT_SYNC_DEST. 
+
 ## Usage
 
 ```
 # build the container
 docker build -t git-sync .
 # run the git-sync container
-docker run -d GIT_SYNC_REPO=https://github.com/GoogleCloudPlatform/kubernetes GIT_SYNC_DEST=/git -e GIT_SYNC_BRANCH=gh-pages -r HEAD GIT_SYNC_DEST=/git -v /git-data:/git git-sync
+docker run -d GIT_SYNC_REPO=https://github.com/GoogleCloudPlatform/kubernetes GIT_SYNC_DEST=/git -e GIT_SYNC_BRANCH=gh-pages -r HEAD -v /git-data:/git git-sync
 # run a nginx container to serve sync'ed content
 docker run -d -p 8080:80 -v /git-data:/usr/share/nginx/html nginx 
 ```


### PR DESCRIPTION
The git-sync sidecar container pulls Git content into a shared volume, but another container may begin accessing the incomplete repository while the initial pull is occurring. There has been some discussion of the matter here: https://github.com/kubernetes/kubernetes/issues/17676.

This change provides the option to make the initial clone/pull atomic (i.e. the target directory will not appear in the filesystem until the pull is complete). I've included atomic.md as a readme with more information about usage and implementation, but can merge that into the existing README.md instead if that is preferred. 

@thockin @huggsboson
