### PR TITLE
[nginx-ingress-controller]: Use ClientConfig to configure connection

### DIFF
--- a/ingress/controllers/nginx/README.md
+++ b/ingress/controllers/nginx/README.md
@@ -19,6 +19,7 @@ This is a nginx Ingress controller that uses [ConfigMap](https://github.com/kube
 * [NGINX customization](configuration.md)
 * [NGINX status page](#nginx-status-page)
 * [Disabling NGINX ingress controller](#disabling-nginx-ingress-controller)
+* [Local cluster](#local-cluster)
 * [Debug & Troubleshooting](#troubleshooting)
 * [Limitations](#limitations)
 * [NGINX Notes](#nginx-notes)
@@ -342,6 +343,12 @@ To extract the information in JSON format the module provides a custom URL: `/ng
 ### Disabling NGINX ingress controller
 
 Setting the annotation `kubernetes.io/ingress.class` to any value other than "nginx" or the empty string, will force the NGINX Ingress controller to ignore your Ingress. Do this if you wish to use one of the other Ingress controllers at the same time as the NGINX controller.
+
+### Local cluster
+
+Using [`hack/local-up-cluster.sh`](https://github.com/kubernetes/kubernetes/blob/master/hack/local-up-cluster.sh) is possible to start a local kubernetes cluster consisting of a master and a single node. Please read [running-locally.md](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/running-locally.md) for more details.
+
+Use of `hostNetwork: true` in the ingress controller is required to falls back at localhost:8080 for the apiserver if every other client creation check fails (eg: service account not present, kubeconfig doesn't exist, no master env vars...)
 
 
 ### Debug & Troubleshooting

--- a/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
+++ b/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
@@ -22,7 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/custom-errors/rc-custom-errors.yaml
+++ b/ingress/controllers/nginx/examples/custom-errors/rc-custom-errors.yaml
@@ -22,7 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
+++ b/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
@@ -22,7 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
+++ b/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/default/rc-default.yaml
+++ b/ingress/controllers/nginx/examples/default/rc-default.yaml
@@ -22,7 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/full/rc-full.yaml
+++ b/ingress/controllers/nginx/examples/full/rc-full.yaml
@@ -27,7 +27,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
+++ b/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
@@ -22,7 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
+++ b/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
@@ -95,7 +95,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
+++ b/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
@@ -22,7 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
+++ b/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
@@ -22,7 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/examples/udp/rc-udp.yaml
+++ b/ingress/controllers/nginx/examples/udp/rc-udp.yaml
@@ -22,7 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/main.go
+++ b/ingress/controllers/nginx/main.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	healthPort = 10249
+	healthPort = 10254
 )
 
 var (

--- a/ingress/controllers/nginx/main.go
+++ b/ingress/controllers/nginx/main.go
@@ -56,10 +56,6 @@ var (
 	nxgConfigMap = flags.String("nginx-configmap", "",
 		`Name of the ConfigMap that containes the custom nginx configuration to use`)
 
-	inCluster = flags.Bool("running-in-cluster", true,
-		`Optional, if this controller is running in a kubernetes cluster, use the
-		 pod secrets for creating a Kubernetes client.`)
-
 	tcpConfigMapName = flags.String("tcp-services-configmap", "",
 		`Name of the ConfigMap that containes the definition of the TCP services to expose.
 		The key in the map indicates the external port to be used. The value is the name of the
@@ -91,7 +87,6 @@ var (
 )
 
 func main() {
-	var kubeClient *unversioned.Client
 	flags.AddGoFlagSet(flag.CommandLine)
 	flags.Parse(os.Args)
 	clientConfig := kubectl_util.DefaultClientConfig(flags)
@@ -107,26 +102,20 @@ func main() {
 		glog.Fatalf("Please specify --default-backend-service")
 	}
 
-	var err error
-	if *inCluster {
-		kubeClient, err = unversioned.NewInCluster()
-	} else {
-		config, connErr := clientConfig.ClientConfig()
-		if connErr != nil {
-			glog.Fatalf("error connecting to the client: %v", err)
-		}
-		kubeClient, err = unversioned.New(config)
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		glog.Fatalf("error connecting to the client: %v", err)
 	}
+	kubeClient, err := unversioned.New(config)
+
 	if err != nil {
 		glog.Fatalf("failed to create client: %v", err)
 	}
 
-	runtimePodInfo := &podInfo{NodeIP: "127.0.0.1"}
-	if *inCluster {
-		runtimePodInfo, err = getPodDetails(kubeClient)
-		if err != nil {
-			glog.Fatalf("unexpected error getting runtime information: %v", err)
-		}
+	runtimePodInfo, err := getPodDetails(kubeClient)
+	if err != nil {
+		runtimePodInfo = &podInfo{NodeIP: "127.0.0.1"}
+		glog.Warningf("unexpected error getting runtime information: %v", err)
 	}
 	if err := isValidService(kubeClient, *defaultSvc); err != nil {
 		glog.Fatalf("no service with name %v found: %v", *defaultSvc, err)

--- a/ingress/controllers/nginx/nginx/utils.go
+++ b/ingress/controllers/nginx/nginx/utils.go
@@ -228,7 +228,7 @@ func diff(b1, b2 []byte) (data []byte, err error) {
 func sysctlSomaxconn() int {
 	maxConns, err := sysctl.GetSysctl("net/core/somaxconn")
 	if err != nil || maxConns < 512 {
-		glog.Warningf("system net.core.somaxconn=%v. Using NGINX default (511)", maxConns)
+		glog.V(3).Infof("system net.core.somaxconn=%v. Using NGINX default (511)", maxConns)
 		return 511
 	}
 

--- a/ingress/controllers/nginx/rc.yaml
+++ b/ingress/controllers/nginx/rc.yaml
@@ -74,7 +74,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10249
+            port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5

--- a/ingress/controllers/nginx/utils.go
+++ b/ingress/controllers/nginx/utils.go
@@ -119,6 +119,10 @@ func getPodDetails(kubeClient *unversioned.Client) (*podInfo, error) {
 	podName := os.Getenv("POD_NAME")
 	podNs := os.Getenv("POD_NAMESPACE")
 
+	if podName == "" && podNs == "" {
+		return nil, fmt.Errorf("unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable")
+	}
+
 	err := waitForPodRunning(kubeClient, podNs, podName, time.Millisecond*200, time.Second*30)
 	if err != nil {
 		return nil, err
@@ -126,7 +130,7 @@ func getPodDetails(kubeClient *unversioned.Client) (*podInfo, error) {
 
 	pod, _ := kubeClient.Pods(podNs).Get(podName)
 	if pod == nil {
-		return nil, fmt.Errorf("Unable to get POD information")
+		return nil, fmt.Errorf("unable to get POD information")
 	}
 
 	node, err := kubeClient.Nodes().Get(pod.Spec.NodeName)


### PR DESCRIPTION
fixes #1459

Running with `docker run`:

```
core@localhost ~ $ docker run -it aledbf/nginx-third-party:0.31 bash
root@f6a96f46eab0:/# export KUBERNETES_MASTER=http://172.17.4.99:8080
root@f6a96f46eab0:/# /nginx-ingress-controller --default-backend-service=default/nginx-errors
I0802 14:44:58.604384       7 main.go:94] Using build: https://github.com/aledbf/contrib - git-5b9146a
W0802 14:44:58.605282       7 main.go:118] unexpected error getting runtime information: unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable)
I0802 14:44:58.607270       7 main.go:123] Validated default/nginx-errors as the default backend
W0802 14:44:58.611322       7 ssl.go:132] no file dhparam.pem found in secrets
I0802 14:44:58.615637       7 controller.go:1128] starting NGINX loadbalancer controller
I0802 14:44:58.615902       7 command.go:35] Starting NGINX process...
```

Running inside in a cluster:

```
I0802 14:47:50.254736       1 main.go:94] Using build: https://github.com/aledbf/contrib - git-5b9146a
I0802 14:47:50.254920       1 merged_client_builder.go:103] No kubeconfig could be created, falling back to service account.
I0802 14:47:50.343440       1 main.go:123] Validated default/nginx-errors as the default backend
W0802 14:47:50.343677       1 ssl.go:132] no file dhparam.pem found in secrets
I0802 14:47:50.347322       1 controller.go:1128] starting NGINX loadbalancer controller
I0802 14:47:50.347870       1 command.go:35] Starting NGINX process...
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1467)

<!-- Reviewable:end -->
