### PR TITLE
That could be nil

### DIFF
--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -115,7 +115,7 @@ func (b *BlunderbussMunger) Munge(obj *github.MungeObject) {
 			glog.Warningf("Couldn't find an owner for: %s", *file.Filename)
 		}
 
-		if b.features.Aliases.IsEnabled {
+		if b.features.Aliases != nil && b.features.Aliases.IsEnabled {
 			fileOwners = b.features.Aliases.Expand(fileOwners)
 		}
 


### PR DESCRIPTION
I'm pushing this right now because the merge queue is hitting it and crashlooping.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1615)

<!-- Reviewable:end -->
