### PR TITLE
submit-queue: Display uncached request count to github API

### DIFF
--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -224,6 +224,7 @@
                             <th order-by="$key" name="Call"></th>
                             <th order-by="Count" name="Count ({{ cntl.botStats.APICount }})" numeric descend-first></th>
                             <th order-by="CachedCount" name="Cached Count ({{ cntl.botStats.CachedAPICount }})" numeric descend-first></th>
+                            <th order-by="UncachedCount" name="Uncached Count ({{ cntl.botStats.UncachedAPICount }})" numeric descend-first></th>
                           </tr>
                         </thead>
                         <tbody>
@@ -231,6 +232,7 @@
                             <td>{{stat.$key}}</td>
                             <td>{{stat.Count}}</td>
                             <td>{{stat.CachedCount}}</td>
+                            <td>{{stat.UncachedCount}}</td>
                           </tr>
                         </tbody>
                       </table>

--- a/mungegithub/submit-queue/www/script.js
+++ b/mungegithub/submit-queue/www/script.js
@@ -168,6 +168,11 @@ function SQCntl(dataService, $interval, $location) {
   function refreshBotStats() {
     dataService.getData('stats').then(function successCallback(response) {
       self.botStats = response.data;
+      for (var key in self.botStats.Analytics) {
+        var analytic = self.botStats.Analytics[key];
+        analytic.UncachedCount = analytic.Count - analytic.CachedCount;
+      }
+      self.botStats.UncachedAPICount = self.botStats.APICount - self.botStats.CachedAPICount;
     });
   }
 


### PR DESCRIPTION
We currently display number of total requests to github API, and number
of cached requests. Let's print number of uncached request as this is
the number that matters the most.
