### PR TITLE
Removing defaults from code and making command-line options explicit in deployment.yaml.

### DIFF
--- a/mungegithub/cherrypick/deployment.yaml
+++ b/mungegithub/cherrypick/deployment.yaml
@@ -14,10 +14,14 @@ spec:
         command:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
+        - --organization=kubernetes
+        - --project=kubernetes
         - --pr-mungers=cherrypick-must-have-milestone,cherrypick-clear-after-merge,cherrypick-queue
         - --state=all
         - --labels=cherrypick-candidate
+        - --http-cache-dir=/cache/httpcache
         - --dry-run=true
+        - --admin-port=9999
         - --kubernetes-dir=/gitrepo/kubernetes
         - --period=3m
         image: docker.io/eparis/cherrypick:2016-03-14-7fb1dae

--- a/mungegithub/features/google-cloud-storage.go
+++ b/mungegithub/features/google-cloud-storage.go
@@ -17,8 +17,8 @@ limitations under the License.
 package features
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/golang/glog"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -65,8 +65,8 @@ func (g *GCSInfo) EachLoop() error {
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (g *GCSInfo) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&g.BucketName, "gcs-bucket", "kubernetes-jenkins", "Name of GCS bucket.")
-	cmd.Flags().StringVar(&g.LogDir, "gcs-logs-dir", "logs", "Directory containing test logs.")
-	cmd.Flags().StringVar(&g.PullLogDir, "pull-logs-dir", "pr-logs", "Directory of the PR builder.")
-	cmd.Flags().StringVar(&g.PullKey, "pull-key", "pull", "String to look for in job name for it to be a pull (presubmit) job.")
+	cmd.Flags().StringVar(&g.BucketName, "gcs-bucket", "", "Name of GCS bucket.")
+	cmd.Flags().StringVar(&g.LogDir, "gcs-logs-dir", "", "Directory containing test logs.")
+	cmd.Flags().StringVar(&g.PullLogDir, "pull-logs-dir", "", "Directory of the PR builder.")
+	cmd.Flags().StringVar(&g.PullKey, "pull-key", "", "String to look for in job name for it to be a pull (presubmit) job.")
 }

