### PR TITLE
[nginx-ingress-controller]: Adapt nginx hash sizes to the number of ingress

### DIFF
--- a/ingress/controllers/nginx/nginx/config/config.go
+++ b/ingress/controllers/nginx/nginx/config/config.go
@@ -167,7 +167,7 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size
 	ServerNameHashMaxSize int `structs:"server-name-hash-max-size,omitempty"`
 
-	// Size of the bucker for the server names hash tables
+	// Size of the bucket for the server names hash tables
 	// http://nginx.org/en/docs/hash.html
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size
 	ServerNameHashBucketSize int `structs:"server-name-hash-bucket-size,omitempty"`


### PR DESCRIPTION
This change allows the tuning of 2 important NGINX variables:
- server_names_hash_max_size
- server_names_hash_bucket_size

The default values should be enough for most of the users but after +300 Ingress rules or long hostnames as FQDN NGINX requires tuning of this values or it will not start.

The introduced change allows the self-tuning using the Ingress information
Using `--v=3` it's possible to see the changes:

```
...
I0822 21:42:10.517778       1 template.go:84] adjusting ServerNameHashMaxSize variable from 4096 to 16384
...
```

fixes #1487

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1596)

<!-- Reviewable:end -->
