### PR TITLE
Add kubernetes-cross-build to list of non-blocking builds

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -16,7 +16,7 @@ data:
 
   # submit-queue options.
   submit-queue.required-contexts: "Jenkins GCE Node e2e"
-  submit-queue.nonblocking-jenkins-jobs: kubernetes-e2e-gke-staging,kubernetes-e2e-gke-staging-parallel,kubernetes-e2e-gce-serial,kubernetes-e2e-gke-serial,kubernetes-e2e-gke-test,kubernetes-e2e-gce-examples,kubernetes-e2e-gce-federation,kubernetes-e2e-gce-scalability,kubernetes-soak-continuous-e2e-gce,kubernetes-soak-continuous-e2e-gke,kubernetes-kubemark-5-gce,kubernetes-kubemark-500-gce,kubelet-serial-gce-e2e-ci
+  submit-queue.nonblocking-jenkins-jobs: kubernetes-cross-build,kubernetes-e2e-gke-staging,kubernetes-e2e-gke-staging-parallel,kubernetes-e2e-gce-serial,kubernetes-e2e-gke-serial,kubernetes-e2e-gke-test,kubernetes-e2e-gce-examples,kubernetes-e2e-gce-federation,kubernetes-e2e-gce-scalability,kubernetes-soak-continuous-e2e-gce,kubernetes-soak-continuous-e2e-gke,kubernetes-kubemark-5-gce,kubernetes-kubemark-500-gce,kubelet-serial-gce-e2e-ci
   submit-queue.jenkins-jobs: kubelet-gce-e2e-ci,kubernetes-build,kubernetes-test-go,kubernetes-verify-master,kubernetes-e2e-gce,kubernetes-e2e-gce-slow,kubernetes-e2e-gke,kubernetes-e2e-gke-slow
   submit-queue.presubmit-jobs: kubernetes-pull-build-test-e2e-gce,kubernetes-pull-build-test-e2e-gke,kubernetes-pull-build-test-federation-e2e-gce,node-pull-build-e2e-test
   submit-queue.weak-stable-jobs: "\"\""


### PR DESCRIPTION
I'd prefer this to be a blocking build, but we aren't doing a full crossbuild on PRs, so I guess we don't want to make it blocking?

Broken crossbuild does already block cutting releases, though.

cc @luxas @david-mcmahon @spxtr 

x-ref https://github.com/kubernetes/test-infra/issues/393

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1613)

<!-- Reviewable:end -->
