### PR TITLE
default tls option 

### DIFF
--- a/ingress/controllers/nginx/Makefile
+++ b/ingress/controllers/nginx/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any release builds
-TAG = 0.8.1
+TAG = 0.8.2
 PREFIX = gcr.io/google_containers/nginx-ingress-controller
 
 REPO_INFO=$(shell git config --get remote.origin.url)

--- a/ingress/controllers/nginx/nginx/ssl.go
+++ b/ingress/controllers/nginx/nginx/ssl.go
@@ -50,7 +50,7 @@ func (nginx *Manager) AddOrUpdateCertAndKey(name string, cert string, key string
 
 	temporaryPemFile, err := ioutil.TempFile("", temporaryPemFileName)
 	if err != nil {
-		return SSLCert{}, fmt.Errorf("Couldn't create temp pem file %v: %v", temporaryPemFile.Name(), err)
+		return SSLCert{}, fmt.Errorf("Couldn't create temp pem file %v: %v", temporaryPemFileName, err)
 	}
 
 	_, err = temporaryPemFile.WriteString(fmt.Sprintf("%v\n%v", cert, key))


### PR DESCRIPTION
- adding an extra command line option -default-tls which is a reference to a k8s secret which will be used if no secretName name is defined in the ingress resource. This permits us to reuse certificates from one namespace across others. A use case being keeping a wildcard certificate in one namespace, but allow others to use it.
- shifting the tag to version 0.8.2
- fixed the bug in the ssl.go, should not use temporaryPemFile.Name() on error, it will be nil