### PR TITLE
cross namespace tls secrets

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -10,6 +10,7 @@ cloud-config
 cloud-provider
 cluster-uid
 configuration-name
+cross-permitted
 current-release-pr
 custom-error-service
 default-backend-service

--- a/ingress/controllers/nginx/README.md
+++ b/ingress/controllers/nginx/README.md
@@ -10,6 +10,7 @@ This is a nginx Ingress controller that uses [ConfigMap](https://github.com/kube
 * [HTTP](#http)
 * [HTTPS](#https)
   * [Default SSL Certificate](#default-ssl-certificate)
+  * [Cross Namespace Permissions](#cross-namespace-permission)
   * [HTTPS enforcement](#server-side-https-enforcement)
   * [HSTS](#http-strict-transport-security)
   * [Kube-Lego](#automated-certificate-management-with-kube-lego)
@@ -210,6 +211,15 @@ core@localhost ~ $ curl -v https://10.2.78.7:443 -k
 * Connection #0 to host 10.2.78.7 left intact
 ```
 
+### Cross Namespace Permissions
+
+By default all references to TLS certificates via secretName are relative to the namespace of the ingress resource. It useful however to be able to host a certificate in one namespace
+and provide permission for others to use it; a use case for this would be wildcard certs. Using --cross-permitted you can specify a comma separate list of secrets which a ingress resource
+is able to consume.
+
+```shell
+--cross-permitted=ingress/wildcard,ingress/internal
+```
 
 ### Server-side HTTPS enforcement
 

--- a/ingress/controllers/nginx/nginx/ssl.go
+++ b/ingress/controllers/nginx/nginx/ssl.go
@@ -50,7 +50,7 @@ func (nginx *Manager) AddOrUpdateCertAndKey(name string, cert string, key string
 
 	temporaryPemFile, err := ioutil.TempFile("", temporaryPemFileName)
 	if err != nil {
-		return SSLCert{}, fmt.Errorf("Couldn't create temp pem file %v: %v", temporaryPemFile.Name(), err)
+		return SSLCert{}, fmt.Errorf("Couldn't create temp pem file %v: %v", temporaryPemFileName, err)
 	}
 
 	_, err = temporaryPemFile.WriteString(fmt.Sprintf("%v\n%v", cert, key))


### PR DESCRIPTION
- adding an extra commad line option --cross-permitted which is a comma separated list of cross namespace secrets a ingress resource can request. This permits us to reuse certificates from one namespace across others. A use case being keeping a wildcard certificate in one namespace, but allow others to use it.
- shifting the tag to version 0.8.2
- fixed the bug in the ssl.go, should not use temporaryPemFile.Name() on error, it will be nil

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1404)

<!-- Reviewable:end -->
