### PR TITLE
Correctly handle ingress.class in GCE controller 

### DIFF
--- a/ingress/controllers/gce/Makefile
+++ b/ingress/controllers/gce/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG = 0.7.0
+TAG = 0.7.1
 PREFIX = gcr.io/google_containers/glbc
 
 server:

--- a/ingress/controllers/gce/controller/utils.go
+++ b/ingress/controllers/gce/controller/utils.go
@@ -188,7 +188,10 @@ type StoreToIngressLister struct {
 // List lists all Ingress' in the store.
 func (s *StoreToIngressLister) List() (ing extensions.IngressList, err error) {
 	for _, m := range s.Store.List() {
-		ing.Items = append(ing.Items, *(m.(*extensions.Ingress)))
+		newIng := m.(*extensions.Ingress)
+		if isGCEIngress(newIng) {
+			ing.Items = append(ing.Items, *newIng)
+		}
 	}
 	return ing, nil
 }


### PR DESCRIPTION
This bug would only get activated when a user has both `ingess.class=gce` and `ingress.class=nginx` ingresses active in the same GCE/GKE cluster, and would manifest as a set of cloud resources created wastefully for the `ingress.class=nginx` ingress as well.

We were previously only ignoring ingress.class (documented here: https://github.com/kubernetes/contrib/blob/master/ingress/controllers/gce/BETA_LIMITATIONS.md#disabling-glbc) when the ingress was created/deleted/modified. There's a chance another ingress with the correct class results in us entering the `sync` routine and listing all ingresses. The listing routine was not smart enough to ignore `ingress.class=nginx`, so we ended up creating resources for the nginx ingress anyway. 

The second commit fixes some of the nginx examples to include a `readiness` probe that is == liveness probe. 

Minhan or Girish, whichever one has spare cycles first. 
