### PR TITLE
More central and readable logging of mungegithub command-line options

### DIFF
--- a/mungegithub/features/google-cloud-storage.go
+++ b/mungegithub/features/google-cloud-storage.go
@@ -19,7 +19,6 @@ package features
 import (
 	"k8s.io/contrib/mungegithub/github"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
@@ -53,11 +52,6 @@ func (g *GCSInfo) Name() string {
 
 // Initialize will initialize the feature.
 func (g *GCSInfo) Initialize(config *github.Config) error {
-	glog.Infof("gcs-bucket: %#v\n", g.BucketName)
-	glog.Infof("gcs-logs-dir: %#v\n", g.LogDir)
-	glog.Infof("pull-logs-dir: %#v\n", g.PullLogDir)
-	glog.Infof("pull-key: %#v\n", g.PullKey)
-
 	return nil
 }
 

--- a/mungegithub/features/test-options.go
+++ b/mungegithub/features/test-options.go
@@ -19,7 +19,6 @@ package features
 import (
 	"k8s.io/contrib/mungegithub/github"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +44,6 @@ func (t *TestOptions) Name() string {
 
 // Initialize will initialize the feature.
 func (t *TestOptions) Initialize(config *github.Config) error {
-	glog.Infof("required-retest-contexts: %#v\n", t.RequiredRetestContexts)
 	return nil
 }
 

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -143,10 +143,10 @@ type Config struct {
 	Org      string
 	Project  string
 
-	state  string
-	labels []string
+	State  string
+	Labels []string
 
-	Token     string
+	token     string
 	TokenFile string
 
 	Address string // if a munger runs a web server, where it should live
@@ -300,15 +300,15 @@ func TestObject(config *Config, issue *github.Issue, pr *github.PullRequest, com
 
 // AddRootFlags will add all of the flags needed for the github config to the cobra command
 func (config *Config) AddRootFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&config.Token, "token", "", "The OAuth Token to use for requests.")
+	cmd.PersistentFlags().StringVar(&config.token, "token", "", "The OAuth Token to use for requests.")
 	cmd.PersistentFlags().StringVar(&config.TokenFile, "token-file", "", "The file containing the OAuth Token to use for requests.")
 	cmd.PersistentFlags().IntVar(&config.MinPRNumber, "min-pr-number", 0, "The minimum PR to start with")
 	cmd.PersistentFlags().IntVar(&config.MaxPRNumber, "max-pr-number", maxInt, "The maximum PR to start with")
 	cmd.PersistentFlags().BoolVar(&config.DryRun, "dry-run", true, "If true, don't actually merge anything")
 	cmd.PersistentFlags().StringVar(&config.Org, "organization", "", "The github organization to scan")
 	cmd.PersistentFlags().StringVar(&config.Project, "project", "", "The github project to scan")
-	cmd.PersistentFlags().StringVar(&config.state, "state", "", "State of PRs to process: 'open', 'all', etc")
-	cmd.PersistentFlags().StringSliceVar(&config.labels, "labels", []string{}, "CSV list of label which should be set on processed PRs. Unset is all labels.")
+	cmd.PersistentFlags().StringVar(&config.State, "state", "", "State of PRs to process: 'open', 'all', etc")
+	cmd.PersistentFlags().StringSliceVar(&config.Labels, "labels", []string{}, "CSV list of label which should be set on processed PRs. Unset is all labels.")
 	cmd.PersistentFlags().StringVar(&config.Address, "address", ":8080", "The address to listen on for HTTP Status")
 	cmd.PersistentFlags().StringVar(&config.WWWRoot, "www", "www", "Path to static web files to serve from the webserver")
 	cmd.PersistentFlags().StringVar(&config.HTTPCacheDir, "http-cache-dir", "", "Path to directory where github data can be cached across restarts, if unset use in memory cache")
@@ -319,20 +319,6 @@ func (config *Config) AddRootFlags(cmd *cobra.Command) {
 // PreExecute will initialize the Config. It MUST be run before the config
 // may be used to get information from Github
 func (config *Config) PreExecute() error {
-	glog.Infof("token: %#v\n", config.Token)
-	glog.Infof("token-file: %#v\n", config.TokenFile)
-	glog.Infof("min-pr-number: %#v\n", config.MinPRNumber)
-	glog.Infof("max-pr-number: %#v\n", config.MaxPRNumber)
-	glog.Infof("dry-run: %#v\n", config.DryRun)
-	glog.Infof("organization: %#v\n", config.Org)
-	glog.Infof("project: %#v\n", config.Project)
-	glog.Infof("state: %#v\n", config.state)
-	glog.Infof("labels: %#v\n", config.labels)
-	glog.Infof("address: %#v\n", config.Address)
-	glog.Infof("www: %#v\n", config.WWWRoot)
-	glog.Infof("http-cache-dir: %#v\n", config.HTTPCacheDir)
-	glog.Infof("http-cache-size: %#v\n", config.HTTPCacheSize)
-
 	if len(config.Org) == 0 {
 		glog.Fatalf("--organization is required.")
 	}
@@ -340,7 +326,7 @@ func (config *Config) PreExecute() error {
 		glog.Fatalf("--project is required.")
 	}
 
-	token := config.Token
+	token := config.token
 	if len(token) == 0 && len(config.TokenFile) != 0 {
 		data, err := ioutil.ReadFile(config.TokenFile)
 		if err != nil {
@@ -1699,8 +1685,8 @@ func (config *Config) ForEachIssueDo(fn MungeFunction) error {
 		glog.V(4).Infof("Fetching page %d of issues", page)
 		listOpts := &github.IssueListByRepoOptions{
 			Sort:        "created",
-			State:       config.state,
-			Labels:      config.labels,
+			State:       config.State,
+			Labels:      config.Labels,
 			Direction:   "asc",
 			ListOptions: github.ListOptions{PerPage: 100, Page: page},
 		}

--- a/mungegithub/mungegithub.go
+++ b/mungegithub/mungegithub.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"k8s.io/contrib/mungegithub/mungers/mungerutil"
 )
 
 var (
@@ -86,11 +87,7 @@ func main() {
 		Use:   filepath.Base(os.Args[0]),
 		Short: "A program to add labels, check tests, and generally mess with outstanding PRs",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			glog.Infof("once: %#v\n", config.Once)
-			glog.Infof("pr-mungers: %#v\n", config.PRMungersList)
-			glog.Infof("issue-reports: %#v\n", config.IssueReportsList)
-			glog.Infof("period: %#v\n", config.Period)
-
+			glog.Info(mungerutil.PrettyString(config))
 			if err := config.PreExecute(); err != nil {
 				return err
 			}

--- a/mungegithub/mungers/assign-fixes.go
+++ b/mungegithub/mungers/assign-fixes.go
@@ -29,7 +29,7 @@ import (
 type AssignFixesMunger struct {
 	config              *github.Config
 	features            *features.Features
-	assignfixesReassign bool
+	AssignfixesReassign bool
 }
 
 func init() {
@@ -45,8 +45,6 @@ func (a *AssignFixesMunger) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (a *AssignFixesMunger) Initialize(config *github.Config, features *features.Features) error {
-	glog.Infof("fixes-issue-reassign: %#v\n", a.assignfixesReassign)
-
 	a.features = features
 	a.config = config
 	return nil
@@ -57,7 +55,7 @@ func (a *AssignFixesMunger) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (a *AssignFixesMunger) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().BoolVar(&a.assignfixesReassign, "fixes-issue-reassign", false, "Assign fixes Issues even if they're already assigned")
+	cmd.Flags().BoolVar(&a.AssignfixesReassign, "fixes-issue-reassign", false, "Assign fixes Issues even if they're already assigned")
 }
 
 // Munge is the workhorse the will actually make updates to the PR
@@ -85,8 +83,8 @@ func (a *AssignFixesMunger) Munge(obj *github.MungeObject) {
 			continue
 		}
 		issue := issueObj.Issue
-		if !a.assignfixesReassign && issue.Assignee != nil {
-			glog.V(6).Infof("skipping %v: reassign: %v assignee: %v", *issue.Number, a.assignfixesReassign, github.DescribeUser(issue.Assignee))
+		if !a.AssignfixesReassign && issue.Assignee != nil {
+			glog.V(6).Infof("skipping %v: reassign: %v assignee: %v", *issue.Number, a.AssignfixesReassign, github.DescribeUser(issue.Assignee))
 			continue
 		}
 		glog.Infof("Assigning %v to %v (previously assigned to %v)", *issue.Number, prOwner, github.DescribeUser(issue.Assignee))

--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -47,7 +47,7 @@ type configBlockPath struct {
 
 // BlockPath will add a label to block auto merge if a PR touches certain paths
 type BlockPath struct {
-	path             string
+	Path             string
 	blockRegexp      []regexp.Regexp
 	doNotBlockRegexp []regexp.Regexp
 }
@@ -66,12 +66,10 @@ func (b *BlockPath) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (b *BlockPath) Initialize(config *github.Config, features *features.Features) error {
-	glog.Infof("block-path-config: %#v\n", b.path)
-
-	if len(b.path) == 0 {
+	if len(b.Path) == 0 {
 		glog.Fatalf("--block-path-config is required with the block-path munger")
 	}
-	file, err := os.Open(b.path)
+	file, err := os.Open(b.Path)
 	if err != nil {
 		glog.Fatalf("Failed to load block-path config: %v", err)
 	}
@@ -107,7 +105,7 @@ func (b *BlockPath) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (b *BlockPath) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().StringVar(&b.path, "block-path-config", "", "file containing the pathnames to block or not block")
+	cmd.Flags().StringVar(&b.Path, "block-path-config", "", "file containing the pathnames to block or not block")
 }
 
 func matchesAny(path string, regs []regexp.Regexp) bool {

--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -40,7 +40,7 @@ type BlunderbussConfig struct {
 type BlunderbussMunger struct {
 	config              *BlunderbussConfig
 	features            *features.Features
-	blunderbussReassign bool
+	BlunderbussReassign bool
 }
 
 func init() {
@@ -56,8 +56,6 @@ func (b *BlunderbussMunger) RequiredFeatures() []string { return []string{featur
 
 // Initialize will initialize the munger
 func (b *BlunderbussMunger) Initialize(config *github.Config, features *features.Features) error {
-	glog.Infof("blunderbuss-reassign: %#v\n", b.blunderbussReassign)
-
 	b.features = features
 	return nil
 }
@@ -67,7 +65,7 @@ func (b *BlunderbussMunger) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (b *BlunderbussMunger) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().BoolVar(&b.blunderbussReassign, "blunderbuss-reassign", false, "Assign PRs even if they're already assigned; use with -dry-run to judge changes to the assignment algorithm")
+	cmd.Flags().BoolVar(&b.BlunderbussReassign, "blunderbuss-reassign", false, "Assign PRs even if they're already assigned; use with -dry-run to judge changes to the assignment algorithm")
 }
 
 func chance(val, total int64) float64 {
@@ -91,8 +89,8 @@ func (b *BlunderbussMunger) Munge(obj *github.MungeObject) {
 	}
 
 	issue := obj.Issue
-	if !b.blunderbussReassign && issue.Assignee != nil {
-		glog.V(6).Infof("skipping %v: reassign: %v assignee: %v", *issue.Number, b.blunderbussReassign, github.DescribeUser(issue.Assignee))
+	if !b.BlunderbussReassign && issue.Assignee != nil {
+		glog.V(6).Infof("skipping %v: reassign: %v assignee: %v", *issue.Number, b.BlunderbussReassign, github.DescribeUser(issue.Assignee))
 		return
 	}
 

--- a/mungegithub/mungers/check-labels.go
+++ b/mungegithub/mungers/check-labels.go
@@ -41,7 +41,7 @@ type labelAccessor interface {
 // CheckLabelsMunger will check that the labels specified in the labels yaml file
 // are created.
 type CheckLabelsMunger struct {
-	labelFilePath string
+	LabelFilePath string
 	prevHash      string
 	labelAccessor labelAccessor
 	features      *features.Features
@@ -60,20 +60,20 @@ func (c *CheckLabelsMunger) RequiredFeatures() []string { return []string{featur
 
 // Initialize will initialize the munger.
 func (c *CheckLabelsMunger) Initialize(config *githubhelper.Config, features *features.Features) error {
-	if len(c.labelFilePath) == 0 {
+	if len(c.LabelFilePath) == 0 {
 		glog.Fatalf("No --label-file= supplied, cannot check labels")
 	}
 	c.labelAccessor = config
 	c.features = features
 	c.readFunc = func() ([]byte, error) {
-		bytes, err := ioutil.ReadFile(c.labelFilePath)
+		bytes, err := ioutil.ReadFile(c.LabelFilePath)
 		if err != nil {
 			return []byte{}, fmt.Errorf("Unable to read label file: %v", err)
 		}
 		return bytes, nil
 	}
 
-	if _, err := os.Stat(c.labelFilePath); os.IsNotExist(err) {
+	if _, err := os.Stat(c.LabelFilePath); os.IsNotExist(err) {
 		return fmt.Errorf("Failed to stat the check label config: %v", err)
 	}
 
@@ -134,7 +134,7 @@ func (c *CheckLabelsMunger) addMissingLabels(repoLabels, fileLabels []*github.La
 
 // AddFlags will add any request flags to the cobra `cmd`.
 func (c *CheckLabelsMunger) AddFlags(cmd *cobra.Command, config *githubhelper.Config) {
-	cmd.Flags().StringVar(&c.labelFilePath, "label-file", "", "Path from repository root to file containing"+
+	cmd.Flags().StringVar(&c.LabelFilePath, "label-file", "", "Path from repository root to file containing"+
 		" list of labels")
 }
 

--- a/mungegithub/mungers/flake-manager.go
+++ b/mungegithub/mungers/flake-manager.go
@@ -53,14 +53,13 @@ type issueFinder interface {
 
 // FlakeManager files issues for flaky tests.
 type FlakeManager struct {
+	OwnerPath            string
 	finder               issueFinder
 	sq                   *SubmitQueue
 	config               *github.Config
 	googleGCSBucketUtils *utils.Utils
-
-	syncer    *sync.IssueSyncer
-	ownerPath string
-	features  *features.Features
+	syncer               *sync.IssueSyncer
+	features             *features.Features
 }
 
 func init() {
@@ -75,8 +74,6 @@ func (p *FlakeManager) RequiredFeatures() []string { return []string{features.GC
 
 // Initialize will initialize the munger
 func (p *FlakeManager) Initialize(config *github.Config, features *features.Features) error {
-	glog.Infof("test-owners-csv: %#v\n", p.ownerPath)
-
 	// TODO: don't get the mungers from the global list, they should be passed in...
 	for _, m := range GetAllMungers() {
 		if m.Name() == "issue-cacher" {
@@ -100,8 +97,8 @@ func (p *FlakeManager) Initialize(config *github.Config, features *features.Feat
 
 	var owner sync.OwnerMapper
 	var err error
-	if p.ownerPath != "" {
-		owner, err = testowner.NewReloadingOwnerList(p.ownerPath)
+	if p.OwnerPath != "" {
+		owner, err = testowner.NewReloadingOwnerList(p.OwnerPath)
 		if err != nil {
 			return err
 		}
@@ -128,7 +125,7 @@ func (p *FlakeManager) EachLoop() error {
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (p *FlakeManager) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().StringVar(&p.ownerPath, "test-owners-csv", "", "file containing a CSV-exported test-owners spreadsheet")
+	cmd.Flags().StringVar(&p.OwnerPath, "test-owners-csv", "", "file containing a CSV-exported test-owners spreadsheet")
 }
 
 // Munge is unused by this munger.

--- a/mungegithub/mungers/mungers.go
+++ b/mungegithub/mungers/mungers.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"k8s.io/contrib/mungegithub/mungers/mungerutil"
 )
 
 // Munger is the interface which all mungers must implement to register
@@ -88,6 +89,7 @@ func InitializeMungers(config *github.Config, features *features.Features) error
 		if err := munger.Initialize(config, features); err != nil {
 			return err
 		}
+		glog.Infof(mungerutil.PrettyString(munger))
 		glog.Infof("Initialized munger: %s", munger.Name())
 	}
 	return nil

--- a/mungegithub/mungers/mungerutil/pretty.go
+++ b/mungegithub/mungers/mungerutil/pretty.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungerutil
+
+import (
+	"encoding/json"
+	"github.com/golang/glog"
+)
+
+// PrettyMarshal creates pretty marshaled bytes from a structure.
+func PrettyMarshal(data interface{}) []byte {
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		glog.Errorf("Unable to Marshal data: %#v: %v", data, err)
+		return nil
+	}
+	return b
+}
+
+// PrettyString is used by logging functions to get a readable version of a struct.
+func PrettyString(data interface{}) string {
+	return string(PrettyMarshal(data))
+}

--- a/mungegithub/mungers/path_label.go
+++ b/mungegithub/mungers/path_label.go
@@ -48,9 +48,9 @@ type labelMap struct {
 // PathLabelMunger will add labels to PRs based on what files it modified.
 // The mapping of files to labels if provided in a file in --path-label-config
 type PathLabelMunger struct {
+	PathLabelFile string
 	labelMap      []labelMap
 	allLabels     sets.String
-	pathLabelFile string
 }
 
 func init() {
@@ -65,11 +65,9 @@ func (p *PathLabelMunger) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (p *PathLabelMunger) Initialize(config *github.Config, features *features.Features) error {
-	glog.Infof("path-label-config: %#v\n", p.pathLabelFile)
-
 	allLabels := sets.NewString()
 	out := []labelMap{}
-	file := p.pathLabelFile
+	file := p.PathLabelFile
 	if len(file) == 0 {
 		glog.Infof("No --path-label-config= supplied, applying no labels")
 		return nil
@@ -117,7 +115,7 @@ func (p *PathLabelMunger) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (p *PathLabelMunger) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().StringVar(&p.pathLabelFile, "path-label-config", "", "file containing the pathname to label mappings")
+	cmd.Flags().StringVar(&p.PathLabelFile, "path-label-config", "", "file containing the pathname to label mappings")
 }
 
 // Munge is the workhorse the will actually make updates to the PR

--- a/mungegithub/mungers/path_label_test.go
+++ b/mungegithub/mungers/path_label_test.go
@@ -152,7 +152,7 @@ func TestPathLabelMunge(t *testing.T) {
 		config.SetClient(client)
 
 		p := PathLabelMunger{}
-		p.pathLabelFile = "../path-label.txt"
+		p.PathLabelFile = "../path-label.txt"
 		err := p.Initialize(config, nil)
 		if err != nil {
 			t.Fatalf("%v", err)

--- a/mungegithub/mungers/size.go
+++ b/mungegithub/mungers/size.go
@@ -44,7 +44,7 @@ var (
 // It will exclude certain files in it's calculations based on the config
 // file provided in --generated-files-config
 type SizeMunger struct {
-	generatedFilesFile string
+	GeneratedFilesFile string
 	genFiles           *sets.String
 	genPrefixes        *[]string
 }
@@ -63,7 +63,7 @@ func (SizeMunger) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (s *SizeMunger) Initialize(config *github.Config, features *features.Features) error {
-	glog.Infof("generated-files-config: %#v\n", s.generatedFilesFile)
+	glog.Infof("generated-files-config: %#v\n", s.GeneratedFilesFile)
 
 	return nil
 }
@@ -73,7 +73,7 @@ func (SizeMunger) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (s *SizeMunger) AddFlags(cmd *cobra.Command, config *github.Config) {
-	cmd.Flags().StringVar(&s.generatedFilesFile, "generated-files-config", "", "file containing the pathname to label mappings")
+	cmd.Flags().StringVar(&s.GeneratedFilesFile, "generated-files-config", "", "file containing the pathname to label mappings")
 }
 
 // getGeneratedFiles returns a list of all automatically generated files in the repo. These include
@@ -93,7 +93,7 @@ func (s *SizeMunger) getGeneratedFiles(obj *github.MungeObject) {
 	s.genFiles = &files
 	s.genPrefixes = &prefixes
 
-	file := s.generatedFilesFile
+	file := s.GeneratedFilesFile
 	if len(file) == 0 {
 		glog.Infof("No --generated-files-config= supplied, applying no labels")
 		return

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -196,7 +196,7 @@ func getTestSQ(startThreads bool, config *github_util.Config, server *httptest.S
 	sq.startTime = sq.clock.Now()
 	sq.healthHistory = make([]healthRecord, 0)
 
-	sq.doNotMergeMilestones = []string{doNotMergeMilestone}
+	sq.DoNotMergeMilestones = []string{doNotMergeMilestone}
 
 	sq.e2e = &fake_e2e.FakeE2ETester{
 		JobNames:           sq.BlockingJobNames,


### PR DESCRIPTION
People often forget to log new command-line options as they are added because the two were decoupled. This change would let us log entire
structs **as long as the required fields are exported** (which is a bit contentious because we are breaking encapsulation).

With this change, we'd get logging of options that looks a lot nicer as well:

```
I0806 22:28:27.669612   90248 mungegithub.go:90] {
  "Org": "foxish",
  "Project": "test-repo",
  "Token": "",
  "TokenFile": "./.token",
  "Address": ":8080",
  "WWWRoot": "submit-queue/www/",
  "HTTPCacheDir": "",
  "HTTPCacheSize": 1000,
  "MinPRNumber": 0,
  "MaxPRNumber": 9223372036854775807,
  "DryRun": true,
  "PendingWaitTime": null,
  "MinIssueNumber": 0,
  "PRMungersList": [
    "submit-queue"
  ],
  "IssueReportsList": [],
  "Once": false,
  "Period": 10000000000,
  "Repos": null,
  "GCSInfo": null,
  "TestOptions": null
}
I0806 22:28:27.669698   90248 github.go:224] Made 0 API calls since the last Reset 0.000000 calls/sec
I0806 22:28:27.669769   90248 features.go:54] Initializing feature: google-cloud-storage
I0806 22:28:27.669777   90248 features.go:54] Initializing feature: test-options
I0806 22:28:27.669862   90248 mungers.go:92] {
  "BlockingJobNames": [],
  "NonBlockingJobNames": [],
  "PresubmitJobNames": [],
  "WeakStableJobNames": [],
  "FakeE2E": false,
  "Committers": "",
  "RequiredStatusContexts": [
    "continuous-integration/travis-ci/pr"
  ],
  "DoNotMergeMilestones": [],
  "RequiredRetestContexts": [],
  "RetestBody": "@k8s-bot test this [submit-queue is verifying that this PR is safe to merge]",
  "Metadata": {
    "ProjectName": "Test-Repo",
    "ChartUrl": "",
    "HistoryUrl": "",
    "RepoPullUrl": "https://github.com/foxish/test-repo/pulls/"
  }
}
```

as opposed to what we currently have:

```
I0806 22:26:57.506125   88136 google-cloud-storage.go:56] gcs-bucket: ""
I0806 22:26:57.506140   88136 google-cloud-storage.go:57] gcs-logs-dir: ""
I0806 22:26:57.506155   88136 google-cloud-storage.go:58] pull-logs-dir: ""
I0806 22:26:57.506169   88136 google-cloud-storage.go:59] pull-key: ""
I0806 22:26:57.506183   88136 features.go:54] Initializing feature: test-options
I0806 22:26:57.506198   88136 test-options.go:48] required-retest-contexts: []string{""}
I0806 22:26:57.506224   88136 submit-queue.go:381] jenkins-jobs: []string{}
I0806 22:26:57.506239   88136 submit-queue.go:382] nonblocking-jenkins-jobs: []string{}
I0806 22:26:57.506254   88136 submit-queue.go:383] presubmit-jobs: []string{}
I0806 22:26:57.506269   88136 submit-queue.go:384] weak-stable-jobs: []string{}
I0806 22:26:57.506284   88136 submit-queue.go:385] required-contexts: []string{"continuous-integration/travis-ci/pr"}
I0806 22:26:57.506302   88136 submit-queue.go:386] required-retest-contexts: []string{}
I0806 22:26:57.506317   88136 submit-queue.go:387] do-not-merge-milestones: []string{}
I0806 22:26:57.506332   88136 submit-queue.go:388] admin-port: 9999
I0806 22:26:57.506350   88136 submit-queue.go:389] retest-body: "@k8s-bot test this [submit-queue is verifying that this PR is safe to merge]"
I0806 22:26:57.506368   88136 submit-queue.go:390] fake-e2e: false
I0806 22:26:57.506383   88136 submit-queue.go:391] chart-url: ""
I0806 22:26:57.506399   88136 submit-queue.go:392] history-url: ""
```
