### PR TITLE
service-loadbalancer Makefile tweaks

### DIFF
--- a/service-loadbalancer/Makefile
+++ b/service-loadbalancer/Makefile
@@ -1,20 +1,25 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG = 0.4
-PREFIX = gcr.io/google_containers/servicelb
+TAG ?= 0.4
+PREFIX ?= gcr.io/google_containers/servicelb
+GCLOUD ?= gcloud
 HAPROXY_IMAGE = contrib-haproxy
+SRC = service_loadbalancer.go loadbalancer_log.go
 
-server: service_loadbalancer.go
-	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o service_loadbalancer ./service_loadbalancer.go ./loadbalancer_log.go
+service_loadbalancer: $(SRC)
+	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o $@ $(SRC)
 
-container: server
+container: service_loadbalancer
 	docker build -t $(PREFIX):$(TAG) .
 
 push: container
-	gcloud docker push $(PREFIX):$(TAG)
+	$(GCLOUD) docker push $(PREFIX):$(TAG)
 
 clean:
 	# remove servicelb and contrib-haproxy images
 	docker rmi -f $(HAPROXY_IMAGE):$(TAG) || true
 	docker rmi -f $(PREFIX):$(TAG) || true
+	rm -f service_loadbalancer
+
+.PHONY: container push


### PR DESCRIPTION
- change `server` target to `service_loadbalancer` and add prerequisites
- conditionally assign TAG, PREFIX, and GCLOUD
- make `container` and `push` PHONY
- `rm -f service_loadbalancer` in `clean`

Original `make` behavior is the same, except that `make` will not build
`service_loadbalancer` unless there are updates to service_loadbalancer.go or
loadbalancer_log.go since the last build.

Facilitates usage by non GCP users. E.g., `PREFIX=silasbw/servicelb GCLOUD= make`
