### PR TITLE
define fake 'restart deamons' handler for kubernetes-addons role

### DIFF
--- a/ansible/roles/kubernetes-addons/handlers/main.yml
+++ b/ansible/roles/kubernetes-addons/handlers/main.yml
@@ -9,3 +9,9 @@
 
 - name: restart apiserver
   service: name=kube-apiserver state=restarted
+
+# The kubernetes role invokes restart daemons. It must be defined here
+# since the kubernetes-addons playbook depends on that role to setup basic
+# variables such as the kubernetes configuration file directory.
+- name: restart daemons
+  command: /bin/true


### PR DESCRIPTION
The kubernetes role invokes restart daemons. It must be defined here
since the kubernetes-addons playbook depends on that role to setup basic
variables such as the kubernetes configuration file directory.

Fixes: #1619

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1620)

<!-- Reviewable:end -->
