### PR TITLE
mungegithub: Fix comment regex to NOT repost

### DIFF
--- a/mungegithub/mungers/close-stale-pr.go
+++ b/mungegithub/mungers/close-stale-pr.go
@@ -47,8 +47,8 @@ You can add 'keep-open' label to prevent this from happening, or add a comment t
 )
 
 var (
-	closingCommentRE = regexp.MustCompile(`This PR hasn't been active in \d+ days?\..*label to prevent this from happening again.`)
-	warningCommentRE = regexp.MustCompile(`This PR hasn't been active in \d+ days?\..*be closed in \d+ days?\.`)
+	closingCommentRE = regexp.MustCompile(`This PR hasn't been active in \d+ days?\..*label to prevent this from happening again`)
+	warningCommentRE = regexp.MustCompile(`This PR hasn't been active in \d+ days?\..*be closed in \d+ days`)
 )
 
 // CloseStalePR will ask the Bot to close any PullRequest that didn't


### PR DESCRIPTION
The regex to find that we have already added a warning is broken
(because of a change in punctuation). This is causing the mungebot to
repost the warning every time.

Fixing the regex will remove previous comments and prevent the bot from
posting too much.