### PR TITLE
Added new feature to handle test options.

### DIFF
--- a/mungegithub/features/features.go
+++ b/mungegithub/features/features.go
@@ -26,9 +26,10 @@ import (
 // Features are all features the code know about. Care should be taken
 // not to try to use a feature which isn't 'active'
 type Features struct {
-	Repos   *RepoInfo
-	GCSInfo *GCSInfo
-	active  []feature
+	Repos       *RepoInfo
+	GCSInfo     *GCSInfo
+	TestOptions *TestOptions
+	active      []feature
 }
 
 type feature interface {
@@ -62,6 +63,8 @@ func (f *Features) Initialize(requestedFeatures []string) error {
 			f.Repos = feat.(*RepoInfo)
 		case GCSFeature:
 			f.GCSInfo = feat.(*GCSInfo)
+		case TestOptionsFeature:
+			f.TestOptions = feat.(*TestOptions)
 		}
 	}
 	return nil

--- a/mungegithub/features/test-options.go
+++ b/mungegithub/features/test-options.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	// TestOptionsFeature is how mungers should indicate this is required.
+	TestOptionsFeature   = "test-options"
+	jenkinsE2EContext    = "Jenkins GCE e2e"
+	jenkinsUnitContext   = "Jenkins unit/integration"
+	jenkinsVerifyContext = "Jenkins verification"
+	jenkinsNodeContext   = "Jenkins GCE Node e2e"
+)
+
+var (
+	requiredContexts = []string{
+		jenkinsUnitContext,
+		jenkinsE2EContext,
+		jenkinsNodeContext,
+		jenkinsVerifyContext,
+	}
+)
+
+// TestOptions is a struct that handles parameters required by mungers
+// to find out about specific tests.
+type TestOptions struct {
+	RequiredRetestContexts []string
+}
+
+func init() {
+	RegisterFeature(&TestOptions{})
+}
+
+// Name is just going to return the name mungers use to request this feature
+func (t *TestOptions) Name() string {
+	return TestOptionsFeature
+}
+
+// Initialize will initialize the feature.
+func (t *TestOptions) Initialize() error {
+	return nil
+}
+
+// EachLoop is called at the start of every munge loop
+func (t *TestOptions) EachLoop() error {
+	return nil
+}
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (t *TestOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&t.RequiredRetestContexts, "required-retest-contexts", requiredContexts, "Comma separate list of statuses which will be retested and which must come back green after the `retest-body` comment is posted to a PR")
+}

--- a/mungegithub/mungers/rebuild.go
+++ b/mungegithub/mungers/rebuild.go
@@ -33,7 +33,8 @@ import (
 // RebuildMunger looks for situations where a someone has asked for an e2e rebuild, but hasn't provided
 // an issue
 type RebuildMunger struct {
-	robots sets.String
+	robots   sets.String
+	features *features.Features
 }
 
 const (
@@ -64,11 +65,12 @@ func init() {
 func (r *RebuildMunger) Name() string { return "rebuild-request" }
 
 // RequiredFeatures is a slice of 'features' that must be provided
-func (r *RebuildMunger) RequiredFeatures() []string { return []string{} }
+func (r *RebuildMunger) RequiredFeatures() []string { return []string{features.TestOptionsFeature} }
 
 // Initialize will initialize the munger
 func (r *RebuildMunger) Initialize(config *github.Config, features *features.Features) error {
 	r.robots = sets.NewString("googlebot", jenkinsBotName, botName)
+	r.features = features
 	return nil
 }
 
@@ -131,7 +133,7 @@ func (r *RebuildMunger) isStaleComment(obj *github.MungeObject, comment githubap
 	if !rebuildCommentRE.MatchString(*comment.Body) {
 		return false
 	}
-	stale := commentBeforeLastCI(obj, comment)
+	stale := commentBeforeLastCI(obj, comment, r.features.TestOptions.RequiredRetestContexts)
 	if stale {
 		glog.V(6).Infof("Found stale RebuildMunger comment")
 	}

--- a/mungegithub/mungers/stale-green-ci_test.go
+++ b/mungegithub/mungers/stale-green-ci_test.go
@@ -32,9 +32,23 @@ import (
 	"github.com/google/go-github/github"
 )
 
+const (
+	jenkinsE2EContext    = "Jenkins GCE e2e"
+	jenkinsUnitContext   = "Jenkins unit/integration"
+	jenkinsVerifyContext = "Jenkins verification"
+	jenkinsNodeContext   = "Jenkins GCE Node e2e"
+)
+
 var (
 	_ = fmt.Printf
 	_ = glog.Errorf
+
+	requiredContexts = []string{
+		jenkinsUnitContext,
+		jenkinsE2EContext,
+		jenkinsNodeContext,
+		jenkinsVerifyContext,
+	}
 )
 
 func timePtr(t time.Time) *time.Time { return &t }
@@ -130,6 +144,9 @@ func TestOldUnitTestMunge(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 
+		s.getRetestContexts = func() []string {
+			return requiredContexts
+		}
 		s.Munge(obj)
 
 		if tested != test.tested {


### PR DESCRIPTION
- The required-retest-contexts are used by several mungers. Previously, it was [a global variable](https://github.com/kubernetes/contrib/issues/1304#issuecomment-231817807) which would get referenced irrespective of the parameters supplied via the command-line.
- We abstract the retest-context flag out as a feature that the mungers that want to can access them.
- In future, if multiple mungers start to use any other test related parameters, they could be added into the test-options feature. 