--- a/mungegithub/features/google-cloud-storage.go
+++ b/mungegithub/features/google-cloud-storage.go
@@ -18,6 +18,7 @@ package features
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/golang/glog"
 )
 
 const (
@@ -50,6 +51,10 @@ func (g *GCSInfo) Name() string {
 
 // Initialize will initialize the feature.
 func (g *GCSInfo) Initialize() error {
+	glog.Infof("gcs-bucket: %#v\n", g.BucketName)
+	glog.Infof("gcs-logs-dir: %#v\n", g.LogDir)
+	glog.Infof("pull-logs-dir: %#v\n", g.PullLogDir)
+	glog.Infof("pull-key: %#v\n", g.PullKey)
 	return nil
 }
 

--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -135,8 +135,9 @@ func (o *RepoInfo) updateRepoUsers() error {
 
 // Initialize will initialize the munger
 func (o *RepoInfo) Initialize() error {
-	o.enabled = true
+	glog.Infof("kubernetes-dir: %#v\n", o.kubernetesDir)
 
+	o.enabled = true
 	if len(o.kubernetesDir) == 0 {
 		glog.Fatalf("--kubernetes-dir is required with selected munger(s)")
 	}

--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -168,7 +168,7 @@ func (o *RepoInfo) EachLoop() error {
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (o *RepoInfo) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.kubernetesDir, "kubernetes-dir", "./gitrepos/kubernetes", "Path to git checkout of kubernetes tree")
+	cmd.Flags().StringVar(&o.kubernetesDir, "kubernetes-dir", "", "Path to git checkout of kubernetes tree")
 }
 
 // GitCommand will execute the git command with the `args`

--- a/mungegithub/features/test-options.go
+++ b/mungegithub/features/test-options.go
@@ -17,25 +17,13 @@ limitations under the License.
 package features
 
 import (
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
 const (
 	// TestOptionsFeature is how mungers should indicate this is required.
-	TestOptionsFeature   = "test-options"
-	jenkinsE2EContext    = "Jenkins GCE e2e"
-	jenkinsUnitContext   = "Jenkins unit/integration"
-	jenkinsVerifyContext = "Jenkins verification"
-	jenkinsNodeContext   = "Jenkins GCE Node e2e"
-)
-
-var (
-	requiredContexts = []string{
-		jenkinsUnitContext,
-		jenkinsE2EContext,
-		jenkinsNodeContext,
-		jenkinsVerifyContext,
-	}
+	TestOptionsFeature = "test-options"
 )
 
 // TestOptions is a struct that handles parameters required by mungers
@@ -55,6 +43,7 @@ func (t *TestOptions) Name() string {
 
 // Initialize will initialize the feature.
 func (t *TestOptions) Initialize() error {
+	glog.Infof("required-retest-contexts: %#v\n", t.RequiredRetestContexts)
 	return nil
 }
 
@@ -65,5 +54,5 @@ func (t *TestOptions) EachLoop() error {
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (t *TestOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVar(&t.RequiredRetestContexts, "required-retest-contexts", requiredContexts, "Comma separate list of statuses which will be retested and which must come back green after the `retest-body` comment is posted to a PR")
+	cmd.Flags().StringSliceVar(&t.RequiredRetestContexts, "required-retest-contexts", []string{}, "Comma separate list of statuses which will be retested and which must come back green after the `retest-body` comment is posted to a PR")
 }

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -301,9 +301,9 @@ func (config *Config) AddRootFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&config.MinPRNumber, "min-pr-number", 0, "The minimum PR to start with")
 	cmd.PersistentFlags().IntVar(&config.MaxPRNumber, "max-pr-number", maxInt, "The maximum PR to start with")
 	cmd.PersistentFlags().BoolVar(&config.DryRun, "dry-run", true, "If true, don't actually merge anything")
-	cmd.PersistentFlags().StringVar(&config.Org, "organization", "kubernetes", "The github organization to scan")
-	cmd.PersistentFlags().StringVar(&config.Project, "project", "kubernetes", "The github project to scan")
-	cmd.PersistentFlags().StringVar(&config.state, "state", "open", "State of PRs to process: 'open', 'all', etc")
+	cmd.PersistentFlags().StringVar(&config.Org, "organization", "", "The github organization to scan")
+	cmd.PersistentFlags().StringVar(&config.Project, "project", "", "The github project to scan")
+	cmd.PersistentFlags().StringVar(&config.state, "state", "", "State of PRs to process: 'open', 'all', etc")
 	cmd.PersistentFlags().StringSliceVar(&config.labels, "labels", []string{}, "CSV list of label which should be set on processed PRs. Unset is all labels.")
 	cmd.PersistentFlags().StringVar(&config.Address, "address", ":8080", "The address to listen on for HTTP Status")
 	cmd.PersistentFlags().StringVar(&config.WWWRoot, "www", "www", "Path to static web files to serve from the webserver")
@@ -329,7 +329,6 @@ func (config *Config) PreExecute() error {
 	glog.Infof("http-cache-dir: %#v\n", config.HTTPCacheDir)
 	glog.Infof("http-cache-size: %#v\n", config.HTTPCacheSize)
 
-	
 	if len(config.Org) == 0 {
 		glog.Fatalf("--organization is required.")
 	}

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -315,6 +315,21 @@ func (config *Config) AddRootFlags(cmd *cobra.Command) {
 // PreExecute will initialize the Config. It MUST be run before the config
 // may be used to get information from Github
 func (config *Config) PreExecute() error {
+	glog.Infof("token: %#v\n", config.Token)
+	glog.Infof("token-file: %#v\n", config.TokenFile)
+	glog.Infof("min-pr-number: %#v\n", config.MinPRNumber)
+	glog.Infof("max-pr-number: %#v\n", config.MaxPRNumber)
+	glog.Infof("dry-run: %#v\n", config.DryRun)
+	glog.Infof("organization: %#v\n", config.Org)
+	glog.Infof("project: %#v\n", config.Project)
+	glog.Infof("state: %#v\n", config.state)
+	glog.Infof("labels: %#v\n", config.labels)
+	glog.Infof("address: %#v\n", config.Address)
+	glog.Infof("www: %#v\n", config.WWWRoot)
+	glog.Infof("http-cache-dir: %#v\n", config.HTTPCacheDir)
+	glog.Infof("http-cache-size: %#v\n", config.HTTPCacheSize)
+
+	
 	if len(config.Org) == 0 {
 		glog.Fatalf("--organization is required.")
 	}

--- a/mungegithub/mungegithub.go
+++ b/mungegithub/mungegithub.go
@@ -86,6 +86,11 @@ func main() {
 		Use:   filepath.Base(os.Args[0]),
 		Short: "A program to add labels, check tests, and generally mess with outstanding PRs",
 		RunE: func(_ *cobra.Command, _ []string) error {
+			glog.Infof("once: %#v\n", config.Once)
+			glog.Infof("pr-mungers: %#v\n", config.PRMungersList)
+			glog.Infof("issue-reports: %#v\n", config.IssueReportsList)
+			glog.Infof("period: %#v\n", config.Period)
+
 			if err := config.PreExecute(); err != nil {
 				return err
 			}

--- a/mungegithub/mungers/assign-fixes.go
+++ b/mungegithub/mungers/assign-fixes.go
@@ -45,6 +45,8 @@ func (a *AssignFixesMunger) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (a *AssignFixesMunger) Initialize(config *github.Config, features *features.Features) error {
+	glog.Infof("fixes-issue-reassign: %#v\n", a.assignfixesReassign)
+
 	a.features = features
 	a.config = config
 	return nil

--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -107,7 +107,7 @@ func (b *BlockPath) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (b *BlockPath) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().StringVar(&b.path, "block-path-config", "block-path.yaml", "file containing the pathnames to block or not block")
+	cmd.Flags().StringVar(&b.path, "block-path-config", "", "file containing the pathnames to block or not block")
 }
 
 func matchesAny(path string, regs []regexp.Regexp) bool {

--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -66,6 +66,8 @@ func (b *BlockPath) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (b *BlockPath) Initialize(config *github.Config, features *features.Features) error {
+	glog.Infof("block-path-config: %#v\n", b.path)
+
 	if len(b.path) == 0 {
 		glog.Fatalf("--block-path-config is required with the block-path munger")
 	}

--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -56,6 +56,8 @@ func (b *BlunderbussMunger) RequiredFeatures() []string { return []string{featur
 
 // Initialize will initialize the munger
 func (b *BlunderbussMunger) Initialize(config *github.Config, features *features.Features) error {
+	glog.Infof("blunderbuss-reassign: %#v\n", b.blunderbussReassign)
+
 	b.features = features
 	return nil
 }

--- a/mungegithub/mungers/flake-manager.go
+++ b/mungegithub/mungers/flake-manager.go
@@ -74,6 +74,8 @@ func (p *FlakeManager) RequiredFeatures() []string { return []string{features.GC
 
 // Initialize will initialize the munger
 func (p *FlakeManager) Initialize(config *github.Config, features *features.Features) error {
+	glog.Infof("test-owners-csv: %#v\n", p.ownerPath)
+
 	// TODO: don't get the mungers from the global list, they should be passed in...
 	for _, m := range GetAllMungers() {
 		if m.Name() == "issue-cacher" {

--- a/mungegithub/mungers/old-test-getter.go
+++ b/mungegithub/mungers/old-test-getter.go
@@ -49,6 +49,8 @@ func (p *OldTestGetter) RequiredFeatures() []string { return nil }
 
 // Initialize will initialize the munger
 func (p *OldTestGetter) Initialize(config *github.Config, features *features.Features) error {
+	glog.Infof("number-of-old-test-results: %#v\n", p.numberOfOldTestsToGet)
+
 	// TODO: don't get the mungers from the global list, they should be passed in...
 	for _, m := range GetAllMungers() {
 		if m.Name() == "submit-queue" {

--- a/mungegithub/mungers/old-test-getter.go
+++ b/mungegithub/mungers/old-test-getter.go
@@ -127,7 +127,7 @@ func (p *OldTestGetter) getPresubmitTests(jobs []string, e2eTester *e2e.RealE2ET
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (p *OldTestGetter) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().IntVar(&p.numberOfOldTestsToGet, "number-of-old-test-results", 5, "The number of old test results to get (and therefore file issues for). In case submit queue has some downtime, set this to a higher number and it will file issues for older test runs.")
+	cmd.Flags().IntVar(&p.numberOfOldTestsToGet, "number-of-old-test-results", 0, "The number of old test results to get (and therefore file issues for). In case submit queue has some downtime, set this to a higher number and it will file issues for older test runs.")
 }
 
 // Munge is unused by this munger.

--- a/mungegithub/mungers/path_label.go
+++ b/mungegithub/mungers/path_label.go
@@ -117,7 +117,7 @@ func (p *PathLabelMunger) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (p *PathLabelMunger) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().StringVar(&p.pathLabelFile, "path-label-config", "path-label.txt", "file containing the pathname to label mappings")
+	cmd.Flags().StringVar(&p.pathLabelFile, "path-label-config", "", "file containing the pathname to label mappings")
 }
 
 // Munge is the workhorse the will actually make updates to the PR

--- a/mungegithub/mungers/path_label.go
+++ b/mungegithub/mungers/path_label.go
@@ -65,6 +65,8 @@ func (p *PathLabelMunger) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (p *PathLabelMunger) Initialize(config *github.Config, features *features.Features) error {
+	glog.Infof("path-label-config: %#v\n", p.pathLabelFile)
+
 	allLabels := sets.NewString()
 	out := []labelMap{}
 	file := p.pathLabelFile

--- a/mungegithub/mungers/size.go
+++ b/mungegithub/mungers/size.go
@@ -73,7 +73,7 @@ func (SizeMunger) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (s *SizeMunger) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().StringVar(&s.generatedFilesFile, "generated-files-config", "generated-files.txt", "file containing the pathname to label mappings")
+	cmd.Flags().StringVar(&s.generatedFilesFile, "generated-files-config", "", "file containing the pathname to label mappings")
 }
 
 // getGeneratedFiles returns a list of all automatically generated files in the repo. These include

--- a/mungegithub/mungers/size.go
+++ b/mungegithub/mungers/size.go
@@ -63,6 +63,8 @@ func (SizeMunger) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (s *SizeMunger) Initialize(config *github.Config, features *features.Features) error {
+	glog.Infof("generated-files-config: %#v\n", s.generatedFilesFile)
+
 	return nil
 }
 

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -467,32 +467,9 @@ func (sq *SubmitQueue) EachLoop() error {
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (sq *SubmitQueue) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().StringSliceVar(&sq.NonBlockingJobNames, "nonblocking-jenkins-jobs", []string{
-		"kubernetes-e2e-gke-staging",
-		"kubernetes-e2e-gke-staging-parallel",
-		"kubernetes-e2e-gce-serial",
-		"kubernetes-e2e-gke-serial",
-		"kubernetes-e2e-gke-test",
-		"kubernetes-e2e-gce-examples",
-		"kubernetes-e2e-gce-federation",
-		"kubernetes-e2e-gce-scalability",
-		"kubernetes-soak-continuous-e2e-gce",
-		"kubernetes-soak-continuous-e2e-gke",
-	}, "Comma separated list of jobs that don't block merges, but will have status reported and issues filed.")
-	cmd.Flags().StringSliceVar(&sq.BlockingJobNames, "jenkins-jobs", []string{
-		"kubelet-gce-e2e-ci",
-		"kubernetes-build",
-		"kubernetes-test-go",
-		"kubernetes-verify-master",
-		"kubernetes-e2e-gce",
-		"kubernetes-e2e-gce-slow",
-		"kubernetes-e2e-gke",
-		"kubernetes-e2e-gke-slow",
-		"kubernetes-kubemark-5-gce",
-	}, "Comma separated list of jobs in Jenkins that should block merges if failing.")
-	cmd.Flags().StringSliceVar(&sq.PresubmitJobNames, "presubmit-jobs", []string{
-		"kubernetes-pull-build-test-e2e-gce",
-	}, "Comma separated list of jobs in Jenkins that run presubmit and should have issues filed for flakes.")
+	cmd.Flags().StringSliceVar(&sq.NonBlockingJobNames, "nonblocking-jenkins-jobs", []string{}, "Comma separated list of jobs that don't block merges, but will have status reported and issues filed.")
+	cmd.Flags().StringSliceVar(&sq.BlockingJobNames, "jenkins-jobs", []string{}, "Comma separated list of jobs in Jenkins that should block merges if failing.")
+	cmd.Flags().StringSliceVar(&sq.PresubmitJobNames, "presubmit-jobs", []string{""}, "Comma separated list of jobs in Jenkins that run presubmit and should have issues filed for flakes.")
 	cmd.Flags().StringSliceVar(&sq.WeakStableJobNames, "weak-stable-jobs",
 		[]string{},
 		"Comma separated list of jobs in Jenkins to use for stability testing that needs only weak success")

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -367,6 +367,17 @@ func (sq *SubmitQueue) internalInitialize(config *github.Config, features *featu
 	sq.RequiredRetestContexts = cleanStringSlice(sq.RequiredRetestContexts)
 	sq.doNotMergeMilestones = cleanStringSlice(sq.doNotMergeMilestones)
 
+	glog.Infof("jenkins-jobs: %#v\n", sq.BlockingJobNames)
+	glog.Infof("nonblocking-jenkins-jobs: %#v\n", sq.NonBlockingJobNames)
+	glog.Infof("presubmit-jobs: %#v\n", sq.PresubmitJobNames)
+	glog.Infof("weak-stable-jobs: %#v\n", sq.WeakStableJobNames)
+	glog.Infof("required-contexts: %#v\n", sq.RequiredStatusContexts)
+	glog.Infof("required-retest-contexts: %#v\n", sq.RequiredRetestContexts)
+	glog.Infof("do-not-merge-milestones: %#v\n", sq.doNotMergeMilestones)
+	glog.Infof("admin-port: %#v\n", sq.adminPort)
+	glog.Infof("retest-body: %#v\n", sq.retestBody)
+	glog.Infof("fake-e2e: %#v\n", sq.FakeE2E)
+
 	sq.githubConfig = config
 
 	// TODO: This is not how injection for tests should work.

--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -14,13 +14,33 @@ spec:
         command:
         - /mungegithub
         - --token-file=/etc/secret-volume/token
+        - --organization=kubernetes
+        - --project=kubernetes
+        - --state=open
         - --pr-mungers=blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,ok-to-test,rebuild-request,path-label,size,stale-pending-ci,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue,issue-cacher,flake-manager,old-test-getter,close-stale-pr
         - --dry-run=true
-        - --weak-stable-jobs=kubernetes-kubemark-500-gce
         - --required-contexts="Jenkins GCE Node e2e"
-        - --number-of-old-test-results=5
         - --http-cache-dir=/cache/httpcache
+        - --path-label-config=path-label.txt
+        - --block-path-config=block-path.yaml
+        - --path-label-config=path-label.txt
+        - --kubernetes-dir=/gitrepos/kubernetes
         - --test-owners-csv=/gitrepos/kubernetes/test/test_owners.csv
+        - --number-of-old-test-results=5
+        - --fixes-issue-reassign=false
+        - --blunderbuss-reassign=false
+        - --generated-files-config=generated-files.txt
+        - --nonblocking-jenkins-jobs=kubernetes-e2e-gke-staging,kubernetes-e2e-gke-staging-parallel,kubernetes-e2e-gce-serial,kubernetes-e2e-gke-serial,kubernetes-e2e-gke-test,kubernetes-e2e-gce-examples,kubernetes-e2e-gce-federation,kubernetes-e2e-gce-scalability,kubernetes-soak-continuous-e2e-gce,kubernetes-soak-continuous-e2e-gke
+        - --jenkins-jobs=kubelet-gce-e2e-ci,kubernetes-build,kubernetes-test-go,kubernetes-verify-master,kubernetes-e2e-gce,kubernetes-e2e-gce-slow,kubernetes-e2e-gke,kubernetes-e2e-gke-slow,kubernetes-kubemark-5-gce
+        - --presubmit-jobs=kubernetes-pull-build-test-e2e-gce
+        - --weak-stable-jobs=kubernetes-kubemark-500-gce
+        - --required-retest-contexts="Jenkins GCE e2e","Jenkins unit/integration","Jenkins verification","Jenkins GCE Node e2e"
+        - --do-not-merge-milestones=""
+        - --admin-port=9999
+        - --gcs-bucket=kubernetes-jenkins
+        - --gcs-logs-dir=logs
+        - --pull-logs-dir=pr-logs
+        - --pull-key=pull
         image: gcr.io/google_containers/submit-queue:2016-05-24-86f86cd
         ports:
         - name: status


### PR DESCRIPTION
Continuing work on #1304. 

We have a large number of defaults specified for various flags according to the main kubernetes repository. 
The defaults don't make sense as we make mungegithub work with other repositories.

- The first commit adds logging to print the values of various command-line parameters.
- The second removes defaults and includes them in the deployment.yaml file. 