### PR TITLE
Removing the use of gitrepo volume.

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -48,7 +48,6 @@ issue-mungers
 issue-reports
 jenkins-host
 jenkins-jobs
-kubernetes-dir
 last-release-pr
 left-build-number
 max-pr-number
@@ -70,6 +69,7 @@ pull-logs-dir
 rate-limit
 rate-limit-burst
 relnote-filter
+repo-dir
 required-contexts
 right-build-number
 running-in-cluster

--- a/mungegithub/cherrypick/deployment.yaml
+++ b/mungegithub/cherrypick/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --http-cache-dir=/cache/httpcache
         - --dry-run=true
         - --admin-port=9999
-        - --kubernetes-dir=/gitrepo/kubernetes
+        - --repo-dir=/gitrepo
         - --period=3m
         image: docker.io/eparis/cherrypick:2016-03-14-7fb1dae
         ports:
@@ -37,12 +37,10 @@ spec:
         - mountPath: /etc/secret-volume
           name: cherrypick-secret-volume
         - mountPath: /gitrepo
-          name: kubernetes-repo
+          name: repo
       volumes:
       - name: cherrypick-secret-volume
         secret:
           secretName: cherrypick-secret-volume
-      - name: kubernetes-repo
-        gitRepo:
-          repository: "https://github.com/kubernetes/kubernetes.git"
-          revision: "master"
+      - name: repo
+        emptyDir: {}

