### PR TITLE
mungegithub: Stop process if it fails

### DIFF
--- a/mungegithub/mungers/cherrypick-label-unapproved.go
+++ b/mungegithub/mungers/cherrypick-label-unapproved.go
@@ -69,6 +69,11 @@ func (LabelUnapprovedPicks) Munge(obj *github.MungeObject) {
 		return
 	}
 
+	if _, err := obj.GetPR(); err != nil {
+		glog.Errorf("Failed to retrieve PR: %s", err)
+		return
+	}
+
 	if obj.IsForBranch("master") {
 		return
 	}

--- a/mungegithub/mungers/docs-no-retest.go
+++ b/mungegithub/mungers/docs-no-retest.go
@@ -80,6 +80,7 @@ func (DocsNeedNoRetest) Munge(obj *github.MungeObject) {
 	files, err := obj.ListFiles()
 	if err != nil {
 		glog.Errorf("Failed to list files for PR %d: %s", obj.Issue.Number, err)
+		return
 	}
 
 	docsOnly := areFilesDocOnly(files)


### PR DESCRIPTION
Currently, the code keeps running if it fails to fetch a pull-request
(maybe because Github is down) doing things it shouldn't do (like adding
labels).
Just stop as soon as we can if we detect an error.

Fixes #1445

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1446)

<!-- Reviewable:end -->
