### PR TITLE
fix bug in fluentd-es-logging sidecar

### DIFF
--- a/logging/fluentd-sidecar-es/config_generator.sh
+++ b/logging/fluentd-sidecar-es/config_generator.sh
@@ -19,9 +19,24 @@ if [ -z "$FILES_TO_COLLECT" ]; then
   exit 0
 fi
 
+declare -A names_count
+
+function get_uncollided_name {
+  next_name=$1
+  base_name=$1
+  while [ ${names_count[$next_name]} ];
+  do
+    ((names_count[$base_name]++))
+    next_name=${base_name}_${names_count[$base_name]}
+  done
+  names_count+=([$next_name]=1)
+}
+
 for filepath in $FILES_TO_COLLECT
 do
   filename=$(basename $filepath)
+  get_uncollided_name $filename
+  filename=$next_name
   cat > "/etc/td-agent/files/${filename}" << EndOfMessage
 <source>
   type tail


### PR DESCRIPTION
`filename=$(basename $filepath)` will cause problem if multiple files are of the same base name, 
e.g. 
`"/mnt/log1/synthetic-dates.log /mnt/log2/synthetic-dates.log"` are two different files, but there will be only one `/etc/td-agent/files/synthetic-dates.log` indicating fluentd to collect logs from  `/mnt/log2/synthetic-dates.log`.

In my case, the config under /etc/td-agent/files become like `/etc/td-agent/files/_mnt_log1_synthetic-dates.log`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1565)

<!-- Reviewable:end -->
