### PR TITLE
add playbook for kubernetes-addons role, decrease dependency

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -66,6 +66,24 @@ You can just setup certain parts instead of doing it all.
 
 `$ ./deploy-cluster.sh --tags=nodes`
 
+### Addons
+
+By default, the Ansible playbook deploys Kubernetes addons as well. Addons consist of:
+
+* DNS (skydns)
+* cluster monitoring (Grafana, Heapster, InfluxDB)
+* cluster logging (Kibana, ElasticSearch)
+* Kubernetes dashboard
+* Kubernetes dash
+
+In order to skip addons deployment, run
+
+`$ ./deploy-cluster.sh --skip-tags=addons`
+
+In order to run addons deployment only (requires kubernetes master already deployed), run
+
+`$ ./deploy-cluster.sh --tags=addons` or `$ ./deploy-addons.sh`
+
 ### Component sources
 
 Each component can be installed from various sources. For instance:

--- a/ansible/playbooks/deploy-addons.yml
+++ b/ansible/playbooks/deploy-addons.yml
@@ -1,0 +1,8 @@
+---
+- hosts: masters
+  become: yes
+  roles:
+    - kubernetes-addons
+  tags:
+    - addons
+    - dns

--- a/ansible/playbooks/deploy-cluster.yml
+++ b/ansible/playbooks/deploy-cluster.yml
@@ -50,13 +50,7 @@
 - include: deploy-master.yml
 
 # launch addons, like dns
-- hosts: masters
-  become: yes
-  roles:
-    - kubernetes-addons
-  tags:
-    - addons
-    - dns
+- include: deploy-addons.yml
 
 # install kubernetes on the nodes
 - include: deploy-node.yml

--- a/ansible/roles/kubernetes-addons/handlers/main.yml
+++ b/ansible/roles/kubernetes-addons/handlers/main.yml
@@ -6,3 +6,6 @@
 
 - name: restart kube-addons
   service: name=kube-addons state=restarted
+
+- name: restart apiserver
+  service: name=kube-apiserver state=restarted

--- a/ansible/roles/kubernetes-addons/meta/main.yml
+++ b/ansible/roles/kubernetes-addons/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
-  - { role: master }
+  - { role: common }
+  - { role: kubernetes }

--- a/ansible/scripts/deploy-addons.sh
+++ b/ansible/scripts/deploy-addons.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. ./init.sh
+
+inventory=${INVENTORY:-${INVENTORY_DIR}/inventory}
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-addons.yml "$@"


### PR DESCRIPTION
Introduce new playbook for kubernetes-addons role.

At the same time decrease dependency of the role from master to kubernetes. With the master dependency everytime the addons is run (e.g. to update addons), master role is run as well (resulting in update or re-configuration) which is not always desired. On the other hand, if the addons role is run, functioning master is required in advance.

Fixes: #1280

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1607)

<!-- Reviewable:end -->
