### PR TITLE
Adding submit-queue munger to the contrib deployment.

### DIFF
--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -7,7 +7,7 @@ data:
   config.http-cache-dir: /cache/httpcache
   config.organization: kubernetes
   config.project: contrib
-  config.pr-mungers: blunderbuss,size
+  config.pr-mungers: blunderbuss,submit-queue
   config.state: open
   config.token-file: /etc/secret-volume/token
   gitrepo.repo-dir: /gitrepos
@@ -16,7 +16,7 @@ data:
   test-options.required-retest-contexts: "\"\""
 
   # submit-queue options.
-  submit-queue.required-contexts: "\"\""
+  submit-queue.required-contexts: "continuous-integration/travis-ci/pr"
   submit-queue.nonblocking-jenkins-jobs: "\"\""
   submit-queue.jenkins-jobs: "\"\""
   submit-queue.presubmit-jobs: "\"\""


### PR DESCRIPTION
The check-labels munger (https://github.com/kubernetes/contrib/pull/1306) needs to be merged before, so that it can create the necessary labels.

Also adding the submit-queue munger to the deployment to enable automatic merging of PRs with LGTM, after they pass CI tests.
