### PR TITLE
GCE ingress http-only annotation naming fix

### DIFF
--- a/ingress/controllers/gce/README.md
+++ b/ingress/controllers/gce/README.md
@@ -538,7 +538,7 @@ kind: Ingress
 metadata:
   name: test
   annotations:
-    kubernetes.io/ingress.allowHTTP: "false"
+    kubernetes.io/ingress.allow-http: "false"
 spec:
   tls:
   # This assumes tls-secret exists.


### PR DESCRIPTION
```
GCE ingress http-only annotation naming fix
```
