### PR TITLE
Add support for SSH in git-sync

### DIFF
--- a/git-sync/Dockerfile
+++ b/git-sync/Dockerfile
@@ -5,10 +5,16 @@ VOLUME ["/git"]
 
 RUN apt-get update && \
   apt-get install -y git ca-certificates --no-install-recommends && \
+  apt-get install -y openssh-client && \
   apt-get clean -y && \
   rm -rf /var/lib/apt/lists/*
 
 COPY git-sync /git-sync
+
+# Move the existing SSH binary, then replace it with the wrapper script
+RUN mv /usr/bin/ssh /usr/bin/ssh-binary
+COPY ssh-wrapper.sh /usr/bin/ssh
+RUN chmod 755 /usr/bin/ssh
 
 RUN mkdir /nonexistent && chmod 777 /nonexistent
 

--- a/git-sync/docs/ssh.md
+++ b/git-sync/docs/ssh.md
@@ -1,0 +1,78 @@
+# Using SSH with git-sync
+
+Git-sync supports using the SSH protocol for pulling git content.
+
+## Step 1: Create Secret
+Create a Secret to store your SSH private key, with the Secret keyed as "ssh". This can be done one of two ways:
+
+***Method 1:***
+
+Use the ``kubectl create secret`` command and point to the file on your filesystem that stores the key. Ensure that the file is mapped to "ssh" as shown (the file can be located anywhere).
+```
+kubectl create secret generic git-creds --from-file=ssh=~/.ssh/id_rsa
+```
+
+***Method 2:***
+
+Write a config file for a Secret that holds your SSH private key, with the key (pasted as plaintext) mapped to the "ssh" field.
+```
+{
+  "kind": "Secret",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "git-creds"
+  },
+  "data": {
+    "ssh": <private-key>
+}
+```
+
+Create the Secret using ``kubectl create -f``.
+```
+kubectl create -f /path/to/secret-config.json
+```
+
+## Step 2: Configure Pod/Deployment Volume
+
+In your Pod or Deployment configuration, specify a Volume for mounting the Secret. Ensure that secretName matches the name you used when creating the Secret (e.g. "git-creds" used in both above examples).
+```
+volumes: [
+    {
+        "name": "git-secret",
+        "secret": {
+          "secretName": "git-creds"
+        }
+    },
+    ...
+],
+```
+
+## Step 3: Configure git-sync container
+
+In your git-sync container configuration, mount the Secret Volume at "/etc/git-secret". Ensure that the environment variable GIT_SYNC_REPO is set to use a URL with the SSH protocol, and set GIT_SYNC_SSH to true.
+```
+{
+    name: "git-sync",
+    ...
+    env: [
+        {
+            name: "GIT_SYNC_REPO",
+            value:  "git@github.com:kubernetes/kubernetes.git",
+        }, {
+            name: "GIT_SYNC_SSH",
+            value: "true",
+        },
+    ...
+    ]
+    volumeMounts: [
+        {
+            "name": "git-secret",
+            "mountPath": "/etc/git-secret"
+        },
+        ...
+    ],
+}
+```
+**Note: Do not mount the Secret Volume with "readOnly: true".** Kubernetes mounts the Secret with permissions 0444 by default (not restrictive enough to be used as an SSH key), so the container runs a chmod command on the Secret. Mounting the Secret Volume as a read-only filesystem prevents chmod and thus prevents the use of the Secret as an SSH key.
+
+***TODO***: Remove the chmod command once Kubernetes allows for specifying permissions for a Secret Volume. See https://github.com/kubernetes/kubernetes/pull/28936.

--- a/git-sync/ssh-wrapper.sh
+++ b/git-sync/ssh-wrapper.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script wraps the standard SSH binary so that the mounted SSH key can be used without user confirmation.
+# In the Dockerfile, the original SSH binary is moved to /usr/bin/ssh-binary (and is then used as the base command here).
+# This script is moved to /usr/bin/ssh so that Git uses it by default.
+
+# The "UserKnownHostsFile" and "StrictHostKeyChecking" options avoid the user confirmation check.
+# The -i flag specifies where the SSH key is located.
+
+secret_path=/etc/git-secret/ssh
+ssh-binary -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $secret_path "$@"


### PR DESCRIPTION
This PR for git-sync adds the ability to use SSH for pulling git content. 

**Implementation Notes:**
- Running as a sidecar container, git-sync needs to avoid requiring the user to confirm use of the SSH key, so we override the /usr/bin/ssh binary with our own script (ssh-wrapper.sh) that has the necessary flags, and git then uses that script by default.
- Currently, secret files are always mounted with permission 0444. This is not restrictive enough to be used as an SSH key, so we chmod the mounted secret file to 0400. https://github.com/kubernetes/kubernetes/pull/28936 is in progress to allow for explicitly setting the permissions of a secret, and that can be incorporated into a future version of git-sync to avoid the chmod command.
- Setting the mounted secret volume with readOnly: true (as suggested in the example here: http://kubernetes.io/docs/user-guide/secrets/#use-case-pod-with-ssh-keys) actually makes it impossible to use the secret as an SSH key. As mentioned above, the secret will be mounted as 0444, but the read-only nature prevents running the necessary chmod command. I've included a warning about this in ssh.md and in the error message if the chmod fails. Again, the PR above should allow for avoiding this issue.

There are more detailed instructions for usage in the ssh.md readme, which I can move into the main README.md if that is preferred.
