### PR TITLE
Consider .dia and .svg as documentation

### DIFF
--- a/mungegithub/mungers/docs-no-retest.go
+++ b/mungegithub/mungers/docs-no-retest.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	ignoreFilesRegex = regexp.MustCompile(".*\\.(md|png)$")
+	ignoreFilesRegex = regexp.MustCompile(".*\\.(md|png|svg|dia)$")
 )
 
 // DocsNeedNoRetest automatically labels documentation only pull-requests as retest-not-required


### PR DESCRIPTION
Follow-up on #1566

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1580)

<!-- Reviewable:end -->
