### PR TITLE
[Ansible] #1407 sudo depreciation warning: sudo -> become

### DIFF
--- a/ansible/deploy-cluster.yml
+++ b/ansible/deploy-cluster.yml
@@ -1,10 +1,10 @@
 ---
-# This playbook deploys a kubernetes cluster 
+# This playbook deploys a kubernetes cluster
 # with the default addons.
 
 - hosts: all
   gather_facts: false
-  sudo: yes
+  become: yes
   roles:
     - pre-ansible
   tags:
@@ -12,7 +12,7 @@
 
 # Install etcd
 - hosts: etcd
-  sudo: yes
+  become: yes
   roles:
     - etcd
   tags:
@@ -20,7 +20,7 @@
 
 # Install docker
 - hosts: all
-  sudo: yes
+  become: yes
   roles:
     - common
     - docker
@@ -31,7 +31,7 @@
 - hosts:
     - masters
     - nodes
-  sudo: yes
+  become: yes
   roles:
     - { role: flannel, when: networking == 'flannel' }
   tags:
@@ -39,7 +39,7 @@
 
 # install opencontrail
 - hosts: all
-  sudo: yes
+  become: yes
   roles:
     - { role: opencontrail, when: networking == 'opencontrail'}
   tags:
@@ -47,13 +47,13 @@
 
 # install contiv netmaster
 - hosts: masters
-  sudo: yes
+  become: yes
   roles:
     - { role: contiv, contiv_role: netmaster, when: networking == 'contiv' }
 
 # install kube master services
 - hosts: masters
-  sudo: yes
+  become: yes
   roles:
     - master
   tags:
@@ -61,7 +61,7 @@
 
 # launch addons, like dns
 - hosts: masters
-  sudo: yes
+  become: yes
   roles:
     - kubernetes-addons
   tags:
@@ -70,7 +70,7 @@
 
 # install kubernetes on the nodes
 - hosts: nodes
-  sudo: yes
+  become: yes
   roles:
     - node
   tags:
@@ -80,7 +80,7 @@
 - hosts:
     - masters[0]
     - nodes
-  sudo: yes
+  become: yes
   roles:
     - { role: opencontrail-provision, when: networking == 'opencontrail' }
   tags:
@@ -88,13 +88,13 @@
 
 # install contiv netplugin
 - hosts: nodes
-  sudo: yes
+  become: yes
   roles:
     - { role: contiv, contiv_role: netplugin, when: networking == 'contiv' }
 
 # install runtime dependencies
 - hosts: nodes
-  sudo: yes
+  become: yes
   roles:
   - epilogue
   tags:

--- a/ansible/playbooks/adhoc/uninstall.yml
+++ b/ansible/playbooks/adhoc/uninstall.yml
@@ -4,7 +4,7 @@
     - nodes
     - etcd
 
-  sudo: yes
+  become: yes
 
   tasks:
     - name: Detecting Operating System
@@ -154,16 +154,16 @@
       command: systemctl daemon-reload
 
 - hosts: nodes
-  sudo: yes
+  become: yes
   tasks:
     - name: restart docker
       service: name=docker state=restarted
 
-- hosts: 
+- hosts:
     - masters
     - nodes
-    - etcd 
-  sudo: yes
+    - etcd
+  become: yes
   tasks:
     - name: CoreOS | unbootstrap python
       raw: rm -r {{ item }}

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -9,7 +9,7 @@
   local_action: file
     path={{ local_temp_addon_dir }}
     state=directory
-  sudo: no
+  become: no
 
 - name: Make sure the system services namespace exists
   copy:

--- a/ansible/vagrant/vagrant-ansible.yml
+++ b/ansible/vagrant/vagrant-ansible.yml
@@ -1,12 +1,12 @@
 - hosts: all
   gather_facts: false
-  sudo: yes
+  become: yes
   roles:
     # On CoreOS pre-ansible installs Python required to run further ansible steps.
     - pre-ansible
 
 - hosts: all
-  sudo: yes
+  become: yes
   vars:
     - public_iface: "{{ ansible_default_ipv4.interface }}"
   tasks:


### PR DESCRIPTION
    [DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default). This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

Usage example from Ansible documentation:

    - name: Ensure the httpd service is running
      service:
         name: httpd
        state: started
      become: true
   

Ansible [become module](http://docs.ansible.com/ansible/become.html#become) default user is `root`

Fixes: #1407 