### PR TITLE
iptables: adapt for new iptables mode

### DIFF
--- a/ansible/roles/flannel/tasks/firewalld.yml
+++ b/ansible/roles/flannel/tasks/firewalld.yml
@@ -13,14 +13,24 @@
   # we have to manually invoke firewall-cmd
 - name: Open flanneld subnet traffic
   command: /bin/firewall-cmd --direct --add-rule ipv4 filter FORWARD 1
-           -i flannel.1 -o docker0 -j ACCEPT
-           -m comment --comment "flannel subnet"
+           -i flannel.1 -j ACCEPT -m comment --comment "flannel subnet"
   # in case this is also a node where firewalld turned off
   ignore_errors: yes
 
 - name: Save flanneld subnet traffic
   command: /bin/firewall-cmd --permanent --direct --add-rule ipv4 filter FORWARD 1
-           -i flannel.1 -o docker0 -j ACCEPT
-           -m comment --comment "flannel subnet"
+           -i flannel.1 -j ACCEPT -m comment --comment "flannel subnet"
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+
+- name: Open flanneld to DNAT'ed traffic
+  command: /bin/firewall-cmd --direct --add-rule ipv4 filter FORWARD 1
+           -o flannel.1 -j ACCEPT -m comment --comment "flannel subnet"
+  # in case this is also a node where firewalld turned off
+  ignore_errors: yes
+
+- name: Save flanneld to DNAT'ed traffic
+  command: /bin/firewall-cmd --permanent --direct --add-rule ipv4 filter FORWARD 1
+           -o flannel.1 -j ACCEPT -m comment --comment "flannel subnet"
   # in case this is also a node where firewalld turned off
   ignore_errors: yes

--- a/ansible/roles/flannel/tasks/iptables.yml
+++ b/ansible/roles/flannel/tasks/iptables.yml
@@ -12,7 +12,11 @@
            -j ACCEPT -m comment --comment "vxlan"
 
 - name: Allow flanneld subnet traffic with iptables
-  command: /sbin/iptables -I FORWARD 1 -i flannel.1 -o docker0
+  command: /sbin/iptables -I FORWARD 1 -i flannel.1
+           -j ACCEPT -m comment --comment "flannel subnet"
+
+- name: Allow DNAT'ed packets through to flanneld
+  command: /sbin/iptables -I FORWARD 1 -o flannel.1
            -j ACCEPT -m comment --comment "flannel subnet"
 
 - name: Save iptables rules

--- a/ansible/roles/node/tasks/firewalld.yml
+++ b/ansible/roles/node/tasks/firewalld.yml
@@ -17,12 +17,26 @@
   ignore_errors: yes
   when: open_cadvisor_port
 
+# this is needed if the kube-proxy is running in userspace mode
 - name: Open redirected service traffic
   command: /bin/firewall-cmd --direct --add-rule ipv4 filter INPUT 1
            -i docker0 -j ACCEPT -m comment --comment "kube-proxy redirects"
   ignore_errors: yes
 
+# this is needed if the kube-proxy is running in userspace mode
 - name: Save redirected service traffic
   command: /bin/firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT 1
            -i docker0 -j ACCEPT -m comment --comment "kube-proxy redirects"
+  ignore_errors: yes
+
+# this is needed if the kube-proxy is running in iptables mode
+- name: Open DNAT'ed service traffic
+  command: /bin/firewall-cmd --direct --add-rule ipv4 filter FORWARD 1
+           -o docker0 -j ACCEPT -m comment --comment "docker subnet"
+  ignore_errors: yes
+
+# this is needed if the kube-proxy is running in iptables mode
+- name: Save DNAT'ed service traffic
+  command: /bin/firewall-cmd --permanent --direct --add-rule ipv4 filter FORWARD 1
+           -o docker0 -j ACCEPT -m comment --comment "docker subnet"
   ignore_errors: yes

--- a/ansible/roles/node/tasks/iptables.yml
+++ b/ansible/roles/node/tasks/iptables.yml
@@ -11,9 +11,15 @@
   command: /sbin/iptables -I INPUT 1 -p tcp --dport 10250 -j ACCEPT -m comment --comment "kubelet"
   when: "'kubelet' not in iptablesrules.stdout"
 
+# this is needed if the kube-proxy is running in userspace mode
 - name: Allow redirected service traffic
   command: /sbin/iptables -I INPUT 1 -i docker0
       -j ACCEPT -m comment --comment "kube-proxy redirects"
+
+# this is needed if the kube-proxy is running in iptables mode
+- name: Allow DNAT'ed traffic through to docker
+  command: /sbin/iptables -I FORWARD 1 -o docker0
+      -j ACCEPT -m comment --comment "docker subnet"
 
 - name: Save iptables rules
   command: service iptables save


### PR DESCRIPTION
In the new "iptables" mode of kube-proxy, packets addressed for a node
port will get DNAT'ed to one of the endpoints. If that endpoint does not
reside on the node, then flannel needs to be able to do the proxying to
the endpoint. We generalize and add flannel rules for this.

If the endpoint does reside on the node, then the packet will be
addressed to the docker bridge, in which case we need to allow it. We
modify the node rules for this. The previous node rules there are no
longer needed (they were only relevant in the "userspace" mode).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1612)

<!-- Reviewable:end -->
