### PR TITLE
Revert "Turning up lgtm-handler on contrib"

### DIFF
--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -7,7 +7,7 @@ data:
   config.http-cache-dir: /cache/httpcache
   config.organization: kubernetes
   config.project: contrib
-  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,check-labels,lgtm-handler
+  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,check-labels
   config.state: open
   config.token-file: /etc/secret-volume/token
   gitrepo.repo-dir: /gitrepos


### PR DESCRIPTION
Reverts kubernetes/contrib#1545

Issue https://github.com/kubernetes/contrib/issues/1546 needs to be addressed first before we can do this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1547)

<!-- Reviewable:end -->