--- a/mungegithub/features/features.go
+++ b/mungegithub/features/features.go
@@ -19,6 +19,8 @@ package features
 import (
 	"fmt"
 
+	"k8s.io/contrib/mungegithub/github"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
@@ -35,7 +37,7 @@ type Features struct {
 type feature interface {
 	Name() string
 	AddFlags(cmd *cobra.Command)
-	Initialize() error
+	Initialize(config *github.Config) error
 	EachLoop() error
 }
 
@@ -47,7 +49,7 @@ func (f *Features) GetActive() []feature {
 }
 
 // Initialize should be called with the set of all features needed by all (active) mungers
-func (f *Features) Initialize(requestedFeatures []string) error {
+func (f *Features) Initialize(config *github.Config, requestedFeatures []string) error {
 	for _, name := range requestedFeatures {
 		glog.Infof("Initializing feature: %v", name)
 		feat, found := featureMap[name]
@@ -55,7 +57,7 @@ func (f *Features) Initialize(requestedFeatures []string) error {
 			return fmt.Errorf("Could not find a feature named: %s", name)
 		}
 		f.active = append(f.active, featureMap[name])
-		if err := feat.Initialize(); err != nil {
+		if err := feat.Initialize(config); err != nil {
 			return err
 		}
 		switch name {

--- a/mungegithub/features/google-cloud-storage.go
+++ b/mungegithub/features/google-cloud-storage.go
@@ -17,6 +17,8 @@ limitations under the License.
 package features
 
 import (
+	"k8s.io/contrib/mungegithub/github"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
@@ -50,11 +52,12 @@ func (g *GCSInfo) Name() string {
 }
 
 // Initialize will initialize the feature.
-func (g *GCSInfo) Initialize() error {
+func (g *GCSInfo) Initialize(config *github.Config) error {
 	glog.Infof("gcs-bucket: %#v\n", g.BucketName)
 	glog.Infof("gcs-logs-dir: %#v\n", g.LogDir)
 	glog.Infof("pull-logs-dir: %#v\n", g.PullLogDir)
 	glog.Infof("pull-key: %#v\n", g.PullKey)
+
 	return nil
 }
 

--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
+	"k8s.io/contrib/mungegithub/github"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/yaml"
 
@@ -43,10 +45,12 @@ type assignmentConfig struct {
 
 // RepoInfo provides information about users in OWNERS files in a git repo
 type RepoInfo struct {
-	enabled       bool
-	kubernetesDir string
-	assignees     map[string]sets.String
-	//owners     map[string]sets.String
+	enabled    bool
+	projectDir string
+	baseDir    string
+	assignees  map[string]sets.String
+	config     *github.Config
+	//owners   map[string]sets.String
 }
 
 func init() {
@@ -92,9 +96,9 @@ func (o *RepoInfo) walkFunc(path string, info os.FileInfo, err error) error {
 		return nil
 	}
 
-	path, err = filepath.Rel(o.kubernetesDir, path)
+	path, err = filepath.Rel(o.projectDir, path)
 	if err != nil {
-		glog.Errorf("Unable to find relative path between %q and %q: %v", o.kubernetesDir, path, err)
+		glog.Errorf("Unable to find relative path between %q and %q: %v", o.projectDir, path, err)
 		return err
 	}
 	path = filepath.Dir(path)
@@ -123,33 +127,44 @@ func (o *RepoInfo) updateRepoUsers() error {
 
 	o.assignees = map[string]sets.String{}
 	//o.owners = map[string]sets.String{}
-	err = filepath.Walk(o.kubernetesDir, o.walkFunc)
+	err = filepath.Walk(o.projectDir, o.walkFunc)
 	if err != nil {
 		glog.Errorf("Got error %v", err)
 	}
-	glog.Infof("Loaded config from %s:%s", o.kubernetesDir, sha)
+	glog.Infof("Loaded config from %s:%s", o.projectDir, sha)
 	glog.V(5).Infof("assignees: %v", o.assignees)
 	//glog.V(5).Infof("owners: %v", o.owners)
 	return nil
 }
 
 // Initialize will initialize the munger
-func (o *RepoInfo) Initialize() error {
-	glog.Infof("kubernetes-dir: %#v\n", o.kubernetesDir)
+func (o *RepoInfo) Initialize(config *github.Config) error {
+	glog.Infof("kubernetes-dir: %#v\n", o.baseDir)
 
 	o.enabled = true
-	if len(o.kubernetesDir) == 0 {
-		glog.Fatalf("--kubernetes-dir is required with selected munger(s)")
-	}
+	o.config = config
+	o.projectDir = path.Join(o.baseDir, o.config.Project)
 
-	finfo, err := os.Stat(o.kubernetesDir)
+	if len(o.baseDir) == 0 {
+		glog.Fatalf("--repo-dir is required with selected munger(s)")
+	}
+	finfo, err := os.Stat(o.baseDir)
 	if err != nil {
-		return fmt.Errorf("Unable to stat --kubernetes-dir: %v", err)
+		return fmt.Errorf("Unable to stat --repo-dir: %v", err)
 	}
 	if !finfo.IsDir() {
-		return fmt.Errorf("--kubernetes-dir is not a git directory")
+		return fmt.Errorf("--repo-dir is not a directory")
+	}
+	if cloneUrl, err := o.cloneRepo(); err != nil {
+		return fmt.Errorf("Unable to clone %v: %v", cloneUrl, err)
 	}
 	return o.updateRepoUsers()
+}
+
+func (o *RepoInfo) cloneRepo() (string, error) {
+	cloneUrl := fmt.Sprintf("https://github.com/%s/%s.git", o.config.Org, o.config.Project)
+	_, err := o.gitCommandDir([]string{"clone", cloneUrl}, o.baseDir)
+	return cloneUrl, err
 }
 
 // EachLoop is called at the start of every munge loop
@@ -157,24 +172,27 @@ func (o *RepoInfo) EachLoop() error {
 	if !o.enabled {
 		return nil
 	}
-
 	_, err := o.GitCommand([]string{"remote", "update"})
 	if err != nil {
 		glog.Errorf("Unable to git remote update: %v", err)
 	}
-
 	return o.updateRepoUsers()
 }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (o *RepoInfo) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.kubernetesDir, "kubernetes-dir", "", "Path to git checkout of kubernetes tree")
+	cmd.Flags().StringVar(&o.baseDir, "repo-dir", "", "Path to perform checkout of repository")
 }
 
-// GitCommand will execute the git command with the `args`
+// GitCommand will execute the git command with the `args` within the project directory.
 func (o *RepoInfo) GitCommand(args []string) ([]byte, error) {
+	return o.gitCommandDir(args, o.projectDir)
+}
+
+// GitCommandDir will execute the git command with the `args` within the 'dir' directory.
+func (o *RepoInfo) gitCommandDir(args []string, cmdDir string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
-	cmd.Dir = o.kubernetesDir
+	cmd.Dir = cmdDir
 	return cmd.CombinedOutput()
 }
 

--- a/mungegithub/features/test-options.go
+++ b/mungegithub/features/test-options.go
@@ -17,6 +17,8 @@ limitations under the License.
 package features
 
 import (
+	"k8s.io/contrib/mungegithub/github"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
@@ -42,7 +44,7 @@ func (t *TestOptions) Name() string {
 }
 
 // Initialize will initialize the feature.
-func (t *TestOptions) Initialize() error {
+func (t *TestOptions) Initialize(config *github.Config) error {
 	glog.Infof("required-retest-contexts: %#v\n", t.RequiredRetestContexts)
 	return nil
 }

--- a/mungegithub/mungegithub.go
+++ b/mungegithub/mungegithub.go
@@ -104,7 +104,7 @@ func main() {
 				glog.Fatalf("unable to find requested mungers: %v", err)
 			}
 			requestedFeatures := mungers.RequestedFeatures()
-			if err := config.Features.Initialize(requestedFeatures); err != nil {
+			if err := config.Features.Initialize(&config.Config, requestedFeatures); err != nil {
 				return err
 			}
 			if err := mungers.InitializeMungers(&config.Config, &config.Features); err != nil {

--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - --path-label-config=path-label.txt
         - --block-path-config=block-path.yaml
         - --path-label-config=path-label.txt
-        - --kubernetes-dir=/gitrepos/kubernetes
+        - --repo-dir=/gitrepos
         - --test-owners-csv=/gitrepos/kubernetes/test/test_owners.csv
         - --number-of-old-test-results=5
         - --fixes-issue-reassign=false
@@ -54,17 +54,15 @@ spec:
         - mountPath: /etc/secret-volume
           name: secret-volume
         - mountPath: /gitrepos
-          name: kubernetes-repo
+          name: repo
         - mountPath: /cache
           name: cache-volume
       volumes:
       - name: secret-volume
         secret:
           secretName: github-token
-      - name: kubernetes-repo
-        gitRepo:
-          repository: "https://github.com/kubernetes/kubernetes.git"
-          revision: "master"
+      - name: repo
+        emptyDir: {}
       - name: cache-volume
         persistentVolumeClaim:
           claimName: submit-queue-cache


### PR DESCRIPTION
Issue #1304 

The gitrepo volume is difficult to parameterize as we move towards configmaps to deploy mungegithub to different repositories. This change uses an emptyDir instead for the /gitrepos mount, and moves the repository cloning logic to within mungegithub.
