### PR TITLE
Added URL param keyed sticky sessions

### DIFF
--- a/service-loadbalancer/README.md
+++ b/service-loadbalancer/README.md
@@ -361,7 +361,7 @@ Europe
 
 #### Advanced features
 
-* __Sticky sessions__: Currently undocumented but [possible via annotations](https://github.com/kubernetes/contrib/blob/master/service-loadbalancer/service_loadbalancer.go#L155), see https://gist.github.com/bprashanth/50355c25f4e2245d623f for an example of use.
+* __Sticky sessions__: Currently undocumented but [possible via annotations](https://github.com/kubernetes/contrib/blob/master/service-loadbalancer/service_loadbalancer.go#L155), see https://gist.github.com/bprashanth/50355c25f4e2245d623f for an example of use. The stick-table configuration can also be configured through a `serviceloadbalancer/lb.stick-table-params` annotation.
 * __Name based virtual hosting__: Currently undocumented but [possible via annotations](https://github.com/kubernetes/contrib/blob/master/service-loadbalancer/service_loadbalancer.go#L148).
 * __Configurable algorithms__: Currently undocumented but [possible via annotations](https://github.com/kubernetes/contrib/blob/master/service-loadbalancer/service_loadbalancer.go#L153).
 

--- a/service-loadbalancer/README.md
+++ b/service-loadbalancer/README.md
@@ -152,7 +152,7 @@ metadata:
     - name: secret-volume
       secret:
         secretName: my-secret
-       
+
 ```
 
 - Add your SSL configuration to loadbalancer pod
@@ -166,7 +166,7 @@ metadata:
 
 ##### Custom ACL
  - Adding the aclMatch annotation will allow you to serve the service on a specific path although URLs will not be rewritten back to root. The following will cause your service to be available at /test and your web service will be passed the url with /test on the front.
- 
+
 ```yaml
  metadata:
    name: myservice
@@ -361,7 +361,7 @@ Europe
 
 #### Advanced features
 
-* __Sticky sessions__: Currently undocumented but [possible via annotations](https://github.com/kubernetes/contrib/blob/master/service-loadbalancer/service_loadbalancer.go#L155).
+* __Sticky sessions__: Currently undocumented but [possible via annotations](https://github.com/kubernetes/contrib/blob/master/service-loadbalancer/service_loadbalancer.go#L155), see https://gist.github.com/bprashanth/50355c25f4e2245d623f for an example of use.
 * __Name based virtual hosting__: Currently undocumented but [possible via annotations](https://github.com/kubernetes/contrib/blob/master/service-loadbalancer/service_loadbalancer.go#L148).
 * __Configurable algorithms__: Currently undocumented but [possible via annotations](https://github.com/kubernetes/contrib/blob/master/service-loadbalancer/service_loadbalancer.go#L153).
 

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -3,7 +3,7 @@
 global
     daemon
     stats socket /tmp/haproxy
-    server-state-file global       
+    server-state-file global
     server-state-base /var/state/haproxy/
 
 {{ if eq .startSyslog "true" }}
@@ -19,29 +19,29 @@ global
 
 defaults
     log global
-   
+
     load-server-state-from-file global
-    
+
     # Enable session redistribution in case of connection failure.
     option redispatch
-    
-    # Disable logging of null connections (haproxy connections like checks). 
+
+    # Disable logging of null connections (haproxy connections like checks).
     # This avoids excessive logs from haproxy internals.
     option dontlognull
-    
+
     # Enable HTTP connection closing on the server side.
     option http-server-close
 
-    # Enable insertion of the X-Forwarded-For header to requests sent to 
+    # Enable insertion of the X-Forwarded-For header to requests sent to
     # servers and keep client IP address.
     option forwardfor
-    
+
     # Enable HTTP keep-alive from client to server.
     option http-keep-alive
 
     # Clients should send their full http request in 5s.
     timeout http-request    5s
-    
+
     # Maximum time to wait for a connection attempt to a server to succeed.
     timeout connect         5s
 
@@ -50,16 +50,16 @@ defaults
     timeout client          50s
 
     # Inactivity timeout on the client side for half-closed connections.
-    # Applies when the client is expected to acknowledge or send data 
+    # Applies when the client is expected to acknowledge or send data
     # while one direction is already shut down.
     timeout client-fin      50s
-    
+
     # Maximum inactivity time on the server side.
     timeout server          50s
-    
+
     # timeout to use with WebSocket and CONNECT
     timeout tunnel          1h
-    
+
     # Maximum allowed time to wait for a new HTTP request to appear.
     timeout http-keep-alive 60s
 
@@ -93,7 +93,7 @@ frontend httpsfrontend
     {{ if $svc.AclMatch }} acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
     {{else}} acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
     {{ end }}
-    
+
     {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
     use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
     {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
@@ -135,15 +135,24 @@ backend {{$svc.Name}}
     balance {{$svc.Algorithm}}
     # TODO: Make the path used to access a service customizable.
     reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
+{{if and $svc.SessionAffinity (not $svc.CookieStickySession) (not $svc.UrlStickySession)}}
     # create a stickiness table using client IP address as key
     # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
+    stick-table type ip {{$svc.StickTableParams}}
     stick on src
     {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} check port {{$svc.BackendPort}} inter 5
     {{end}}
 {{end}}
-{{if and $svc.SessionAffinity $svc.CookieStickySession}}
+{{if and $svc.SessionAffinity $svc.UrlStickySession (not $svc.CookieStickySession)}}
+    # create a stickiness table using url param 'session' as key
+    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick%20on
+    # & http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#url_param
+    stick-table type string len 40 {{$svc.StickTableParams}}
+    stick on url_param(session)
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} check port {{$svc.BackendPort}} inter 5
+    {{end}}
+{{end}}
+{{if and $svc.SessionAffinity $svc.CookieStickySession (not $svc.UrlStickySession)}}
     # insert a cookie with name SERVERID to stick a client with a backend server
     # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
     cookie SERVERID insert indirect nocache
@@ -209,8 +218,8 @@ backend {{$svc.Name}}
 {{if $svc.SessionAffinity}}
     # create a stickiness table using client IP address as key
     # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src    
+    stick-table type ip {{$svc.StickTableParams}}
+    stick on src
 {{end}}
     {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
     {{end}}


### PR DESCRIPTION
This pull request enables using sticky sessions keyed by a URL param `session`, enabled through annotation `serviceloadbalancer/lb.url-param-sticky-session`. 
Additionally, the parameters for the stick table can now be configured by annotation `serviceloadbalancer/lb.stick-table-params`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1458)

<!-- Reviewable:end -->
