### PR TITLE
[ansible] Add master_cluster_hostname param

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -37,6 +37,12 @@ insecure_registrys:
 #https_proxy: "http://proxy.example.com:3128"
 #no_proxy: "127.0.0.1,localhost,docker-registry.somecorporation.com"
 
+# Internal fqdn used for the cluster (certificat only)
+# master_cluster_hostname: int-kubernetes
+
+# External fqdn used for the cluster (certificat only)
+# master_cluster_public_hostname: public-kubernetes
+
 # The port that the Kubernetes apiserver component listens on.
 kube_master_api_port: 443
 

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -39,6 +39,12 @@ kube_cert_dir: "{{ kube_config_dir }}/certs"
 # The IP(s) for which the certificate will be valid
 kube_cert_ip: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | join (',IP:') }}"
 
+# The internal name for the cluster
+kube_master_cluster_hostname: "{{ master_cluster_hostname | default('int-kubernetes') }}"
+
+# The public name for the cluster
+kube_master_cluster_public_hostname: "{{ master_cluster_public_hostname | default('public-kubernetes') }}"
+
 # This is where all of the bearer tokens will be stored
 kube_token_dir: "{{ kube_config_dir }}/tokens"
 

--- a/ansible/roles/kubernetes/files/make-ca-cert.sh
+++ b/ansible/roles/kubernetes/files/make-ca-cert.sh
@@ -34,6 +34,8 @@ set -o pipefail
 
 cert_ip="${MASTER_IP:="${1}"}"
 master_name="${MASTER_NAME:="kubernetes"}"
+master_cluster_hostname="${CLUSTER_MASTER_HOSTNAME:="public-kubernetes"}"
+master_cluster_public_hostname="${CLUSTER_MASTER_PUBLIC_HOSTNAME:="int-kubernetes"}"
 service_range="${SERVICE_CLUSTER_IP_RANGE:="10.0.0.0/16"}"
 dns_domain="${DNS_DOMAIN:="cluster.local"}"
 cert_dir="${CERT_DIR:-"/srv/kubernetes"}"
@@ -94,7 +96,7 @@ octets=($(echo "${service_range}" | sed -e 's|/.*||' -e 's/\./ /g'))
 service_ip=$(echo "${octets[*]}" | sed 's/ /./g')
 
 # Determine appropriete subject alt names
-sans="IP:${cert_ip},IP:${service_ip},DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.${dns_domain},DNS:${master_name}"
+sans="IP:${cert_ip},IP:${service_ip},DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.${dns_domain},DNS:${master_name},DNS:${master_cluster_hostname},DNS:${master_cluster_public_hostname}"
 
 curl -sSL -O https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz
 tar xzf easy-rsa.tar.gz

--- a/ansible/roles/kubernetes/tasks/gen_certs.yml
+++ b/ansible/roles/kubernetes/tasks/gen_certs.yml
@@ -31,6 +31,8 @@
   environment:
     MASTER_IP: "{{ kube_cert_ip }}"
     MASTER_NAME: "{{ inventory_hostname }}"
+    CLUSTER_MASTER_HOSTNAME: "{{ kube_master_cluster_hostname }}"
+    CLUSTER_MASTER_PUBLIC_HOSTNAME: "{{ kube_master_cluster_public_hostname }}"
     DNS_DOMAIN: "{{ dns_domain }}"
     SERVICE_CLUSTER_IP_RANGE: "{{ kube_service_addresses }}"
     CERT_DIR: "{{ kube_cert_dir }}"


### PR DESCRIPTION
- In order to add access to the api with an internal and public fqdn
  We added 2 variables in order to update the server.crt
- Add master_cluster_hostname variable
- Add kube_master_cluster_public_hostname variable
  
  TODO : we should use the internal name to configure the nodes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1361)

<!-- Reviewable:end -->
