### PR TITLE
allow logroate when fluentd-sidecar collecting logs

### DIFF
--- a/logging/fluentd-sidecar-es/config_generator.sh
+++ b/logging/fluentd-sidecar-es/config_generator.sh
@@ -35,3 +35,22 @@ do
 </source>
 EndOfMessage
 done
+
+if [ -z "$FILES_TO_ROTATE" ] || [ -z "$SIZE_LIMIT" ] || [ -z "$ROTATE_TIMES" ]; then
+  eixt 0
+fi
+read -ra files_to_rotate <<<"$FILES_TO_ROTATE"
+read -ra size_limit <<<"$SIZE_LIMIT"
+read -ra rotate_times <<<"$ROTATE_TIMES"
+
+if [ ${#files_to_rotate[@]} -eq ${#size_limit[@]} ] && [ ${#files_to_rotate[@]} -eq ${#rotate_times[@]} ]; then
+  for i in ${!files_to_rotate[*]}
+  do
+    cat >> "/etc/logrotate.conf" << EndOfMessage
+${files_to_rotate[i]} {
+  size ${size_limit[i]}
+  rotate ${rotate_times[i]}
+}
+EndOfMessage
+  done
+fi


### PR DESCRIPTION
When collecting logs, we may want logs be rotated to avoid becoming too large.
Users can defile env variables "FILES_TO_ROTATE" to declare files to be rotated, and their "SIZE_LIMIT", "ROTATE_TIMES".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1567)

<!-- Reviewable:end -->
