### PR TITLE
Remove non-blocking builds stability % from SQ

### DIFF
--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -162,7 +162,7 @@
               <md-chips ng-model="cntl.testResults.nonBlockingBuilds" readonly="true">
                 <md-chip-template title="{{$chip.msg}}">
                   <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="http://ci-test.k8s.io/{{$chip.name}}/{{$chip.id}}/">{{$chip.name}}</a>
-                  <span style="color: {{$chip.color}}">{{$chip.msg}}</span> <span title="Job stability">{{$chip.stability}}</span>
+                  <span style="color: {{$chip.color}}">{{$chip.msg}}</span>
                 </md-chip-template>
               </md-chips>
               <br>


### PR DESCRIPTION
The stability of non-blocking builds is always 100% because they are
never blocking the submit-queue. As this is useless, let's just not
display it.
