### PR TITLE
copy inventory group_vars to vagrant inventory directory

### DIFF
--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -205,6 +205,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # This sets up both flannel and kube.
     ansible.playbook = "../playbooks/deploy-cluster.yml"
 
+    # Copy group_vars directory if it exists
+    vagrant_inventory_directory = ".vagrant/provisioners/ansible/inventory"
+    unless File.directory?(vagrant_inventory_directory)
+      FileUtils.mkdir_p(vagrant_inventory_directory)
+    end
+
+    if File.directory?("../inventory/group_vars")
+      FileUtils.copy_entry "../inventory/group_vars", File.join(vagrant_inventory_directory, "group_vars")
+    end
+
     if provider == :virtualbox
       master_ip = VBOX_STATIC_IP_TEMPLATE % 0
 


### PR DESCRIPTION
Vagrant creates its own inventory file without predefined ansible group_vars.
Thus, it is necessary to copy the directory to vagrant inventory as well.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1606)

<!-- Reviewable:end -->
