### PR TITLE
Deployment flag to control owners embedded in md.

### DIFF
--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -184,6 +184,7 @@ func (o *RepoInfo) updateRepoUsers() error {
 // Initialize will initialize the munger
 func (o *RepoInfo) Initialize(config *github.Config) error {
 	glog.Infof("repo-dir: %#v\n", o.baseDir)
+	glog.Infof("enable-md-yaml: %#v\n", o.enableMdYaml)
 
 	o.enabled = true
 	o.config = config

--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -43,6 +43,7 @@ spec:
         - --generated-files-config=$(GENERATED_FILES_CONFIG)
         - --chart-url=$(CHART_URL)
         - --history-url=$(HISTORY_URL)
+        - --enable-md-yaml=$(ENABLE_MD_YAML)
         image: gcr.io/google_containers/submit-queue:2016-05-24-86f86cd
         env:
           - name: HTTP_CACHE_DIR
@@ -150,6 +151,11 @@ spec:
               configMapKeyRef:
                 name: @@-sq-config
                 key: gitrepo.repo-dir
+          - name: ENABLE_MD_YAML
+            valueFrom:
+              configMapKeyRef:
+                name: @@-sq-config
+                key: gitrepo.enable-md-yaml
           - name: TEST_OWNERS_CSV
             valueFrom:
               configMapKeyRef:

--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -11,6 +11,7 @@ data:
   config.state: open
   config.token-file: /etc/secret-volume/token
   gitrepo.repo-dir: /gitrepos
+  gitrepo.enable-md-yaml: "false"
 
   # test-options feature options.
   test-options.required-retest-contexts: "\"\""

--- a/mungegithub/submit-queue/deployment/docs/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/docs/configmap.yaml
@@ -11,6 +11,7 @@ data:
   config.state: open
   config.token-file: /etc/secret-volume/token
   gitrepo.repo-dir: /gitrepos
+  gitrepo.enable-md-yaml: "true"
 
   # test-options feature options.
   test-options.required-retest-contexts: "\"\""

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -35,6 +35,7 @@ data:
   path-label.path-label-config: path-label.txt
   block-path.block-path-config: block-path.yaml
   gitrepo.repo-dir: /gitrepos
+  gitrepo.enable-md-yaml: "false"
   flake-manager.test-owners-csv: /gitrepos/kubernetes/test/test_owners.csv
   old-test-getter.number-of-old-test-results: "5"
   assign-fixes.fixes-issue-reassign: "false"


### PR DESCRIPTION
The docs repository reads owners from the front-matter in markdown
files as well as dedicated OWNERS files.

cc @pwittrock @lavalamp 
