### PR TITLE
service-loadbalancer Dockerfile: replace wget usage with curl

### DIFF
--- a/service-loadbalancer/Dockerfile
+++ b/service-loadbalancer/Dockerfile
@@ -21,7 +21,7 @@ RUN for ERROR_CODE in 400 403 404 408 500 502 503 504;do curl -sSL -o /etc/hapro
 	https://raw.githubusercontent.com/haproxy/haproxy-1.5/master/examples/errorfiles/$ERROR_CODE.http;done
 
 # https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem
-RUN wget -O /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64 && \
+RUN curl -o /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64 && \
   chmod +x /sbin/dumb-init
 
 ENTRYPOINT ["dumb-init", "/service_loadbalancer"]


### PR DESCRIPTION
wget looks like it's missing from gcr.io/google_containers/haproxy:0.3

```
[service-loadbalancer:master]$ docker run -ti gcr.io/google_containers/haproxy:0.3 wget
exec: "wget": executable file not found in $PATH
Error response from daemon: Cannot start container 5a99d4f99495c74f57045b7926e7211e1f1da1d2db7d7b79be6d69f055d00c04: [8] System error: exec: "wget": executable file not found in $PATH
[service-loadbalancer:master]$ docker run -ti gcr.io/google_containers/haproxy:0.3 bash
root@3437d156cc7d:/# find . -name wget
root@3437d156cc7d:/#
```
