### PR TITLE
Requesting blunderbuss feature to read aliases.

### DIFF
--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -52,7 +52,9 @@ func init() {
 func (b *BlunderbussMunger) Name() string { return "blunderbuss" }
 
 // RequiredFeatures is a slice of 'features' that must be provided
-func (b *BlunderbussMunger) RequiredFeatures() []string { return []string{features.RepoFeatureName} }
+func (b *BlunderbussMunger) RequiredFeatures() []string {
+	return []string{features.RepoFeatureName, features.AliasesFeature}
+}
 
 // Initialize will initialize the munger
 func (b *BlunderbussMunger) Initialize(config *github.Config, features *features.Features) error {


### PR DESCRIPTION
Turn on the aliases feature in the blunderbuss munger.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1617)

<!-- Reviewable:end -->
