### PR TITLE
Use 'do-not-merge' instead of removing 'lgtm' with the release-note process

### DIFF
--- a/mungegithub/mungers/lgtm_after_commit.go
+++ b/mungegithub/mungers/lgtm_after_commit.go
@@ -99,10 +99,10 @@ func (LGTMAfterCommitMunger) isStaleComment(obj *github.MungeObject, comment *gi
 	if !lgtmRemovedRegex.MatchString(*comment.Body) {
 		return false
 	}
-	if !obj.HasLabel("lgtm") {
+	if !obj.HasLabel(lgtmLabel) {
 		return false
 	}
-	lgtmTime := obj.LabelTime("lgtm")
+	lgtmTime := obj.LabelTime(lgtmLabel)
 	if lgtmTime == nil {
 		return false
 	}

--- a/mungegithub/mungers/rebuild.go
+++ b/mungegithub/mungers/rebuild.go
@@ -109,11 +109,6 @@ func (r *RebuildMunger) Munge(obj *github.MungeObject) {
 				glog.Errorf("unexpected error adding comment: %v", err)
 				continue
 			}
-			if obj.HasLabel(lgtmLabel) {
-				if err := obj.RemoveLabel(lgtmLabel); err != nil {
-					glog.Errorf("unexpected error removing lgtm label: %v", err)
-				}
-			}
 		}
 	}
 }

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -36,7 +36,7 @@ const (
 	releaseNoteActionRequired = "release-note-action-required"
 	releaseNoteExperimental   = "release-note-experimental"
 
-	releaseNoteFormat = `Removing LGTM because the release note process has not been followed.
+	releaseNoteFormat = `Adding ` + doNotMergeLabel + ` because the release note process has not been followed.
 One of the following labels is required %q, %q, %q or %q.
 Please see: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes.`
 	parentReleaseNoteFormat = `The 'parent' PR of a cherry-pick PR must have one of the %q or %q labels, or this PR must follow the standard/parent release note labeling requirement. (release-note-experimental must be explicit for cherry-picks)`
@@ -47,8 +47,8 @@ var (
 	parentReleaseNoteBody = fmt.Sprintf(parentReleaseNoteFormat, releaseNote, releaseNoteActionRequired)
 )
 
-// ReleaseNoteLabel will remove the LGTM label from an PR which has not
-// set one of the appropriete 'release-note-*' labels.
+// ReleaseNoteLabel will add the doNotMergeLabel to a PR which has not
+// set one of the appropriete 'release-note-*' labels but has LGTM
 type ReleaseNoteLabel struct {
 	config *github.Config
 }
@@ -133,8 +133,12 @@ func (r *ReleaseNoteLabel) Munge(obj *github.MungeObject) {
 		return
 	}
 
+	if obj.HasLabel(doNotMergeLabel) {
+		return
+	}
+
 	obj.WriteComment(releaseNoteBody)
-	obj.RemoveLabel(lgtmLabel)
+	obj.AddLabel(doNotMergeLabel)
 }
 
 func completedReleaseNoteProcess(obj *github.MungeObject) bool {

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -49,39 +49,39 @@ func TestReleaseNoteLabel(t *testing.T) {
 	}{
 		{
 			name:        "LGTM with release-note",
-			issue:       github_test.Issue(botName, 1, []string{"lgtm", releaseNote}, true),
-			mustHave:    []string{"lgtm", releaseNote},
+			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNote}, true),
+			mustHave:    []string{lgtmLabel, releaseNote},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "LGTM with release-note-none",
-			issue:       github_test.Issue(botName, 1, []string{"lgtm", releaseNoteNone}, true),
-			mustHave:    []string{"lgtm", releaseNoteNone},
+			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNoteNone}, true),
+			mustHave:    []string{lgtmLabel, releaseNoteNone},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "LGTM with release-note-action-required",
-			issue:       github_test.Issue(botName, 1, []string{"lgtm", releaseNoteActionRequired}, true),
-			mustHave:    []string{"lgtm", releaseNoteActionRequired},
+			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNoteActionRequired}, true),
+			mustHave:    []string{lgtmLabel, releaseNoteActionRequired},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "LGTM with release-note-experimental",
-			issue:       github_test.Issue(botName, 1, []string{"lgtm", releaseNoteExperimental}, true),
-			mustHave:    []string{"lgtm", releaseNoteExperimental},
+			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNoteExperimental}, true),
+			mustHave:    []string{lgtmLabel, releaseNoteExperimental},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "LGTM with release-note-label-needed",
-			issue:       github_test.Issue(botName, 1, []string{"lgtm", releaseNoteLabelNeeded}, true),
+			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNoteLabelNeeded}, true),
 			mustHave:    []string{releaseNoteLabelNeeded},
-			mustNotHave: []string{"lgtm"},
+			mustNotHave: []string{lgtmLabel},
 		},
 		{
 			name:        "LGTM only",
-			issue:       github_test.Issue(botName, 1, []string{"lgtm"}, true),
+			issue:       github_test.Issue(botName, 1, []string{lgtmLabel}, true),
 			mustHave:    []string{releaseNoteLabelNeeded},
-			mustNotHave: []string{"lgtm"},
+			mustNotHave: []string{lgtmLabel},
 		},
 		{
 			name:     "No labels",
@@ -143,10 +143,10 @@ func TestReleaseNoteLabel(t *testing.T) {
 		{
 			name:        "do not touch LGTM on non-master when parent PR has releaseNote label",
 			branch:      "release-1.2",
-			issue:       github_test.Issue(botName, 1, []string{"lgtm"}, true),
+			issue:       github_test.Issue(botName, 1, []string{lgtmLabel}, true),
 			body:        "Cherry pick of #2 on release-1.2.",
 			secondIssue: github_test.Issue(botName, 2, []string{releaseNote}, true),
-			mustHave:    []string{"lgtm"},
+			mustHave:    []string{lgtmLabel},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
@@ -160,11 +160,11 @@ func TestReleaseNoteLabel(t *testing.T) {
 		{
 			name:        "remove LGTM on non-master when parent PR has releaseNote label",
 			branch:      "release-1.2",
-			issue:       github_test.Issue(botName, 1, []string{"lgtm"}, true),
+			issue:       github_test.Issue(botName, 1, []string{lgtmLabel}, true),
 			body:        "Cherry pick of #2 on release-1.2.",
 			secondIssue: github_test.Issue(botName, 2, []string{releaseNoteNone}, true),
 			mustHave:    []string{releaseNoteLabelNeeded},
-			mustNotHave: []string{"lgtm"},
+			mustNotHave: []string{lgtmLabel},
 		},
 	}
 	for testNum, test := range tests {

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -74,14 +74,14 @@ func TestReleaseNoteLabel(t *testing.T) {
 		{
 			name:        "LGTM with release-note-label-needed",
 			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNoteLabelNeeded}, true),
-			mustHave:    []string{releaseNoteLabelNeeded},
-			mustNotHave: []string{lgtmLabel},
+			mustHave:    []string{lgtmLabel, doNotMergeLabel, releaseNoteLabelNeeded},
+			mustNotHave: []string{},
 		},
 		{
 			name:        "LGTM only",
 			issue:       github_test.Issue(botName, 1, []string{lgtmLabel}, true),
-			mustHave:    []string{releaseNoteLabelNeeded},
-			mustNotHave: []string{lgtmLabel},
+			mustHave:    []string{lgtmLabel, doNotMergeLabel, releaseNoteLabelNeeded},
+			mustNotHave: []string{},
 		},
 		{
 			name:     "No labels",
@@ -158,13 +158,13 @@ func TestReleaseNoteLabel(t *testing.T) {
 			mustHave:    []string{releaseNoteLabelNeeded},
 		},
 		{
-			name:        "remove LGTM on non-master when parent PR has releaseNote label",
+			name:        "add doNotMergeLabel on non-master when parent PR has releaseNoteNone label",
 			branch:      "release-1.2",
 			issue:       github_test.Issue(botName, 1, []string{lgtmLabel}, true),
 			body:        "Cherry pick of #2 on release-1.2.",
 			secondIssue: github_test.Issue(botName, 2, []string{releaseNoteNone}, true),
-			mustHave:    []string{releaseNoteLabelNeeded},
-			mustNotHave: []string{lgtmLabel},
+			mustHave:    []string{doNotMergeLabel, releaseNoteLabelNeeded},
+			mustNotHave: []string{},
 		},
 	}
 	for testNum, test := range tests {


### PR DESCRIPTION
This should keep the bot from fighting itself to add and remove LGTM.

We also just stop removing LGTM when people (badly) retrigger a flaky test. That was just punitive...
