### PR TITLE
quote additional script arguments

### DIFF
--- a/ansible/scripts/deploy-cluster.sh
+++ b/ansible/scripts/deploy-cluster.sh
@@ -17,4 +17,4 @@
 . ./init.sh
 
 inventory=${INVENTORY:-${INVENTORY_DIR}/inventory}
-ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-cluster.yml $@
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-cluster.yml "$@"

--- a/ansible/scripts/deploy-etcd.sh
+++ b/ansible/scripts/deploy-etcd.sh
@@ -17,4 +17,4 @@
 . ./init.sh
 
 inventory=${INVENTORY:-${INVENTORY_DIR}/inventory}
-ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-etcd.yml $@
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-etcd.yml "$@"

--- a/ansible/scripts/restart-etcd.sh
+++ b/ansible/scripts/restart-etcd.sh
@@ -17,4 +17,4 @@
 . ./init.sh
 
 inventory=${INVENTORY:-${INVENTORY_DIR}/inventory}
-ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-etcd.yml --tags "restart" $@
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-etcd.yml --tags "restart" "$@"

--- a/ansible/scripts/update-etcd.sh
+++ b/ansible/scripts/update-etcd.sh
@@ -18,4 +18,4 @@
 
 inventory=${INVENTORY:-${INVENTORY_DIR}/inventory}
 # no configure tag as it will reset everything to defaults
-ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-etcd.yml --tags "install,restart" $@
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-etcd.yml --tags "install,restart" "$@"


### PR DESCRIPTION
If not quoted, `--extra-vars="source_type=packageManager flannel_subnet=10.253.0.0 flannel_network=16"` gets translated into

`ansible ... --extra-vars source_type=packageManager flannel_subnet=10.253.0.0 flannel_prefix=16`

instead of expected

`ansible ... --extra-vars "source_type=packageManager flannel_subnet=10.253.0.0 flannel_prefix=16"`
