### PR TITLE
Only show 512 characters of comments in the logs

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -1611,9 +1611,13 @@ func (obj *MungeObject) ListComments(withListOpts ...WithListOpt) ([]*github.Iss
 // WriteComment will send the `msg` as a comment to the specified PR
 func (obj *MungeObject) WriteComment(msg string) error {
 	config := obj.config
-	prNum := *obj.Issue.Number
+	prNum := obj.Number()
 	config.analytics.CreateComment.Call(config, nil)
-	glog.Infof("Commenting %q in %d", msg, prNum)
+	comment := msg
+	if len(comment) > 512 {
+		comment = comment[:512]
+	}
+	glog.Infof("Commenting in %d: %q", prNum, comment)
 	if config.DryRun {
 		return nil
 	}


### PR DESCRIPTION
When creating new issues or adding comments to existing issue we can
create VERY long comments which make the logs really hard to read. We
don't need all of that in the logs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1593)

<!-- Reviewable:end -->
