### PR TITLE
Specifying aliases in OWNERs files

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -1,4 +1,5 @@
 admin-port
+alias-file
 allowed-shame-domains
 api-token
 balance-algorithm

--- a/mungegithub/features/aliases.go
+++ b/mungegithub/features/aliases.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"k8s.io/contrib/mungegithub/github"
+	"k8s.io/contrib/mungegithub/mungers/mungerutil"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+)
+
+const (
+	// AliasesFeature is how mungers should indicate this is required.
+	AliasesFeature = "aliases"
+)
+
+type aliasData struct {
+	// Contains the mapping between aliases and lists of members.
+	AliasMap map[string][]string `json:"aliases"`
+}
+
+type aliasReader interface {
+	read() ([]byte, error)
+}
+
+func (a *Aliases) read() ([]byte, error) {
+	return ioutil.ReadFile(a.AliasFile)
+}
+
+// Aliases is a struct that handles parameters required by mungers
+// to expand and lookup aliases.
+type Aliases struct {
+	AliasFile string
+	IsEnabled bool
+
+	data        *aliasData
+	prevHash    string
+	aliasReader aliasReader
+}
+
+var _ feature = &Aliases{}
+
+func init() {
+	RegisterFeature(&Aliases{})
+}
+
+// Name is just going to return the name mungers use to request this feature
+func (a *Aliases) Name() string {
+	return AliasesFeature
+}
+
+// Initialize will initialize the feature.
+func (a *Aliases) Initialize(config *github.Config) error {
+	a.data = &aliasData{
+		AliasMap: map[string][]string{},
+	}
+
+	if len(a.AliasFile) == 0 {
+		return nil
+	}
+
+	// We can enable alias files.
+	a.IsEnabled = true
+	a.aliasReader = a
+	return nil
+}
+
+// EachLoop is called at the start of every munge loop
+func (a *Aliases) EachLoop() error {
+	if !a.IsEnabled {
+		return nil
+	}
+
+	// read and check the alias-file.
+	fileContents, err := a.aliasReader.read()
+	if err != nil {
+		return fmt.Errorf("Unable to read alias file: %v", err)
+	}
+
+	hash := mungerutil.GetHash(fileContents)
+	if a.prevHash != hash {
+		var data aliasData
+		if err := yaml.Unmarshal(fileContents, &data); err != nil {
+			return fmt.Errorf("Failed to decode the alias file: %v", err)
+		}
+		a.data = &data
+		a.prevHash = hash
+	}
+	return nil
+}
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (a *Aliases) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&a.AliasFile, "alias-file", "", "File wherein team members and aliases exist.")
+}
+
+// Expand takes aliases and expands them into owner lists.
+func (a *Aliases) Expand(toExpand sets.String) sets.String {
+	expanded := sets.String{}
+	for _, owner := range toExpand.List() {
+		expanded.Insert(a.resolve(owner)...)
+	}
+	return expanded
+}
+
+func (a *Aliases) resolve(owner string) []string {
+	if val, ok := a.data.AliasMap[owner]; ok {
+		return val
+	}
+	return []string{owner}
+}

--- a/mungegithub/features/aliases_test.go
+++ b/mungegithub/features/aliases_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+
+	github_util "k8s.io/contrib/mungegithub/github"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+var (
+	aliasYaml = `
+aliases:
+  team/t1:
+    - u1
+    - u2
+  team/t2:
+    - u1
+    - u3`
+)
+
+type aliasTest struct{}
+
+func (a *aliasTest) read() ([]byte, error) {
+	return []byte(aliasYaml), nil
+}
+
+func TestExpandAliases(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	tests := []struct {
+		name      string
+		aliasFile string
+		owners    sets.String
+		expected  sets.String
+	}{
+		{
+			name:     "No expansions.",
+			owners:   sets.NewString("abc", "def"),
+			expected: sets.NewString("abc", "def"),
+		},
+		{
+			name:     "No aliases to be expanded",
+			owners:   sets.NewString("abc", "team/t1"),
+			expected: sets.NewString("abc", "u1", "u2"),
+		},
+		{
+			name:     "Duplicates inside and outside alias.",
+			owners:   sets.NewString("u1", "team/t1"),
+			expected: sets.NewString("u1", "u2"),
+		},
+		{
+			name:     "Duplicates in multiple aliases.",
+			owners:   sets.NewString("u1", "team/t1", "team/t2"),
+			expected: sets.NewString("u1", "u2", "u3"),
+		},
+	}
+
+	for _, test := range tests {
+		a := Aliases{
+			aliasReader: &aliasTest{},
+			IsEnabled:   true,
+		}
+
+		if err := a.Initialize(&github_util.Config{}); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		if err := a.EachLoop(); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		expanded := a.Expand(test.owners)
+		if !reflect.DeepEqual(expanded, test.expected) {
+			t.Errorf("%s: expected: %#v, got: %#v", test.name, test.expected, expanded)
+		}
+	}
+}

