### PR TITLE
always run Atomic determination test in Ansible

### DIFF
--- a/ansible/roles/pre-ansible/tasks/main.yml
+++ b/ansible/roles/pre-ansible/tasks/main.yml
@@ -31,6 +31,7 @@
   register: s
   changed_when: false
   failed_when: false
+  always_run: yes
 
 - name: Set the is_atomic fact
   set_fact:


### PR DESCRIPTION
Similar to how `always_run` is specified for commands above in the file.

Without this `ansible-playbook` fails if being run with in
[check mode](https://docs.ansible.com/ansible/playbooks_checkmode.html):

```
$ ansible-playbook -i inventory deploy-cluster.yml -t pre-ansible -DC -v
Using /home/bob/stuff/kubernetes/contrib/ansible/ansible.cfg as config file
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default).
This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAY [all] *********************************************************************

TASK [pre-ansible : Get os_version from /etc/os-release] ***********************
ok: [bob] => {"changed": false, "rc": 0, "stderr": "", "stdout": "\"16.04\"\r\n", "stdout_lines": ["\"16.04\""]}

TASK [pre-ansible : Get distro name from /etc/os-release] **********************
ok: [bob] => {"changed": false, "rc": 0, "stderr": "", "stdout": "\"Ubuntu\"\r\n", "stdout_lines": ["\"Ubuntu\""]}

TASK [pre-ansible : Init the is_coreos fact] ***********************************
ok: [bob] => {"ansible_facts": {"is_coreos": false}, "changed": false}

TASK [pre-ansible : Set the is_coreos fact] ************************************
skipping: [bob] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}

TASK [pre-ansible : Set the bin directory path for CoreOS] *********************
skipping: [bob] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}

TASK [pre-ansible : include] ***************************************************
skipping: [bob] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}

TASK [pre-ansible : Determine if Atomic] ***************************************
skipping: [bob] => {"changed": false, "skipped": true}

TASK [pre-ansible : Set the is_atomic fact] ************************************
fatal: [bob]: FAILED! => {"failed": true, "msg": "The conditional check 's.rc == 0' failed. The error was: error while evaluating conditional (s.r
c == 0): 'dict object' has no attribute 'rc'\n\nThe error appears to have been in '/home/bob/stuff/kubernetes/contrib/ansible/roles/pre-ansible/ta
sks/main.yml': line 36, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\
n\n- name: Set the is_atomic fact\n  ^ here\n"}

NO MORE HOSTS LEFT *************************************************************
        to retry, use: --limit @deploy-cluster.retry

PLAY RECAP *********************************************************************
bob                        : ok=4    changed=0    unreachable=0    failed=1
```

In check mode Ansible skips potentially mutating `raw` command from execution,
which leads to not properly initialized `s` variable with a following failure
of the next command that tries to check `s.rc` value.

Tested on Ubuntu 16.04 with Ansible 2.1.0.0.