### PR TITLE
Add newlines in publisher bot's commit message

### DIFF
--- a/mungegithub/mungers/publisher.sh
+++ b/mungegithub/mungers/publisher.sh
@@ -52,7 +52,9 @@ if git diff --cached --exit-code &>/dev/null; then
     echo "nothing has changed!"
     exit 0
 fi
-git commit -m "published by bot, copied from ${SRCURL}, last commit is ${commit_hash}"
+git commit -m "published by bot
+copied from ${SRCURL}
+last commit is ${commit_hash}"
 git push origin master
 popd > /dev/null
 rm -f ~/.netrc


### PR DESCRIPTION
To make the commit message present nicely in github.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1614)

<!-- Reviewable:end -->
