### PR TITLE
Strip Reviewable footer from issue body when merging.

### DIFF
--- a/mungegithub/github/github_test.go
+++ b/mungegithub/github/github_test.go
@@ -535,3 +535,27 @@ this pr Fixes #23 and FIXES #45 but not fixxx #99`,
 		server.Close()
 	}
 }
+
+func TestCleanIssueBody(t *testing.T) {
+	tests := []struct {
+		body, expected string
+	}{
+		{"foo", "foo"},
+		{"    bar   ", "bar"},
+		{
+			`Some message
+
+<!-- Reviewable:start -->
+gratuitous href
+<!-- Reviewable:end -->`,
+			"Some message",
+		},
+	}
+	for testNum, test := range tests {
+		body := cleanIssueBody(test.body)
+		if body != test.expected {
+			t.Errorf("%d: cleanIssueBody(%#v) == %#v != %#v",
+				testNum, test.body, body, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
This keeps commit messages clean.

An example of the current state: https://github.com/kubernetes/kubernetes/commit/78356b53b0c0e8471478e4bdd71c142605d3a196
