### PR TITLE
Add docker source type

### DIFF
--- a/ansible/playbooks/deploy-cluster.yml
+++ b/ansible/playbooks/deploy-cluster.yml
@@ -14,13 +14,7 @@
 - include: deploy-etcd.yml
 
 # Install docker
-- hosts: all
-  become: yes
-  roles:
-    - common
-    - docker
-  tags:
-    - docker
+- include: deploy-docker.yml
 
 # install flannel
 - hosts:

--- a/ansible/playbooks/deploy-docker.yml
+++ b/ansible/playbooks/deploy-docker.yml
@@ -1,0 +1,9 @@
+---
+# Install docker
+- hosts: all
+  become: yes
+  roles:
+    - common
+    - docker
+  tags:
+    - docker

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -1,2 +1,19 @@
 no_proxy: "localhost,127.0.0.0/8,::1,/var/run/docker.sock"
 docker_config_dir: "/etc/sysconfig"
+
+# Set source of docker binaries
+# Available: package-manager, distribution-rpm, custom-repository
+docker_source_type: "package-manager"
+docker_package_name: "docker"
+
+docker_repository_baseurl: https://yum.dockerproject.org/repo/main/centos/$releasever/
+docker_repository_gpgkey: https://yum.dockerproject.org/gpg
+
+# The URL do download distribution rpms shipping docker binaries from
+docker_rpm_url_base: https://kojipkgs.fedoraproject.org//packages/docker/1.10.3/41.git78aa320.fc23/x86_64
+docker_rpm_url_sufix: 1.10.3-41.git78aa320.fc23.x86_64.rpm
+
+docker_rpms:
+- docker-selinux
+- docker-forward-journald
+- docker

--- a/ansible/roles/docker/tasks/custom-repo-install.yml
+++ b/ansible/roles/docker/tasks/custom-repo-install.yml
@@ -1,0 +1,6 @@
+---
+- name: Install docker custom repository
+  template: src=dockerrepo.repo.j2 dest=/etc/yum.repos.d/dockerrepo.repo
+
+- name: Install docker from custom repository
+  action: "{{ ansible_pkg_mgr }} name={{ docker_package_name }} state=latest enablerepo=dockerrepo"

--- a/ansible/roles/docker/tasks/generic-install.yml
+++ b/ansible/roles/docker/tasks/generic-install.yml
@@ -2,6 +2,6 @@
 - name: Generic | Install Docker
   action: "{{ ansible_pkg_mgr }}"
   args:
-    name: docker
+    name: "{{ docker_package_name }}"
     state: latest
   when: not is_atomic

--- a/ansible/roles/docker/tasks/install-rpms.yml
+++ b/ansible/roles/docker/tasks/install-rpms.yml
@@ -1,0 +1,6 @@
+---
+- name: Install docker distribution rpms
+  yum: name={{ docker_rpm_url_base }}/{{ item }}-{{ docker_rpm_url_sufix }}
+  with_items:
+    - "{{ docker_rpms }}"
+ 

--- a/ansible/roles/docker/tasks/install.yml
+++ b/ansible/roles/docker/tasks/install.yml
@@ -1,0 +1,18 @@
+---
+- include: debian-install.yml
+  when: ansible_distribution == "Debian" and docker_source_type == "package-manager"
+
+- include: apt-docker-install.yml
+  when: ansible_distribution == "Ubuntu" and docker_source_type == "package-manager"
+
+- include: generic-install.yml
+  when: ansible_distribution != "Debian" and ansible_distribution != "Ubuntu" and not is_coreos and docker_source_type == "package-manager"
+
+- include: coreos.yml
+  when: is_coreos
+
+- include: custom-repo-install.yml
+  when: docker_source_type == "custom-repository"
+
+- include: install-rpms.yml
+  when: docker_source_type == "distribution-rpm"

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -7,17 +7,9 @@
 - name: Create config file directory
   file: path={{ docker_config_dir }} state=directory
 
-- include: debian-install.yml
-  when: ansible_distribution == "Debian"
+- name: Install docker
+  include: install.yml
 
-- include: apt-docker-install.yml
-  when: ansible_distribution == "Ubuntu"
-
-- include: generic-install.yml
-  when: ansible_distribution != "Debian" and ansible_distribution != "Ubuntu" and not is_coreos
-
-- include: coreos.yml
-  when: is_coreos
 #
 # systemd service configuration uses EnvironmentFile (docker and docker-network)
 # upstart service configuration sources docker_config_dir / docker

--- a/ansible/roles/docker/templates/dockerrepo.repo.j2
+++ b/ansible/roles/docker/templates/dockerrepo.repo.j2
@@ -1,0 +1,10 @@
+[dockerrepo]
+name=Docker Repository
+baseurl={{ docker_repository_baseurl }}
+enabled=0
+{% if docker_repository_gpgkey == "" %}
+gpgcheck=0
+{% else %}
+gpgcheck=1
+gpgkey={{ docker_repository_gpgkey }}
+{% endif %}

--- a/ansible/scripts/deploy-docker.sh
+++ b/ansible/scripts/deploy-docker.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. ./init.sh
+
+inventory=${INVENTORY:-${INVENTORY_DIR}/inventory}
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-docker.yml "$@"


### PR DESCRIPTION
Continuing with effort in https://github.com/kubernetes/contrib/pull/456 and https://github.com/kubernetes/contrib/pull/291. All credits to @rsmitty and @furikake for bringing the topic up. I have just put crumbs together.

With this PR docker can be installed in addtion to the usual way (via distribution package manager) from custom docker repository or from distribution rpm.

Introducing separate playbook and script so it is easier to test the docker role separately.

Fixes: #455

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1610)

<!-- Reviewable:end -->
