### PR TITLE
Fixes race between lgtm-handler and lgtm-after-commit & adds tests.

### DIFF
--- a/mungegithub/github/testing/github.go
+++ b/mungegithub/github/testing/github.go
@@ -148,6 +148,18 @@ func Commit(sha string, t int64) *github.Commit {
 	}
 }
 
+// IssueComment returns a filled out github.IssueComment which happened at time.Unix(t, 0).
+func IssueComment(id int, body string, user string, createAt int64) *github.IssueComment {
+	return &github.IssueComment{
+		ID:   intPtr(id),
+		Body: stringPtr(body),
+		User: &github.User{
+			Login: stringPtr(user),
+		},
+		CreatedAt: timePtr(time.Unix(createAt, 0)),
+	}
+}
+
 // Commits returns an array of github.RepositoryCommits. The first commit
 // will have happened at time `time`, the next commit `time + 1`, etc
 func Commits(num int, time int64) []*github.RepositoryCommit {

--- a/mungegithub/mungers/lgtm_after_commit.go
+++ b/mungegithub/mungers/lgtm_after_commit.go
@@ -30,11 +30,11 @@ import (
 )
 
 const (
-	lgtmRemovedBody = "PR changed after LGTM, removing LGTM. %s"
+	lgtmRemovedBody = "/lgtm cancel //PR changed after LGTM, removing LGTM. %s"
 )
 
 var (
-	lgtmRemovedRegex = regexp.MustCompile("PR changed after LGTM, removing LGTM.")
+	lgtmRemovedRegex = regexp.MustCompile("/lgtm cancel //PR changed after LGTM, removing LGTM.")
 )
 
 // LGTMAfterCommitMunger will remove the LGTM flag from an PR which has been

--- a/mungegithub/mungers/lgtm_handler_test.go
+++ b/mungegithub/mungers/lgtm_handler_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime"
+	"testing"
+
+	github_util "k8s.io/contrib/mungegithub/github"
+	github_test "k8s.io/contrib/mungegithub/github/testing"
+	"k8s.io/contrib/mungegithub/mungers/mungerutil"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/google/go-github/github"
+)
+
+var (
+	prWithLGTM    = github_test.Issue(botName, 1, []string{lgtmLabel}, true)
+	prWithoutLGTM = github_test.Issue(botName, 1, []string{}, true)
+)
+
+func TestAddLGTMIfCommented(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	tests := []struct {
+		name        string
+		comments    []*github.IssueComment
+		issue       *github.Issue
+		assignees   mungerutil.UserSet
+		mustHave    []string
+		mustNotHave []string
+	}{
+		{
+			name:  "Other comments should not add LGTM.",
+			issue: prWithoutLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/comment 1", "user 1", 0),
+				github_test.IssueComment(2, "/comment 2 //comment3", "user 2", 1),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1")),
+			mustHave:    []string{},
+			mustNotHave: []string{lgtmLabel},
+		},
+		{
+			name:  "/lgtm by non-assignee should not add LGTM label",
+			issue: prWithoutLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm", "user 1", 0),
+				github_test.IssueComment(2, "comment 2", "user 2", 1),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 2")),
+			mustHave:    []string{},
+			mustNotHave: []string{lgtmLabel},
+		},
+		{
+			name:  "/lgtm by assignee should add LGTM label",
+			issue: prWithoutLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm", "user 1", 0),
+				github_test.IssueComment(2, "comment 2", "user 2", 1),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1")),
+			mustHave:    []string{lgtmLabel},
+			mustNotHave: []string{},
+		},
+		{
+			name:  "/lgtm by assignee followed by cancellation by non-assignee should add lgtm",
+			issue: prWithoutLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm", "user 1", 0),
+				github_test.IssueComment(2, "/lgtm cancel", "user 2", 1),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1")),
+			mustHave:    []string{lgtmLabel},
+			mustNotHave: []string{},
+		},
+		{
+			name:  "/lgtm by assignee followed by /lgtm cancel should not add lgtm",
+			issue: prWithoutLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm", "user 1", 0),
+				github_test.IssueComment(2, "/lgtm cancel", "user 2", 1),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1", "user 2")),
+			mustHave:    []string{},
+			mustNotHave: []string{lgtmLabel},
+		},
+		{
+			name:  "/lgtm followed by comment should be honored",
+			issue: prWithoutLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm //this is a comment", "user 1", 0),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1")),
+			mustHave:    []string{lgtmLabel},
+			mustNotHave: []string{},
+		},
+		{
+			name:  "/lgtm cancel by bot should be honored",
+			issue: prWithoutLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm //this is a comment", "user 1", 0),
+				github_test.IssueComment(1, "/lgtm cancel //this is a bot", botName, 0),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1")),
+			mustHave:    []string{},
+			mustNotHave: []string{lgtmLabel},
+		},
+	}
+
+	for testNum, test := range tests {
+		pr := ValidPR()
+		client, server, mux := github_test.InitServer(t, test.issue, pr, nil, nil, nil, nil, nil)
+		path := fmt.Sprintf("/repos/o/r/issue/%s/labels", *test.issue.Number)
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			out := []github.Label{{}}
+			data, err := json.Marshal(out)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			w.Write(data)
+		})
+
+		config := &github_util.Config{}
+		config.Org = "o"
+		config.Project = "r"
+		config.SetClient(client)
+
+		l := LGTMHandler{}
+		obj, err := config.GetObject(*test.issue.Number)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		l.addLGTMIfCommented(obj, test.comments, test.assignees)
+		for _, lab := range test.mustHave {
+			if !obj.HasLabel(lab) {
+				t.Errorf("%s:%d: Did not find label %q, labels: %v", test.name, testNum, lab, obj.Issue.Labels)
+			}
+		}
+		for _, lab := range test.mustNotHave {
+			if obj.HasLabel(lab) {
+				t.Errorf("%s:%d: Found label %q and should not have, labels: %v", test.name, testNum, lab, obj.Issue.Labels)
+			}
+		}
+		server.Close()
+	}
+}
+
+func TestRemoveLGTMIfCommented(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	tests := []struct {
+		name        string
+		comments    []*github.IssueComment
+		issue       *github.Issue
+		assignees   mungerutil.UserSet
+		mustHave    []string
+		mustNotHave []string
+	}{
+		{
+			name:  "LGTM with no comments should be unaffected by other comments.",
+			issue: prWithLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/comment 1", "user 1", 0),
+				github_test.IssueComment(2, "/comment 2 //comment 3", "user 2", 1),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1")),
+			mustHave:    []string{lgtmLabel},
+			mustNotHave: []string{},
+		},
+		{
+			name:  "/lgtm cancel followed by comment should be honored.",
+			issue: prWithLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm cancel // something // something else", "user 1", 0),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1")),
+			mustHave:    []string{},
+			mustNotHave: []string{lgtmLabel},
+		},
+		{
+			name:  "/lgtm cancel by non-assignee should be ignored.",
+			issue: prWithLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm cancel // something // something else", "user 1", 0),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 2")),
+			mustHave:    []string{lgtmLabel},
+			mustNotHave: []string{},
+		},
+		{
+			name:  "/lgtm should be honored if after /lgtm cancel.",
+			issue: prWithLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm cancel // something // something else", "user 1", 0),
+				github_test.IssueComment(1, "/lgtm", "user 1", 1),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1")),
+			mustHave:    []string{lgtmLabel},
+			mustNotHave: []string{},
+		},
+		{
+			name:  "/lgtm cancel by bot should be honored",
+			issue: prWithoutLGTM,
+			comments: []*github.IssueComment{
+				github_test.IssueComment(1, "/lgtm //this is a comment", "user 1", 0),
+				github_test.IssueComment(1, "/lgtm cancel //this is a bot", botName, 0),
+			},
+			assignees:   mungerutil.UserSet(sets.NewString("user 1")),
+			mustHave:    []string{},
+			mustNotHave: []string{lgtmLabel},
+		},
+	}
+
+	for testNum, test := range tests {
+		pr := ValidPR()
+		client, server, mux := github_test.InitServer(t, test.issue, pr, nil, nil, nil, nil, nil)
+		path := fmt.Sprintf("/repos/o/r/issue/%s/labels", *test.issue.Number)
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			out := []github.Label{{}}
+			data, err := json.Marshal(out)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			w.Write(data)
+		})
+
+		config := &github_util.Config{}
+		config.Org = "o"
+		config.Project = "r"
+		config.SetClient(client)
+
+		l := LGTMHandler{}
+		obj, err := config.GetObject(*test.issue.Number)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		l.removeLGTMIfCancelled(obj, test.comments, test.assignees)
+		for _, lab := range test.mustHave {
+			if !obj.HasLabel(lab) {
+				t.Errorf("%s:%d: Did not find label %q, labels: %v", test.name, testNum, lab, obj.Issue.Labels)
+			}
+		}
+		for _, lab := range test.mustNotHave {
+			if obj.HasLabel(lab) {
+				t.Errorf("%s:%d: Found label %q and should not have, labels: %v", test.name, testNum, lab, obj.Issue.Labels)
+			}
+		}
+		server.Close()
+	}
+}

--- a/mungegithub/mungers/mungerutil/util.go
+++ b/mungegithub/mungers/mungerutil/util.go
@@ -24,6 +24,11 @@ import (
 	"github.com/google/go-github/github"
 )
 
+const (
+	// BotName is the name of merge-bot
+	BotName = "k8s-merge-robot"
+)
+
 // UserSet is a set a of users
 type UserSet sets.String
 
@@ -98,7 +103,12 @@ func (u *IssueUsers) AllUsers() UserSet {
 	return u.Assignees.union(u.Author)
 }
 
-// IsValidUser returns true only if given user has valid github username (logic account).
+// IsValidUser returns true only if given user has valid github username.
 func IsValidUser(u *github.User) bool {
 	return u != nil && u.Login != nil
+}
+
+// IsMungeBot returns true only if given user is this bot.
+func IsMungeBot(u *github.User) bool {
+	return IsValidUser(u) && *u.Login == BotName
 }


### PR DESCRIPTION
Fixes #1546
- Adds tests for lgtm_handler.
- Change the message posted by lgtm-after-commit when removing LGTM.

cc @lavalamp @eparis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1550)

<!-- Reviewable:end -->
