### PR TITLE
ingress: use POD_NAMESPACE as a namespace in cli parameters

### DIFF
--- a/ingress/controllers/gce/rc.yaml
+++ b/ingress/controllers/gce/rc.yaml
@@ -78,5 +78,5 @@ spec:
             cpu: 100m
             memory: 50Mi
         args:
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
         - --sync-period=300s

--- a/ingress/controllers/gce/rc.yaml
+++ b/ingress/controllers/gce/rc.yaml
@@ -78,5 +78,5 @@ spec:
             cpu: 100m
             memory: 50Mi
         args:
-        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+        - --default-backend-service=default/default-http-backend
         - --sync-period=300s

--- a/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
+++ b/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
@@ -43,5 +43,5 @@ spec:
           hostPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
-        - --nginx-configmap=default/nginx-load-balancer-conf
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+        - --nginx-configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf

--- a/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
+++ b/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
@@ -14,7 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/custom-errors/rc-custom-errors.yaml
+++ b/ingress/controllers/nginx/examples/custom-errors/rc-custom-errors.yaml
@@ -14,7 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
         name: nginx-ingress-lb
@@ -43,4 +43,4 @@ spec:
           hostPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/nginx-errors
+        - --default-backend-service=$(POD_NAMESPACE)/nginx-errors

--- a/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
+++ b/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
@@ -43,7 +43,7 @@ spec:
           hostPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
         volumeMounts:
           - mountPath: /etc/nginx/template
             name: nginx-template-volume

--- a/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
+++ b/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
@@ -14,7 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
+++ b/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
@@ -8,7 +8,7 @@ spec:
       labels:
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
+++ b/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
@@ -37,4 +37,4 @@ spec:
           hostPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/ingress/controllers/nginx/examples/default-backend.yaml
+++ b/ingress/controllers/nginx/examples/default-backend.yaml
@@ -11,7 +11,7 @@ spec:
       labels:
         app: default-http-backend
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - name: default-http-backend
         # Any image is permissable as long as:

--- a/ingress/controllers/nginx/examples/default/rc-default.yaml
+++ b/ingress/controllers/nginx/examples/default/rc-default.yaml
@@ -43,4 +43,4 @@ spec:
           hostPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/ingress/controllers/nginx/examples/default/rc-default.yaml
+++ b/ingress/controllers/nginx/examples/default/rc-default.yaml
@@ -14,7 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/full/rc-full.yaml
+++ b/ingress/controllers/nginx/examples/full/rc-full.yaml
@@ -15,7 +15,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       volumes:
       - name: dhparam-example
         secret:

--- a/ingress/controllers/nginx/examples/full/rc-full.yaml
+++ b/ingress/controllers/nginx/examples/full/rc-full.yaml
@@ -53,5 +53,5 @@ spec:
           name: dhparam-example
         args:
         - /nginx-ingress-controller
-        - --tcp-services-configmap=default/tcp-configmap-example
-        - --default-backend-service=default/default-http-backend
+        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-configmap-example
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
+++ b/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
@@ -42,4 +42,4 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
-        - --nginx-configmap=default/nginx-ingress-controller
+        - --nginx-configmap=$(POD_NAMESPACE)/nginx-ingress-controller

--- a/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
+++ b/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
@@ -41,5 +41,5 @@ spec:
         - containerPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
         - --nginx-configmap=default/nginx-ingress-controller

--- a/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
+++ b/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
@@ -65,23 +65,23 @@ spec:
       labels:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
-    spec:     
+    spec:
       terminationGracePeriodSeconds: 60
       containers:
       - image: alpine:3.4
         name: sysctl-buddy
         # using kubectl exec you can check which other parameters is possible to change
-        # IPC Namespace:     kernel.msgmax, kernel.msgmnb, kernel.msgmni, kernel.sem, kernel.shmall, 
-        #                    kernel.shmmax, kernel.shmmni, kernel.shm_rmid_forced and Sysctls 
+        # IPC Namespace:     kernel.msgmax, kernel.msgmnb, kernel.msgmni, kernel.sem, kernel.shmall,
+        #                    kernel.shmmax, kernel.shmmni, kernel.shm_rmid_forced and Sysctls
         #                    beginning with fs.mqueue.*
         # Network Namespace: Sysctls beginning with net.*
-        # 
+        #
         # kubectl <podname> -c sysctl-buddy -- sysctl -A | grep net
         command:
         - /bin/sh
         - -c
         - |
-          while true; do 
+          while true; do
             sysctl -w net.core.somaxconn=32768
             sysctl -w net.ipv4.ip_local_port_range='1024 65535'
             sleep 10

--- a/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
+++ b/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
@@ -120,4 +120,4 @@ spec:
           hostPort: 8080
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
+++ b/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
@@ -47,5 +47,5 @@ spec:
           hostPort: 9000
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
-        - --tcp-services-configmap=default/tcp-configmap-example
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-configmap-example

--- a/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
+++ b/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
@@ -14,7 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
+++ b/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
@@ -43,4 +43,4 @@ spec:
           hostPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
+++ b/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
@@ -14,7 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
         name: nginx-ingress-lb

--- a/ingress/controllers/nginx/examples/udp/rc-udp.yaml
+++ b/ingress/controllers/nginx/examples/udp/rc-udp.yaml
@@ -45,5 +45,5 @@ spec:
           hostPort: 53
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
         - --udp-services-configmap=default/udp-configmap-example

--- a/ingress/controllers/nginx/examples/udp/rc-udp.yaml
+++ b/ingress/controllers/nginx/examples/udp/rc-udp.yaml
@@ -14,7 +14,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
         name: nginx-ingress-lb
@@ -46,4 +46,4 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
-        - --udp-services-configmap=default/udp-configmap-example
+        - --udp-services-configmap=$(POD_NAMESPACE)/udp-configmap-example

--- a/ingress/controllers/nginx/rc.yaml
+++ b/ingress/controllers/nginx/rc.yaml
@@ -99,4 +99,4 @@ spec:
           hostPort: 18080
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend


### PR DESCRIPTION
When you deploy ingress not into `default` namespace, ingress RC fails with the `no service with name default/default-http-backend found: services "default-http-backend" not found` error message.

This fix uses `POD_NAMESPACE` which we already pass into the pod ENV.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1571)

<!-- Reviewable:end -->
