### PR TITLE
OWNERS files for each directory under contrib

### DIFF
--- a/404-server/OWNERS
+++ b/404-server/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- bprashanth
+- luxas
+- mikedanese
+

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- aledbf
+- bprashanth
+- eparis
+- lavalamp

--- a/addon-resizer/OWNERS
+++ b/addon-resizer/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- Q-Lee
+- piosz
+- wojtek-t
+

--- a/ansible/OWNERS
+++ b/ansible/OWNERS
@@ -1,0 +1,7 @@
+assignees:
+- danehans
+- eparis
+- ingvagabund
+- rutsky
+- stephenrlouie
+

--- a/cluster-autoscaler/OWNERS
+++ b/cluster-autoscaler/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- fgrzadkowski
+- mwielgus
+- piosz
+

--- a/cni-plugins/OWNERS
+++ b/cni-plugins/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- MikeSpreitzer
+

--- a/compare/OWNERS
+++ b/compare/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- freehan
+- gmarek
+- mikedanese
+

--- a/continuousdelivery/OWNERS
+++ b/continuousdelivery/OWNERS
@@ -1,0 +1,4 @@
+assignees:
+- emaildanwilson
+- zoidbergwill
+

--- a/diurnal/OWNERS
+++ b/diurnal/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- bprashanth
+- eparis
+- mikedanese
+

--- a/dnsmasq/OWNERS
+++ b/dnsmasq/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- ArtfulCoder
+- girishkalele
+- luxas
+

--- a/docker-micro-benchmark/OWNERS
+++ b/docker-micro-benchmark/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- Random-Liu
+

--- a/election/OWNERS
+++ b/election/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- aledbf
+- brendandburns
+- mikedanese
+

--- a/exec-healthz/OWNERS
+++ b/exec-healthz/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- bprashanth
+- luxas
+- mikedanese
+

--- a/flannel-server/OWNERS
+++ b/flannel-server/OWNERS
@@ -1,0 +1,4 @@
+assignees:
+- bprashanth
+- mikedanese
+

--- a/for-demos/OWNERS
+++ b/for-demos/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- eparis
+- mikedanese
+- pwittrock
+

--- a/git-sync/OWNERS
+++ b/git-sync/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- aledbf
+- mikedanese
+- paulbakker
+

--- a/go2docker/OWNERS
+++ b/go2docker/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- eparis
+- mikedanese
+- raggi
+

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- aledbf
+- bprashanth
+- eparis
+

--- a/images/OWNERS
+++ b/images/OWNERS
@@ -1,0 +1,4 @@
+assignees:
+- aledbf
+- jgmize
+

--- a/ingress/OWNERS
+++ b/ingress/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- aledbf
+- bprashanth
+- simonswine
+

--- a/init/OWNERS
+++ b/init/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- mikedanese
+- rootfs
+- sgallagher
+

--- a/keepalived-vip/OWNERS
+++ b/keepalived-vip/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- aledbf
+- bprashanth
+- mikedanese
+

--- a/kubeform/OWNERS
+++ b/kubeform/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- madhusudancs
+

--- a/kubelet-to-gcm/OWNERS
+++ b/kubelet-to-gcm/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- Q-Lee
+

--- a/logging/OWNERS
+++ b/logging/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- itayariel
+- mattthias
+- mikedanese
+

--- a/micro-demos/OWNERS
+++ b/micro-demos/OWNERS
@@ -1,0 +1,4 @@
+assignees:
+- caesarxuchao
+- thockin
+

--- a/mungegithub/OWNERS
+++ b/mungegithub/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- apelisse
+- eparis
+- foxish
+- lavalamp

--- a/netperf-tester/OWNERS
+++ b/netperf-tester/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- BenTheElder
+- eparis
+- mikedanese
+

--- a/perfdash/OWNERS
+++ b/perfdash/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- Random-Liu
+- brendandburns
+- gmarek
+

--- a/pets/OWNERS
+++ b/pets/OWNERS
@@ -1,0 +1,4 @@
+assignees:
+- aledbf
+- bprashanth
+

--- a/podex/OWNERS
+++ b/podex/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- 3cky
+- eparis
+- mikedanese
+

--- a/prometheus/OWNERS
+++ b/prometheus/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- mikedanese
+

--- a/recipes/OWNERS
+++ b/recipes/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- mikedanese
+

--- a/release-notes/OWNERS
+++ b/release-notes/OWNERS
@@ -1,0 +1,4 @@
+assignees:
+- eparis
+- mikedanese
+

--- a/rescheduler/OWNERS
+++ b/rescheduler/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- piosz
+

--- a/scale-demo/OWNERS
+++ b/scale-demo/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- alekssaul
+- brendandburns
+- roberthbailey
+

--- a/service-loadbalancer/OWNERS
+++ b/service-loadbalancer/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- aledbf
+- bprashanth
+- jdavis7257
+

--- a/test-utils/OWNERS
+++ b/test-utils/OWNERS
@@ -1,0 +1,5 @@
+assignees:
+- freehan
+- gmarek
+- lavalamp
+


### PR DESCRIPTION
Used a modified version of https://github.com/coreos/findowner (at https://github.com/foxish/findowner/tree/foxish-edits) to generate the YAML files.
It populates the top 3 committers over the past 6 months as potential assignees. 

PTAL if the lists make sense and we can get blunderbuss running on contrib.
cc @lavalamp @bgrant0607 @apelisse @pwittrock 
