### PR TITLE
Cluster-autoscaler: max node total count flag for CIDR

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -56,6 +56,7 @@ last-release-pr
 left-build-number
 max-pr-number
 max-sync-failures
+max-nodes-total
 min-pr-number
 network-config
 nonblocking-jenkins-jobs


### PR DESCRIPTION
In some cases we cannot grow the cluster beyond a certain number of nodes. This PR adds a flag to pass this value + appropriate handling in scale up. The cluster won't be forcefully scaled down to meet the passed value.

cc: @piosz @fgrzadkowski 
