### PR TITLE
Adding lgtm-after-commit munger to contrib

### DIFF
--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -7,7 +7,7 @@ data:
   config.http-cache-dir: /cache/httpcache
   config.organization: kubernetes
   config.project: contrib
-  config.pr-mungers: blunderbuss,submit-queue
+  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue
   config.state: open
   config.token-file: /etc/secret-volume/token
   gitrepo.repo-dir: /gitrepos


### PR DESCRIPTION
This munger removes LGTM if commits are pushed after LGTM label was applied.
