### PR TITLE
[Experimental] Getting PR lists instead of one

### DIFF
--- a/mungegithub/mungegithub.go
+++ b/mungegithub/mungegithub.go
@@ -59,6 +59,7 @@ func doMungers(config *mungeConfig) error {
 		glog.Infof("Running mungers")
 		config.NextExpectedUpdate(nextRunStartTime)
 
+		config.Config.EachLoop()
 		config.Features.EachLoop()
 		mungers.EachLoop()
 


### PR DESCRIPTION
Breaks the bot right now due to the absence of information in the PR list about:

- mergeable (submit-queue)
- merged (submit-queue)
- additions/deletions (size)