### PR TITLE
Do not retest if retest-not-required is applied

### DIFF
--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -82,6 +82,10 @@ func (s *StaleGreenCI) Munge(obj *github.MungeObject) {
 		return
 	}
 
+	if obj.HasLabel(retestNotRequiredLabel) || obj.HasLabel(retestNotRequiredDocsOnlyLabel) {
+		return
+	}
+
 	if mergeable, err := obj.IsMergeable(); !mergeable || err != nil {
 		return
 	}


### PR DESCRIPTION
When a PR hasn't been tested in a while, it is retested by the bot.
This behavior also happens when the PR has the label retest-not-required
or retest-not-required-docs-only, because the label is initially meant
for the submit-queue. Let's not retest if it's not required.
