### PR TITLE
[nginx-ingress-controller] improve nginx performance

### DIFF
--- a/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
+++ b/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
@@ -1,0 +1,123 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  labels:
+    k8s-app: default-http-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    k8s-app: default-http-backend
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: default-http-backend
+spec:
+  replicas: 1
+  selector:
+    k8s-app: default-http-backend
+  template:
+    metadata:
+      labels:
+        k8s-app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx-ingress-controller
+  labels:
+    k8s-app: nginx-ingress-lb
+spec:
+  replicas: 1
+  selector:
+    k8s-app: nginx-ingress-lb
+  template:
+    metadata:
+      labels:
+        k8s-app: nginx-ingress-lb
+        name: nginx-ingress-lb
+    spec:     
+      terminationGracePeriodSeconds: 60
+      containers:
+      - image: alpine:3.4
+        name: sysctl-buddy
+        # using kubectl exec you can check which other parameters is possible to change
+        # IPC Namespace:     kernel.msgmax, kernel.msgmnb, kernel.msgmni, kernel.sem, kernel.shmall, 
+        #                    kernel.shmmax, kernel.shmmni, kernel.shm_rmid_forced and Sysctls 
+        #                    beginning with fs.mqueue.*
+        # Network Namespace: Sysctls beginning with net.*
+        # 
+        # kubectl <podname> -c sysctl-buddy -- sysctl -A | grep net
+        command:
+        - /bin/sh
+        - -c
+        - |
+          while true; do 
+            sysctl -w net.core.somaxconn=32768
+            sysctl -w net.ipv4.ip_local_port_range='1024 65535'
+            sleep 10
+          done
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.1
+        name: nginx-ingress-lb
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10249
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        # use downward API
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 443
+        # we expose 8080 to access nginx stats in url /nginx-status
+        # this is optional
+        - containerPort: 8080
+          hostPort: 8080
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=default/default-http-backend

--- a/ingress/controllers/nginx/nginx/utils.go
+++ b/ingress/controllers/nginx/nginx/utils.go
@@ -226,7 +226,7 @@ func diff(b1, b2 []byte) (data []byte, err error) {
 // maximum number of connections that can be queued for acceptance
 // http://nginx.org/en/docs/http/ngx_http_core_module.html#listen
 func sysctlSomaxconn() int {
-	maxConns, err := sysctl.GetSysctl("net.core.somaxconn")
+	maxConns, err := sysctl.GetSysctl("net/core/somaxconn")
 	if err != nil || maxConns < 512 {
 		glog.Warningf("system net.core.somaxconn=%v. Using NGINX default (511)", maxConns)
 		return 511


### PR DESCRIPTION
Changing container `/proc` values with a privileged sidecar.
NGINX reads `net.core.somaxconn` to increase the size of backlog queue of pending connections