### PR TITLE
Turning up lgtm-handler on contrib

### DIFF
--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -7,7 +7,7 @@ data:
   config.http-cache-dir: /cache/httpcache
   config.organization: kubernetes
   config.project: contrib
-  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,check-labels
+  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,check-labels,lgtm-handler
   config.state: open
   config.token-file: /etc/secret-volume/token
   gitrepo.repo-dir: /gitrepos


### PR DESCRIPTION
Now that https://github.com/kubernetes/contrib/pull/1539 has been merged, we can run the lgtm handler as a test on contrib before turning it up on the main repository.
