### PR TITLE
Cluster-autoscaler: handle nil interfaces in CheckGroupsAndNodes

### DIFF
--- a/cluster-autoscaler/utils.go
+++ b/cluster-autoscaler/utils.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"k8s.io/contrib/cluster-autoscaler/cloudprovider"
@@ -132,7 +133,7 @@ func CheckGroupsAndNodes(nodes []*kube_api.Node, cloudProvider cloudprovider.Clo
 		if err != nil {
 			return err
 		}
-		if group == nil {
+		if group == nil || reflect.ValueOf(group).IsNil() {
 			continue
 		}
 		id := group.Id()


### PR DESCRIPTION
Workaround for nil check semantics in go.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1622)

<!-- Reviewable:end -->