--- a/mungegithub/features/features.go
+++ b/mungegithub/features/features.go
@@ -28,6 +28,7 @@ import (
 // Features are all features the code know about. Care should be taken
 // not to try to use a feature which isn't 'active'
 type Features struct {
+	Aliases     *Aliases
 	Repos       *RepoInfo
 	GCSInfo     *GCSInfo
 	TestOptions *TestOptions
@@ -67,6 +68,8 @@ func (f *Features) Initialize(config *github.Config, requestedFeatures []string)
 			f.GCSInfo = feat.(*GCSInfo)
 		case TestOptionsFeature:
 			f.TestOptions = feat.(*TestOptions)
+		case AliasesFeature:
+			f.Aliases = feat.(*Aliases)
 		}
 	}
 	return nil

--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -114,6 +114,11 @@ func (b *BlunderbussMunger) Munge(obj *github.MungeObject) {
 		if fileOwners.Len() == 0 {
 			glog.Warningf("Couldn't find an owner for: %s", *file.Filename)
 		}
+
+		if b.features.Aliases.IsEnabled {
+			fileOwners = b.features.Aliases.Expand(fileOwners)
+		}
+
 		for _, owner := range fileOwners.List() {
 			if owner == *issue.User.Login {
 				continue

--- a/mungegithub/mungers/check-labels.go
+++ b/mungegithub/mungers/check-labels.go
@@ -22,11 +22,11 @@ import (
 
 	"k8s.io/contrib/mungegithub/features"
 	githubhelper "k8s.io/contrib/mungegithub/github"
+	"k8s.io/contrib/mungegithub/mungers/mungerutil"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/yaml"
 
 	"bytes"
-	"crypto/sha1"
 	"github.com/golang/glog"
 	"github.com/google/go-github/github"
 	"github.com/spf13/cobra"
@@ -80,13 +80,6 @@ func (c *CheckLabelsMunger) Initialize(config *githubhelper.Config, features *fe
 	return nil
 }
 
-func (c *CheckLabelsMunger) getHash(fileContents []byte) string {
-	h := sha1.New()
-	h.Write([]byte(fileContents))
-	bs := h.Sum(nil)
-	return string(bs)
-}
-
 // EachLoop is called at the start of every munge loop
 func (c *CheckLabelsMunger) EachLoop() error {
 	fileContents, err := c.readFunc()
@@ -94,7 +87,7 @@ func (c *CheckLabelsMunger) EachLoop() error {
 		glog.Errorf("Failed to read the check label config: %v", err)
 		return err
 	}
-	hash := c.getHash(fileContents)
+	hash := mungerutil.GetHash(fileContents)
 	if c.prevHash != hash {
 		// Get all labels from file.
 		fileLabels := map[string][]*github.Label{}

--- a/mungegithub/mungers/mungerutil/hash.go
+++ b/mungegithub/mungers/mungerutil/hash.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungerutil
+
+import "crypto/sha1"
+
+// GetHash returns SHA1 hash of a byte array.
+func GetHash(fileContents []byte) string {
+	h := sha1.New()
+	h.Write([]byte(fileContents))
+	bs := h.Sum(nil)
+	return string(bs)
+}


### PR DESCRIPTION
--alias-file option can specify team aliases of the following kind:

```
aliases:
  team/t1:
    - team/t2
    - u2
  team/t2:
    - team/t3
    - u3
  team/t3:
    - u4
```

This should let us use OWNERs files better with an extra level of indirection.
Things that need further thought:
1. Do we want to support nested team definitions like above? (If yes, what do we do if there are cyclic loops?)
2. Should the yaml file containing aliases be within the repository, or be globally consistent and supplied to mungegithub at the time of invocation?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1536)

<!-- Reviewable:end -->
