### PR TITLE
Add new way to match events and comments

### DIFF
--- a/mungegithub/mungers/matchers/comment/comment.go
+++ b/mungegithub/mungers/matchers/comment/comment.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comment
+
+import (
+	"time"
+
+	"github.com/google/go-github/github"
+)
+
+// Matcher is an interface to match a comment
+type Matcher interface {
+	Match(comment *github.IssueComment) bool
+}
+
+// CreatedAfter matches comments created after the time
+type CreatedAfter time.Time
+
+// Match returns true if the comment is created after the time
+func (c CreatedAfter) Match(comment *github.IssueComment) bool {
+	if comment == nil || comment.CreatedAt == nil {
+		return false
+	}
+	return comment.CreatedAt.After(time.Time(c))
+}
+
+// CreatedBefore matches comments created before the time
+type CreatedBefore time.Time
+
+// Match returns true if the comment is created before the time
+func (c CreatedBefore) Match(comment *github.IssueComment) bool {
+	if comment == nil || comment.CreatedAt == nil {
+		return false
+	}
+	return comment.CreatedAt.Before(time.Time(c))
+}

--- a/mungegithub/mungers/matchers/comment/comment_test.go
+++ b/mungegithub/mungers/matchers/comment/comment_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comment
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-github/github"
+)
+
+func getDate(year int, month time.Month, day, hour, min, sec int) *time.Time {
+	date := time.Date(year, month, day, hour, min, sec, 0, time.UTC)
+	return &date
+}
+
+func TestCreationBefore(t *testing.T) {
+	if CreatedBefore(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(nil) {
+		t.Error("Shouldn't match nil comment")
+	}
+	if CreatedBefore(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueComment{}) {
+		t.Error("Shouldn't match nil CreatedAt")
+	}
+	if CreatedBefore(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueComment{
+		CreatedAt: getDate(2000, 1, 1, 12, 0, 1),
+	}) {
+		t.Error("Should match later comment")
+	}
+	if !CreatedBefore(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueComment{
+		CreatedAt: getDate(2000, 1, 1, 11, 0, 0),
+	}) {
+		t.Error("Shouldn't match earlier comment")
+	}
+}
+
+func TestCreationAfter(t *testing.T) {
+	if CreatedAfter(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(nil) {
+		t.Error("Shouldn't match nil comment")
+	}
+	if CreatedAfter(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueComment{}) {
+		t.Error("Shouldn't match nil CreatedAt")
+	}
+	if !CreatedAfter(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueComment{
+		CreatedAt: getDate(2000, 1, 1, 12, 0, 1),
+	}) {
+		t.Error("Should match later comment")
+	}
+	if CreatedAfter(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueComment{
+		CreatedAt: getDate(2000, 1, 1, 11, 0, 0),
+	}) {
+		t.Error("Shouldn't match earlier comment")
+	}
+}

--- a/mungegithub/mungers/matchers/comment/finder.go
+++ b/mungegithub/mungers/matchers/comment/finder.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comment
+
+import "github.com/google/go-github/github"
+
+// FilteredComments is a list of comments
+type FilteredComments []*github.IssueComment
+
+// FilterComments will return the list of matching comments
+func FilterComments(comments []*github.IssueComment, matcher Matcher) FilteredComments {
+	matches := FilteredComments{}
+
+	for _, comment := range comments {
+		if matcher.Match(comment) {
+			matches = append(matches, comment)
+		}
+	}
+
+	return matches
+}

--- a/mungegithub/mungers/matchers/comment/finder_test.go
+++ b/mungegithub/mungers/matchers/comment/finder_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comment
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+func TestFilterComments(t *testing.T) {
+	comments := []*github.IssueComment{
+		makeCommentWithBody("1"),
+		makeCommentWithBody("2"),
+		makeCommentWithBody("3"),
+		makeCommentWithBody("4"),
+	}
+
+	emptyList := FilterComments(comments, False{})
+	if len(emptyList) != 0 {
+		t.Error("False filter shouldn't match any element")
+	}
+
+	fullList := FilterComments(comments, True{})
+	if !reflect.DeepEqual([]*github.IssueComment(fullList), comments) {
+		t.Error("True filter should have kept every element")
+	}
+}

--- a/mungegithub/mungers/matchers/comment/interactions.go
+++ b/mungegithub/mungers/matchers/comment/interactions.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comment
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/go-github/github"
+)
+
+// Notification identifies comments with the following format:
+// [NEEDS-REBASE] Optional arguments
+type Notification string
+
+// Match returns true if the comment is a notification
+func (b Notification) Match(comment *github.IssueComment) bool {
+	if comment.Body == nil {
+		return false
+	}
+	match, _ := regexp.MatchString(
+		fmt.Sprintf(`^\[%s\]`, strings.ToLower(string(b))),
+		strings.ToLower(*comment.Body),
+	)
+	return match
+}
+
+// Command identifies messages sent to the bot, with the following format:
+// /COMMAND Optional arguments
+type Command string
+
+// Match will return true if the comment is indeed a command
+func (c Command) Match(comment *github.IssueComment) bool {
+	if comment.Body == nil {
+		return false
+	}
+	match, _ := regexp.MatchString(
+		fmt.Sprintf("^/%s", strings.ToLower(string(c))),
+		strings.ToLower(*comment.Body),
+	)
+	return match
+}

--- a/mungegithub/mungers/matchers/comment/interactions_test.go
+++ b/mungegithub/mungers/matchers/comment/interactions_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comment
+
+import (
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+func makeCommentWithBody(body string) *github.IssueComment {
+	return &github.IssueComment{
+		Body: &body,
+	}
+}
+
+func TestNotification(t *testing.T) {
+	if Notification("MESSAGE").Match(&github.IssueComment{}) {
+		t.Error("Shouldn't match nil body")
+	}
+	if Notification("MESSAGE").Match(makeCommentWithBody("MESSAGE WRONG FORMAT")) {
+		t.Error("Shouldn't match invalid match")
+	}
+	if !Notification("MESSAGE").Match(makeCommentWithBody("[MESSAGE] Valid format")) {
+		t.Error("Should match valid format")
+	}
+	if !Notification("MESSAGE").Match(makeCommentWithBody("[MESSAGE]")) {
+		t.Error("Should match with no arguments")
+	}
+	if !Notification("MESSage").Match(makeCommentWithBody("[meSSAGE]")) {
+		t.Error("Should match with different case")
+	}
+}
+
+func TestCommand(t *testing.T) {
+	if Command("COMMAND").Match(&github.IssueComment{}) {
+		t.Error("Shouldn't match nil body")
+	}
+	if Command("COMMAND").Match(makeCommentWithBody("COMMAND WRONG FORMAT")) {
+		t.Error("Shouldn't match invalid format")
+	}
+	if !Command("COMMAND").Match(makeCommentWithBody("/COMMAND Valid format")) {
+		t.Error("Should match valid format")
+	}
+	if !Command("COMMAND").Match(makeCommentWithBody("/COMMAND")) {
+		t.Error("Should match with no arguments")
+	}
+	if !Command("COMmand").Match(makeCommentWithBody("/ComMAND")) {
+		t.Error("Should match with different case")
+	}
+}

--- a/mungegithub/mungers/matchers/comment/operators.go
+++ b/mungegithub/mungers/matchers/comment/operators.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comment
+
+import "github.com/google/go-github/github"
+
+// True is a matcher that is always true
+type True struct{}
+
+// Match returns true no matter what
+func (t True) Match(comment *github.IssueComment) bool {
+	return true
+}
+
+// False is a matcher that is always false
+type False struct{}
+
+// Match returns false no matter what
+func (t False) Match(comment *github.IssueComment) bool {
+	return false
+}
+
+// And makes sure that each match in the list matches (true if empty)
+type And []Matcher
+
+// Match returns true if all the matcher in the list matches
+func (a And) Match(comment *github.IssueComment) bool {
+	for _, matcher := range []Matcher(a) {
+		if !matcher.Match(comment) {
+			return false
+		}
+	}
+	return true
+}
+
+// Or makes sure that at least one element in the list matches (false if empty)
+type Or []Matcher
+
+// Match returns true if one of the matcher in the list matches
+func (o Or) Match(comment *github.IssueComment) bool {
+	for _, matcher := range []Matcher(o) {
+		if matcher.Match(comment) {
+			return true
+		}
+	}
+	return false
+}
+
+// Not reverses the effect of the matcher
+type Not struct {
+	Matcher Matcher
+}
+
+// Match returns true if the matcher would return false, and vice-versa
+func (n Not) Match(comment *github.IssueComment) bool {
+	return !n.Matcher.Match(comment)
+}

--- a/mungegithub/mungers/matchers/comment/operators_test.go
+++ b/mungegithub/mungers/matchers/comment/operators_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comment
+
+import "testing"
+
+func TestTrue(t *testing.T) {
+	if !(True{}).Match(nil) {
+		t.Error("True shouldn't be false ...")
+	}
+}
+
+func TestFalse(t *testing.T) {
+	if (False{}).Match(nil) {
+		t.Error("False shouldn't be true ...")
+	}
+}
+
+func TestNot(t *testing.T) {
+	if !(Not{False{}}).Match(nil) {
+		t.Error("Not False shouldn't be false ...")
+	}
+
+	if (Not{True{}}).Match(nil) {
+		t.Error("Not True shouldn't be true ...")
+	}
+}
+
+func TestAnd(t *testing.T) {
+	if !(And{}).Match(nil) {
+		t.Error("And(Empty) should be true ...")
+	}
+
+	if !(And([]Matcher{True{}, True{}})).Match(nil) {
+		t.Error("And(All True) should be true ...")
+	}
+
+	if (And([]Matcher{True{}, False{}})).Match(nil) {
+		t.Error("And(Some False) should be false ...")
+	}
+
+	if (And([]Matcher{False{}, False{}})).Match(nil) {
+		t.Error("And(All False) should be false ...")
+	}
+}
+
+func TestOr(t *testing.T) {
+	if (Or{}).Match(nil) {
+		t.Error("Or(Empty) should be false ...")
+	}
+
+	if !(Or([]Matcher{True{}, True{}})).Match(nil) {
+		t.Error("Or(All True) should be true ...")
+	}
+
+	if !(Or([]Matcher{True{}, False{}})).Match(nil) {
+		t.Error("Or(Some False) should be true ...")
+	}
+
+	if (Or([]Matcher{False{}, False{}})).Match(nil) {
+		t.Error("Or(All False) should be false ...")
+	}
+}

--- a/mungegithub/mungers/matchers/event/event.go
+++ b/mungegithub/mungers/matchers/event/event.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/go-github/github"
+)
+
+// Matcher is an interface to match an event
+type Matcher interface {
+	Match(event *github.IssueEvent) bool
+}
+
+// Actor searches for a specific actor
+type Actor string
+
+// Match if the event is from the specified actor
+func (a Actor) Match(event *github.IssueEvent) bool {
+	if event == nil || event.Actor == nil || event.Actor.Login == nil {
+		return false
+	}
+	return strings.ToLower(*event.Actor.Login) == strings.ToLower(string(a))
+}
+
+// AddLabel searches for "labeled" event.
+type AddLabel struct{}
+
+// Match if the event is of type "labeled"
+func (a AddLabel) Match(event *github.IssueEvent) bool {
+	if event == nil || event.Event == nil {
+		return false
+	}
+	return *event.Event == "labeled"
+}
+
+// LabelPrefix searches for event whose label starts with the string
+type LabelPrefix string
+
+// Match if the label starts with the string
+func (l LabelPrefix) Match(event *github.IssueEvent) bool {
+	if event == nil || event.Label == nil || event.Label.Name == nil {
+		return false
+	}
+	return strings.HasPrefix(*event.Label.Name, string(l))
+}
+
+// CreatedAfter looks for event created after time
+type CreatedAfter time.Time
+
+// Match if the event is after the time
+func (c CreatedAfter) Match(event *github.IssueEvent) bool {
+	if event == nil || event.CreatedAt == nil {
+		return false
+	}
+	return event.CreatedAt.After(time.Time(c))
+}
+
+// CreatedBefore looks for event created before time
+type CreatedBefore time.Time
+
+// Match if the event is before the time
+func (c CreatedBefore) Match(event *github.IssueEvent) bool {
+	if event == nil || event.CreatedAt == nil {
+		return false
+	}
+	return event.CreatedAt.Before(time.Time(c))
+}

--- a/mungegithub/mungers/matchers/event/event_test.go
+++ b/mungegithub/mungers/matchers/event/event_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-github/github"
+)
+
+func getDate(year int, month time.Month, day, hour, min, sec int) *time.Time {
+	date := time.Date(year, month, day, hour, min, sec, 0, time.UTC)
+	return &date
+}
+
+func TestCreationBefore(t *testing.T) {
+	if CreatedBefore(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(nil) {
+		t.Error("Shouldn't match nil event")
+	}
+	if CreatedBefore(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueEvent{}) {
+		t.Error("Shouldn't match nil CreatedAt")
+	}
+	if CreatedBefore(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueEvent{
+		CreatedAt: getDate(2000, 1, 1, 12, 0, 1),
+	}) {
+		t.Error("Shouldn't match later event")
+	}
+	if !CreatedBefore(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueEvent{
+		CreatedAt: getDate(2000, 1, 1, 11, 0, 0),
+	}) {
+		t.Error("Should match earlier event")
+	}
+}
+
+func TestCreationAfter(t *testing.T) {
+	if CreatedAfter(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(nil) {
+		t.Error("Shouldn't match nil event")
+	}
+	if CreatedAfter(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueEvent{}) {
+		t.Error("Shouldn't match nil CreatedAt")
+	}
+	if !CreatedAfter(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueEvent{
+		CreatedAt: getDate(2000, 1, 1, 12, 0, 1),
+	}) {
+		t.Error("Should match later event")
+	}
+	if CreatedAfter(
+		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
+	).Match(&github.IssueEvent{
+		CreatedAt: getDate(2000, 1, 1, 11, 0, 0),
+	}) {
+		t.Error("Shouldn't match earlier event")
+	}
+}
+
+func makeEventWithActor(actor string) *github.IssueEvent {
+	return &github.IssueEvent{
+		Actor: &github.User{Login: &actor},
+	}
+}
+
+func TestActor(t *testing.T) {
+	if Actor("actor").Match(nil) {
+		t.Error("Shouldn't match nil event")
+	}
+	if Actor("actor").Match(&github.IssueEvent{}) {
+		t.Error("Shouldn't match nil Actor")
+	}
+	if Actor("actor").Match(&github.IssueEvent{Actor: &github.User{}}) {
+		t.Error("Shouldn't match nil Login")
+	}
+	if Actor("actor").Match(makeEventWithActor("user")) {
+		t.Error("Shouldn't match actor with different names")
+	}
+	if !Actor("actor").Match(makeEventWithActor("actor")) {
+		t.Error("Should match actor with similar name")
+	}
+	if !Actor("actoR").Match(makeEventWithActor("Actor")) {
+		t.Error("Should match actor with similar name, but different case")
+	}
+}

--- a/mungegithub/mungers/matchers/event/finder.go
+++ b/mungegithub/mungers/matchers/event/finder.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import "github.com/google/go-github/github"
+
+// FilteredEvents is a list of events
+type FilteredEvents []*github.IssueEvent
+
+// FilterEvents will return the list of matching events
+func FilterEvents(events []*github.IssueEvent, matcher Matcher) FilteredEvents {
+	matches := FilteredEvents{}
+
+	for _, event := range events {
+		if matcher.Match(event) {
+			matches = append(matches, event)
+		}
+	}
+
+	return matches
+}

--- a/mungegithub/mungers/matchers/event/finder_test.go
+++ b/mungegithub/mungers/matchers/event/finder_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+func makeEvent(event string) *github.IssueEvent {
+	return &github.IssueEvent{
+		Event: &event,
+	}
+}
+
+func TestFilterEvents(t *testing.T) {
+	events := []*github.IssueEvent{
+		makeEvent("1"),
+		makeEvent("2"),
+		makeEvent("3"),
+		makeEvent("4"),
+	}
+
+	emptyList := FilterEvents(events, False{})
+	if len(emptyList) != 0 {
+		t.Error("False filter shouldn't match any element")
+	}
+
+	fullList := FilterEvents(events, True{})
+	if !reflect.DeepEqual([]*github.IssueEvent(fullList), events) {
+		t.Error("True filter should match every element")
+	}
+}

--- a/mungegithub/mungers/matchers/event/operators.go
+++ b/mungegithub/mungers/matchers/event/operators.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import "github.com/google/go-github/github"
+
+// True is a matcher that is always true
+type True struct{}
+
+// Match returns true no matter what
+func (t True) Match(event *github.IssueEvent) bool {
+	return true
+}
+
+// False is a matcher that is always false
+type False struct{}
+
+// Match returns false no matter what
+func (t False) Match(event *github.IssueEvent) bool {
+	return false
+}
+
+// And makes sure that each match in the list matches (true if empty)
+type And []Matcher
+
+// Match returns true if all the matcher in the list matches
+func (a And) Match(event *github.IssueEvent) bool {
+	for _, matcher := range []Matcher(a) {
+		if !matcher.Match(event) {
+			return false
+		}
+	}
+	return true
+}
+
+// Or makes sure that at least one element in the list matches (false if empty)
+type Or []Matcher
+
+// Match returns true if one of the matcher in the list matches
+func (o Or) Match(event *github.IssueEvent) bool {
+	for _, matcher := range []Matcher(o) {
+		if matcher.Match(event) {
+			return true
+		}
+	}
+	return false
+}
+
+// Not reverses the effect of the matcher
+type Not struct {
+	Matcher Matcher
+}
+
+// Match returns true if the matcher would return false, and vice-versa
+func (n Not) Match(event *github.IssueEvent) bool {
+	return !n.Matcher.Match(event)
+}


### PR DESCRIPTION
Each mungers is looking for comments and events all the time. Let's try
to create an easier way to find these.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1530)

<!-- Reviewable:end -->
