### PR TITLE
lgtm handler: auto add/remove lgtm label

### DIFF
--- a/mungegithub/README.md
+++ b/mungegithub/README.md
@@ -55,6 +55,7 @@ A small amount of information about some of the individual mungers inside each o
 * comment-deleter - deletes comments created by the k8s-merge-robot which are no longer relevant. Such as comments about a rebase being required if it has been rebased.
 * comment-deleter-jenkins - deleted comments create by the k8s-bot jenkins bot which are no longer relevant. Such as old test results.
 * lgtm-after-commit - removes `lgtm` label if a PR is changed after the label was added
+* lgtm-handler - adds LGTM label if reviewer has commented "/lgtm", or remove LGTM label if reviewer has commented "/lgtm cancel"
 * needs-rebase - adds and removes a `needs-rebase` label if a PR needs to be rebased before it can be applied.
 * path-label - adds labels, such as `kind/new-api` based on if ANY file which matches changed
 * rebuild-request - Looks for requests to retest a PR but which did not reference a flake.

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -1530,8 +1530,11 @@ func (obj *MungeObject) ListReviewComments() ([]*github.PullRequestComment, erro
 	return allComments, nil
 }
 
+// WithListOpt configures the options to list comments of github issue.
+type WithListOpt func(*github.IssueListCommentsOptions) *github.IssueListCommentsOptions
+
 // ListComments returns all comments for the issue/PR in question
