### PR TITLE
Fix pv definition to match running instance.

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/pv.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/pv.yaml
@@ -12,5 +12,5 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   gcePersistentDisk:
-    pdName: kubernetes-submit-queue
+    pdName: kubernetes-cache
     fsType: ext4


### PR DESCRIPTION
The name of the PD mounted on the utility cluster is kubernetes-cache.

cc @lavalamp 