### PR TITLE
autoscaler: Remove minimum size requirement

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -208,9 +208,6 @@ func buildAsg(value string, awsManager *AwsManager) (*Asg, error) {
 		awsManager: awsManager,
 	}
 	if size, err := strconv.Atoi(tokens[0]); err == nil {
-		if size <= 0 {
-			return nil, fmt.Errorf("min size must be >= 1")
-		}
 		asg.minSize = size
 	} else {
 		return nil, fmt.Errorf("failed to set min size: %s, expected integer", tokens[0])
@@ -226,7 +223,7 @@ func buildAsg(value string, awsManager *AwsManager) (*Asg, error) {
 	}
 
 	if tokens[2] == "" {
-		return nil, fmt.Errorf("asg name must not be blank: %s got error: %v", tokens[2])
+		return nil, fmt.Errorf("asg name must not be blank: %s", tokens[2])
 	}
 
 	asg.Name = tokens[2]

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -213,9 +213,6 @@ func buildMig(value string, gceManager *GceManager) (*Mig, error) {
 		gceManager: gceManager,
 	}
 	if size, err := strconv.Atoi(tokens[0]); err == nil {
-		if size <= 0 {
-			return nil, fmt.Errorf("min size must be >= 1")
-		}
 		mig.minSize = size
 	} else {
 		return nil, fmt.Errorf("failed to set min size: %s, expected integer", tokens[0])


### PR DESCRIPTION
There are use cases (data processing nodes) where an instance group
would need to be zero most of the time and only scale up on demand.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1564)

<!-- Reviewable:end -->