-func (obj *MungeObject) ListComments() ([]*github.IssueComment, error) {
+func (obj *MungeObject) ListComments(withListOpts ...WithListOpt) ([]*github.IssueComment, error) {
 	config := obj.config
 	issueNum := *obj.Issue.Number
 	allComments := []*github.IssueComment{}
@@ -1541,6 +1544,9 @@ func (obj *MungeObject) ListComments() ([]*github.IssueComment, error) {
 	}
 
 	listOpts := &github.IssueListCommentsOptions{}
+	for _, withListOpt := range withListOpts {
+		listOpts = withListOpt(listOpts)
+	}
 
 	page := 1
 	for {

--- a/mungegithub/mungers/lgtm_handler.go
+++ b/mungegithub/mungers/lgtm_handler.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"strings"
+
+	"k8s.io/contrib/mungegithub/features"
+	"k8s.io/contrib/mungegithub/github"
+	"k8s.io/contrib/mungegithub/mungers/mungerutil"
+
+	"github.com/golang/glog"
+	githubapi "github.com/google/go-github/github"
+	"github.com/spf13/cobra"
+)
+
+// LGTMHandler will
+// - apply LGTM label if reviewer has commented "/lgtm", or
+// - remove LGTM label if reviewer has commented "/lgtm cancel"
+type LGTMHandler struct{}
+
+func init() {
+	l := LGTMHandler{}
+	RegisterMungerOrDie(l)
+}
+
+// Name is the name usable in --pr-mungers
+func (LGTMHandler) Name() string { return "lgtm-handler" }
+
+// RequiredFeatures is a slice of 'features' that must be provided
+func (LGTMHandler) RequiredFeatures() []string { return []string{} }
+
+// Initialize will initialize the munger
+func (LGTMHandler) Initialize(config *github.Config, features *features.Features) error { return nil }
+
+// EachLoop is called at the start of every munge loop
+func (LGTMHandler) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (LGTMHandler) AddFlags(cmd *cobra.Command, config *github.Config) {}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (h LGTMHandler) Munge(obj *github.MungeObject) {
+	if !obj.IsPR() {
+		return
+	}
+
+	reviewers := getReviewers(obj)
+	if len(reviewers) == 0 {
+		return
+	}
+
+	comments, err := getComments(obj)
+	if err != nil {
+		glog.Errorf("unexpected error getting comments: %v", err)
+		return
+	}
+
+	if !obj.HasLabel(lgtmLabel) {
+		h.addLGTMIfCommented(obj, comments, reviewers)
+		return
+	}
+	h.removeLGTMIfCancelled(obj, comments, reviewers)
+}
+
+func (h *LGTMHandler) addLGTMIfCommented(obj *github.MungeObject, comments []*githubapi.IssueComment, reviewers mungerutil.UserSet) {
+	// Assumption: The comments should be sorted (by default from github api) from oldest to latest
+	for i := len(comments) - 1; i >= 0; i-- {
+		comment := comments[i]
+		fields := strings.Fields(*comment.Body)
+		if isCancelComment(fields) {
+			// "/lgtm cancell" if commented more recently than "/lgtm"
+			return
+		}
+		if isLGTMComment(fields) {
+			// TODO: support more complex policies for multiple reviewers.
+			// See https://github.com/kubernetes/contrib/issues/1389#issuecomment-235161164
+			// TODO: An approver should be acceptable.
+			// See https://github.com/kubernetes/contrib/pull/1428#discussion_r72563935
+			if mungerutil.IsValidUser(comment.User) && isReviewer(comment.User, reviewers) {
+				glog.Infof("Adding lgtm label. Reviewer (%s) LGTM", *comment.User.Login)
+				obj.AddLabel(lgtmLabel)
+				return
+			}
+		}
+	}
+}
+
+func (h *LGTMHandler) removeLGTMIfCancelled(obj *github.MungeObject, comments []*githubapi.IssueComment, reviewers mungerutil.UserSet) {
+	for i := len(comments) - 1; i >= 0; i-- {
+		comment := comments[i]
+		fields := strings.Fields(*comment.Body)
+		if isLGTMComment(fields) {
+			// "/lgtm" if commented more recently than "/lgtm cancel"
+			return
+		}
+		if isCancelComment(fields) {
+			if mungerutil.IsValidUser(comment.User) && isReviewer(comment.User, reviewers) {
+				glog.Infof("Removing lgtm label. Reviewer (%s) cancelled", *comment.User.Login)
+				obj.RemoveLabel(lgtmLabel)
+				return
+			}
+		}
+	}
+}
+
+func isLGTMComment(fields []string) bool {
+	// Note: later we'd probably move all the bot-command parsing code to its own package.
+	return len(fields) == 1 && strings.ToLower(fields[0]) == "/lgtm"
+}
+
+func isCancelComment(fields []string) bool {
+	return len(fields) == 2 && strings.ToLower(fields[0]) == "/lgtm" && strings.ToLower(fields[1]) == "cancel"
+}
+
+func getReviewers(obj *github.MungeObject) mungerutil.UserSet {
+	// Note: assuming assignees are reviewers
+	allAssignees := append(obj.Issue.Assignees, obj.Issue.Assignee)
+	return mungerutil.GetUsers(allAssignees...)
+}
+
+func getComments(obj *github.MungeObject) ([]*githubapi.IssueComment, error) {
+	afterLastModified := func(opt *githubapi.IssueListCommentsOptions) *githubapi.IssueListCommentsOptions {
+		// Only comments updated at or after this time are returned.
+		// One possible case is that reviewer might "/lgtm" first, contributor updated PR, and reviewer updated "/lgtm".
+		// This is still valid. We don't recommend user to update it.
+		lastModified := *obj.LastModifiedTime()
+		opt.Since = lastModified
+		return opt
+	}
+	return obj.ListComments(afterLastModified)
+}
+
+func isReviewer(user *githubapi.User, reviewers mungerutil.UserSet) bool {
+	return reviewers.Has(user)
+}

--- a/mungegithub/mungers/mungerutil/util.go
+++ b/mungegithub/mungers/mungerutil/util.go
@@ -32,9 +32,10 @@ func GetUsers(users ...*github.User) UserSet {
 	allUsers := sets.String{}
 
 	for _, user := range users {
-		if user != nil && user.Login != nil {
-			allUsers.Insert(*user.Login)
+		if !IsValidUser(user) {
+			continue
 		}
+		allUsers.Insert(*user.Login)
 	}
 
 	return UserSet(allUsers)
@@ -95,4 +96,9 @@ func GetIssueUsers(issue *github.Issue) *IssueUsers {
 // AllUsers return a list of unique users (both assignees and author)
 func (u *IssueUsers) AllUsers() UserSet {
 	return u.Assignees.union(u.Author)
+}
+
+// IsValidUser returns true only if given user has valid github username (logic account).
+func IsValidUser(u *github.User) bool {
+	return u != nil && u.Login != nil
 }


### PR DESCRIPTION
This is to follow-up on #1428.

First of all, the previous race has been fixed in https://github.com/kubernetes/contrib/pull/1518. Thus this PR can add back the functionality of adding lgtm label. A reviewer commenting with only "/lgtm" will do it.
Second, this PR also adds the ability to remove lgtm label. A reviewer commenting with only "/lgtm cancel" will do it.

When both "/lgtm" and "/lgtm cancel" exist, it will find which is the latest created comment.
