### PR TITLE
Remove get commits

### DIFF
--- a/mungegithub/github/github_test.go
+++ b/mungegithub/github/github_test.go
@@ -181,7 +181,7 @@ func TestForEachIssueDo(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		client, server, mux := github_test.InitServer(t, nil, nil, nil, nil, nil, nil)
+		client, server, mux := github_test.InitServer(t, nil, nil, nil, nil, nil, nil, nil)
 		config := &Config{
 			client:      client,
 			Org:         "foo",
@@ -404,7 +404,7 @@ func TestGetLastModified(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		client, server, _ := github_test.InitServer(t, nil, nil, nil, test.commits, nil, nil)
+		client, server, _ := github_test.InitServer(t, nil, nil, nil, test.commits, nil, nil, nil)
 		config := &Config{}
 		config.Org = "o"
 		config.Project = "r"
@@ -450,7 +450,7 @@ func TestRemoveLabel(t *testing.T) {
 		},
 	}
 	for testNum, test := range tests {
-		client, server, mux := github_test.InitServer(t, test.issue, nil, nil, nil, nil, nil)
+		client, server, mux := github_test.InitServer(t, test.issue, nil, nil, nil, nil, nil, nil)
 		config := &Config{}
 		config.Org = "o"
 		config.Project = "r"
@@ -511,7 +511,7 @@ this pr Fixes #23 and FIXES #45 but not fixxx #99`,
 		},
 	}
 	for testNum, test := range tests {
-		client, server, _ := github_test.InitServer(t, test.issue, nil, nil, nil, nil, nil)
+		client, server, _ := github_test.InitServer(t, test.issue, nil, nil, nil, nil, nil, nil)
 		config := &Config{}
 		config.Org = "o"
 		config.Project = "r"

--- a/mungegithub/github/testing/github.go
+++ b/mungegithub/github/testing/github.go
@@ -257,6 +257,8 @@ func setMux(t *testing.T, mux *http.ServeMux, path string, thing interface{}) {
 			data, err = json.Marshal(thing)
 		case *github.CombinedStatus:
 			data, err = json.Marshal(thing)
+		case []*github.CommitFile:
+			data, err = json.Marshal(thing)
 		case []*github.User:
 			data, err = json.Marshal(thing)
 		}
@@ -274,7 +276,7 @@ func setMux(t *testing.T, mux *http.ServeMux, path string, thing interface{}) {
 // InitServer will return a github.Client which will talk to httptest.Server,
 // to retrieve information from the http.ServeMux. If an issue, pr, events, or
 // commits are supplied it will repond with those on o/r/
-func InitServer(t *testing.T, issue *github.Issue, pr *github.PullRequest, events []*github.IssueEvent, commits []*github.RepositoryCommit, status *github.CombinedStatus, masterCommit *github.RepositoryCommit) (*github.Client, *httptest.Server, *http.ServeMux) {
+func InitServer(t *testing.T, issue *github.Issue, pr *github.PullRequest, events []*github.IssueEvent, commits []*github.RepositoryCommit, status *github.CombinedStatus, masterCommit *github.RepositoryCommit, files []*github.CommitFile) (*github.Client, *httptest.Server, *http.ServeMux) {
 	// test server
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -320,6 +322,10 @@ func InitServer(t *testing.T, issue *github.Issue, pr *github.PullRequest, event
 	if masterCommit != nil {
 		path := "/repos/o/r/commits/master"
 		setMux(t, mux, path, masterCommit)
+	}
+	if files != nil {
+		path := fmt.Sprintf("/repos/o/r/pulls/%d/files", issueNum)
+		setMux(t, mux, path, files)
 	}
 	if status != nil {
 		path := fmt.Sprintf("/repos/o/r/commits/%s/status", sha)

--- a/mungegithub/mungers/assign-fixes_test.go
+++ b/mungegithub/mungers/assign-fixes_test.go
@@ -58,7 +58,7 @@ func TestAssignFixes(t *testing.T) {
 	}
 	for _, test := range tests {
 		test.prIssue.Body = &test.prBody
-		client, server, mux := github_test.InitServer(t, test.prIssue, test.pr, nil, nil, nil, nil)
+		client, server, mux := github_test.InitServer(t, test.prIssue, test.pr, nil, nil, nil, nil, nil)
 		path := fmt.Sprintf("/repos/o/r/issues/%d", *test.fixesIssue.Number)
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 			data, err := json.Marshal(test.fixesIssue)

--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -129,21 +129,19 @@ func (b *BlockPath) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	commits, err := obj.GetCommits()
+	files, err := obj.ListFiles()
 	if err != nil {
 		return
 	}
 
-	for _, c := range commits {
-		for _, f := range c.Files {
-			if matchesAny(*f.Filename, b.blockRegexp) {
-				if matchesAny(*f.Filename, b.doNotBlockRegexp) {
-					continue
-				}
-				obj.WriteComment(blockPathBody)
-				obj.AddLabels([]string{doNotMergeLabel})
-				return
+	for _, f := range files {
+		if matchesAny(*f.Filename, b.blockRegexp) {
+			if matchesAny(*f.Filename, b.doNotBlockRegexp) {
+				continue
 			}
+			obj.WriteComment(blockPathBody)
+			obj.AddLabels([]string{doNotMergeLabel})
+			return
 		}
 	}
 }

--- a/mungegithub/mungers/cherrypick-auto-approve_test.go
+++ b/mungegithub/mungers/cherrypick-auto-approve_test.go
@@ -115,7 +115,7 @@ func TestCherrypickAuthApprove(t *testing.T) {
 
 		pr := ValidPR()
 		pr.Base.Ref = &test.prBranch
-		client, server, mux := github_test.InitServer(t, test.issue, pr, nil, nil, nil, nil)
+		client, server, mux := github_test.InitServer(t, test.issue, pr, nil, nil, nil, nil, nil)
 
 		path := fmt.Sprintf("/repos/o/r/issues/%d/labels", *test.issue.Number)
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {

--- a/mungegithub/mungers/path_label.go
+++ b/mungegithub/mungers/path_label.go
@@ -126,18 +126,16 @@ func (p *PathLabelMunger) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	commits, err := obj.GetCommits()
+	files, err := obj.ListFiles()
 	if err != nil {
 		return
 	}
 
 	needsLabels := sets.NewString()
-	for _, c := range commits {
-		for _, f := range c.Files {
-			for _, lm := range p.labelMap {
-				if lm.regexp.MatchString(*f.Filename) {
-					needsLabels.Insert(lm.label)
-				}
+	for _, f := range files {
+		for _, lm := range p.labelMap {
+			if lm.regexp.MatchString(*f.Filename) {
+				needsLabels.Insert(lm.label)
 			}
 		}
 	}

--- a/mungegithub/mungers/path_label_test.go
+++ b/mungegithub/mungers/path_label_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"runtime"
 	"testing"
-	"time"
 
 	github_util "k8s.io/contrib/mungegithub/github"
 	github_test "k8s.io/contrib/mungegithub/github/testing"
@@ -41,26 +40,15 @@ func docsProposalIssue() *github.Issue {
 }
 
 // Commit returns a filled out github.Commit which happened at time.Unix(t, 0)
-func pathsCommit(path []string) []*github.RepositoryCommit {
-	c := &github.Commit{
-		SHA: stringPtr("mysha"),
-		Committer: &github.CommitAuthor{
-			Date: timePtr(time.Unix(10, 0)),
-		},
-	}
-	rc := &github.RepositoryCommit{
-		SHA:    stringPtr("mysha"),
-		Commit: c,
-	}
-	files := []github.CommitFile{}
+func commitFiles(path []string) []*github.CommitFile {
+	files := []*github.CommitFile{}
 	for _, p := range path {
-		f := github.CommitFile{
+		f := &github.CommitFile{
 			Filename: stringPtr(p),
 		}
 		files = append(files, f)
 	}
-	rc.Files = files
-	return []*github.RepositoryCommit{rc}
+	return files
 }
 
 func BotAddedDesign() []*github.IssueEvent {
@@ -81,68 +69,68 @@ func TestPathLabelMunge(t *testing.T) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	tests := []struct {
-		commits     []*github.RepositoryCommit
+		files       []*github.CommitFile
 		events      []*github.IssueEvent
 		mustHave    []string
 		mustNotHave []string
 	}{
 		{
-			commits:     pathsCommit([]string{"docs/proposals"}),
+			files:       commitFiles([]string{"docs/proposals"}),
 			events:      BotAddedDesign(),
 			mustHave:    []string{"kind/design"},
 			mustNotHave: []string{"kind/api-change", "kind/new-api"},
 		},
 		{
-			commits:     pathsCommit([]string{"docs/my/proposals"}),
+			files:       commitFiles([]string{"docs/my/proposals"}),
 			events:      BotAddedDesign(),
 			mustHave:    []string{},
 			mustNotHave: []string{"kind/design", "kind/api-change", "kind/new-api"},
 		},
 		{
-			commits:     pathsCommit([]string{"pkg/api/types.go"}),
+			files:       commitFiles([]string{"pkg/api/types.go"}),
 			events:      BotAddedDesign(),
 			mustHave:    []string{"kind/api-change"},
 			mustNotHave: []string{"kind/design", "kind/new-api"},
 		},
 		{
-			commits:     pathsCommit([]string{"pkg/api/v1/types.go"}),
+			files:       commitFiles([]string{"pkg/api/v1/types.go"}),
 			events:      BotAddedDesign(),
 			mustHave:    []string{"kind/api-change"},
 			mustNotHave: []string{"kind/design", "kind/new-api"},
 		},
 		{
-			commits:     pathsCommit([]string{"pkg/api/v1/duh/types.go"}),
+			files:       commitFiles([]string{"pkg/api/v1/duh/types.go"}),
 			events:      BotAddedDesign(),
 			mustHave:    []string{},
 			mustNotHave: []string{"kind/design", "kind/api-change", "kind/new-api"},
 		},
 		{
-			commits:     pathsCommit([]string{"pkg/apis/experimental/register.go"}),
+			files:       commitFiles([]string{"pkg/apis/experimental/register.go"}),
 			events:      BotAddedDesign(),
 			mustHave:    []string{"kind/new-api"},
 			mustNotHave: []string{"kind/api-change", "kind/design"},
 		},
 		{
-			commits:     pathsCommit([]string{"pkg/apis/experimental/v1beta1/register.go"}),
+			files:       commitFiles([]string{"pkg/apis/experimental/v1beta1/register.go"}),
 			events:      BotAddedDesign(),
 			mustHave:    []string{"kind/new-api"},
 			mustNotHave: []string{"kind/api-change", "kind/design"},
 		},
 		{
-			commits:     pathsCommit([]string{"pkg/apis/experiments/v1beta1/duh/register.go"}),
+			files:       commitFiles([]string{"pkg/apis/experiments/v1beta1/duh/register.go"}),
 			events:      BotAddedDesign(),
 			mustHave:    []string{},
 			mustNotHave: []string{"kind/design", "kind/api-change", "kind/new-api"},
 		},
 		{
-			commits:     pathsCommit([]string{"README"}),
+			files:       commitFiles([]string{"README"}),
 			events:      OtherAddedDesign(),
 			mustHave:    []string{"kind/design"},
 			mustNotHave: []string{"kind/api-change", "kind/new-api"},
 		},
 	}
 	for testNum, test := range tests {
-		client, server, mux := github_test.InitServer(t, docsProposalIssue(), ValidPR(), test.events, test.commits, nil, nil, nil)
+		client, server, mux := github_test.InitServer(t, docsProposalIssue(), ValidPR(), test.events, nil, nil, nil, test.files)
 		mux.HandleFunc("/repos/o/r/issues/1/labels/kind/design", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte{})

--- a/mungegithub/mungers/path_label_test.go
+++ b/mungegithub/mungers/path_label_test.go
@@ -142,7 +142,7 @@ func TestPathLabelMunge(t *testing.T) {
 		},
 	}
 	for testNum, test := range tests {
-		client, server, mux := github_test.InitServer(t, docsProposalIssue(), ValidPR(), test.events, test.commits, nil, nil)
+		client, server, mux := github_test.InitServer(t, docsProposalIssue(), ValidPR(), test.events, test.commits, nil, nil, nil)
 		mux.HandleFunc("/repos/o/r/issues/1/labels/kind/design", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte{})

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -173,7 +173,7 @@ func TestReleaseNoteLabel(t *testing.T) {
 			pr.Base.Ref = &test.branch
 		}
 		test.issue.Body = &test.body
-		client, server, mux := github_test.InitServer(t, test.issue, pr, nil, nil, nil, nil)
+		client, server, mux := github_test.InitServer(t, test.issue, pr, nil, nil, nil, nil, nil)
 		path := fmt.Sprintf("/repos/o/r/issue/%s/labels", *test.issue.Number)
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/mungegithub/mungers/stale-green-ci_test.go
+++ b/mungegithub/mungers/stale-green-ci_test.go
@@ -94,7 +94,7 @@ func TestOldUnitTestMunge(t *testing.T) {
 		issue.Number = intPtr(issueNum)
 		pr := ValidPR()
 		pr.Number = intPtr(issueNum)
-		client, server, mux := github_test.InitServer(t, issue, pr, nil, nil, test.ciStatus, nil)
+		client, server, mux := github_test.InitServer(t, issue, pr, nil, nil, test.ciStatus, nil, nil)
 
 		path := fmt.Sprintf("/repos/o/r/issues/%d/comments", issueNum)
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -290,7 +290,7 @@ func TestQueueOrder(t *testing.T) {
 	}
 	for testNum, test := range tests {
 		config := &github_util.Config{}
-		client, server, mux := github_test.InitServer(t, nil, nil, nil, nil, nil, nil)
+		client, server, mux := github_test.InitServer(t, nil, nil, nil, nil, nil, nil, nil)
 		config.Org = "o"
 		config.Project = "r"
 		config.SetClient(client)
@@ -344,7 +344,7 @@ func TestValidateLGTMAfterPush(t *testing.T) {
 	}
 	for testNum, test := range tests {
 		config := &github_util.Config{}
-		client, server, _ := github_test.InitServer(t, nil, nil, test.issueEvents, test.commits, nil, nil)
+		client, server, _ := github_test.InitServer(t, nil, nil, test.issueEvents, test.commits, nil, nil, nil)
 		config.Org = "o"
 		config.Project = "r"
 		config.SetClient(client)
@@ -866,7 +866,7 @@ func TestSubmitQueue(t *testing.T) {
 		issueNumStr := strconv.Itoa(issueNum)
 
 		test.issue.Number = &issueNum
-		client, server, mux := github_test.InitServer(t, test.issue, test.pr, test.events, test.commits, test.ciStatus, test.masterCommit)
+		client, server, mux := github_test.InitServer(t, test.issue, test.pr, test.events, test.commits, test.ciStatus, test.masterCommit, nil)
 
 		config := &github_util.Config{}
 		config.Org = "o"


### PR DESCRIPTION
Remove as many occurrences of GetCommits as possible. 
There is one left in `cherrypick-clear-after-merge` but it only applies to cherrypick candidates, and there are not so many of these...
Hopefully it can have a good impact on token usage.
