### PR TITLE
Simplify size calculation

### DIFF
--- a/mungegithub/mungers/size.go
+++ b/mungegithub/mungers/size.go
@@ -169,25 +169,23 @@ func (s *SizeMunger) Munge(obj *github.MungeObject) {
 	}
 	dels := *pr.Deletions
 
-	commits, err := obj.GetCommits()
+	files, err := obj.ListFiles()
 	if err != nil {
 		return
 	}
 
-	for _, c := range commits {
-		for _, f := range c.Files {
-			for _, p := range genPrefixes {
-				if strings.HasPrefix(*f.Filename, p) {
-					adds = adds - *f.Additions
-					dels = dels - *f.Deletions
-					continue
-				}
-			}
-			if genFiles.Has(*f.Filename) {
+	for _, f := range files {
+		for _, p := range genPrefixes {
+			if strings.HasPrefix(*f.Filename, p) {
 				adds = adds - *f.Additions
 				dels = dels - *f.Deletions
 				continue
 			}
+		}
+		if genFiles.Has(*f.Filename) {
+			adds = adds - *f.Additions
+			dels = dels - *f.Deletions
+			continue
 		}
 	}
 


### PR DESCRIPTION
I found an optimization in the way we compute the size of a pull-request.

Please let me know if this makes sense as it's pretty much untested (sorry, not sure how to test easily).
This depends on a commit common with #1373  