### PR TITLE
Support SSL bridge mode with HAProxy and ACLs per ServicePort

### DIFF
--- a/service-loadbalancer/.gitignore
+++ b/service-loadbalancer/.gitignore
@@ -1,1 +1,2 @@
 service_loadbalancer
+command-line-arguments.test

--- a/service-loadbalancer/Makefile
+++ b/service-loadbalancer/Makefile
@@ -6,9 +6,13 @@ PREFIX ?= gcr.io/google_containers/servicelb
 GCLOUD ?= gcloud
 HAPROXY_IMAGE = contrib-haproxy
 SRC = service_loadbalancer.go loadbalancer_log.go
+TEST = service_loadbalancer_test.go loadbalancer_log_test.go
 
 service_loadbalancer: $(SRC)
 	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o $@ $(SRC)
+
+test:
+	CGO_ENABLED=0 GOOS=linux godep go test $(SRC) $(TEST)
 
 container: service_loadbalancer
 	docker build -t $(PREFIX):$(TAG) .

--- a/service-loadbalancer/loadbalancer_log_test.go
+++ b/service-loadbalancer/loadbalancer_log_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"testing"
+	"os"
 )
 
 func TestSyslogSocket(t *testing.T) {
@@ -27,4 +28,5 @@ func TestSyslogSocket(t *testing.T) {
 	}
 
 	server.Shutdown()
+	os.Remove("./test-syslog.socket")
 }

--- a/service-loadbalancer/loadbalancer_log_test.go
+++ b/service-loadbalancer/loadbalancer_log_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"testing"
 	"os"
+	"testing"
 )
 
 func TestSyslogSocket(t *testing.T) {

--- a/service-loadbalancer/service_loadbalancer.go
+++ b/service-loadbalancer/service_loadbalancer.go
@@ -233,7 +233,7 @@ func (s serviceAnnotations) getAlgorithm() (string, bool) {
 }
 
 func (s serviceAnnotations) getHost(servicePortName string) (string, bool) {
-	index := lbHostKey + "." + servicePortName;
+	index := lbHostKey + "." + servicePortName
 	if val, ok := s[index]; ok {
 		return val, ok
 	}
@@ -252,7 +252,7 @@ func (s serviceAnnotations) getSslTerm() (string, bool) {
 }
 
 func (s serviceAnnotations) getAclMatch(servicePortName string) (string, bool) {
-	index := lbAclMatch + "." + servicePortName;
+	index := lbAclMatch + "." + servicePortName
 	if val, ok := s[index]; ok {
 		return val, ok
 	}
@@ -261,7 +261,7 @@ func (s serviceAnnotations) getAclMatch(servicePortName string) (string, bool) {
 }
 
 func (s serviceAnnotations) getSslProxy(servicePortName string) (string, bool) {
-	index := lbSslBridge + "." + servicePortName;
+	index := lbSslBridge + "." + servicePortName
 	if val, ok := s[index]; ok {
 		return val, ok
 	}
@@ -520,7 +520,7 @@ func (lbc *loadBalancerController) getServices() (httpSvc []service, httpsTermSv
 				newSvc.FrontendPort = lbc.httpPort
 				if newSvc.SslTerm == true {
 					httpsTermSvc = append(httpsTermSvc, newSvc)
-				} else if (newSvc.SslProxy == true) {
+				} else if newSvc.SslProxy == true {
 					httpsSvc = append(httpsSvc, newSvc)
 				} else {
 					httpSvc = append(httpSvc, newSvc)

--- a/service-loadbalancer/service_loadbalancer_test.go
+++ b/service-loadbalancer/service_loadbalancer_test.go
@@ -312,9 +312,9 @@ func TestDefaultAlgorithm(t *testing.T) {
 	httpSvc, _, tcpSvc, httpsSvc := flb.getServices()
 	if err := flb.cfg.write(
 		map[string][]service{
-			"http": httpSvc,
+			"http":  httpSvc,
 			"https": httpsSvc,
-			"tcp":  tcpSvc,
+			"tcp":   tcpSvc,
 		}, false); err != nil {
 		t.Fatalf("Expected a valid HAProxy cfg, but an error was returned: %v", err)
 	}
@@ -328,9 +328,9 @@ func TestDefaultCustomAlgorithm(t *testing.T) {
 	httpSvc, _, tcpSvc, httpsSvc := flb.getServices()
 	if err := flb.cfg.write(
 		map[string][]service{
-			"http": httpSvc,
+			"http":  httpSvc,
 			"https": httpsSvc,
-			"tcp":  tcpSvc,
+			"tcp":   tcpSvc,
 		}, false); err != nil {
 		t.Fatalf("Expected at least one tcp or http service: %v", err)
 	}
@@ -345,9 +345,9 @@ func TestSyslog(t *testing.T) {
 	flb.cfg.startSyslog = true
 	if err := flb.cfg.write(
 		map[string][]service{
-			"http": httpSvc,
+			"http":  httpSvc,
 			"https": httpsSvc,
-			"tcp":  tcpSvc,
+			"tcp":   tcpSvc,
 		}, false); err != nil {
 		t.Fatalf("Expected at least one tcp or http service: %v", err)
 	}
@@ -362,9 +362,9 @@ func TestSvcCustomAlgorithm(t *testing.T) {
 	httpSvc[0].Algorithm = "leastconn"
 	if err := flb.cfg.write(
 		map[string][]service{
-			"http": httpSvc,
+			"http":  httpSvc,
 			"https": httpsSvc,
-			"tcp":  tcpSvc,
+			"tcp":   tcpSvc,
 		}, false); err != nil {
 		t.Fatalf("Expected at least one tcp or http service: %v", err)
 	}
@@ -379,9 +379,9 @@ func TestCustomDefaultAndSvcAlgorithm(t *testing.T) {
 	httpSvc[0].Algorithm = "roundrobin"
 	if err := flb.cfg.write(
 		map[string][]service{
-			"http": httpSvc,
+			"http":  httpSvc,
 			"https": httpsSvc,
-			"tcp":  tcpSvc,
+			"tcp":   tcpSvc,
 		}, false); err != nil {
 		t.Fatalf("Expected at least one tcp or http service: %v", err)
 	}
@@ -396,9 +396,9 @@ func TestServiceAffinity(t *testing.T) {
 	httpSvc[0].SessionAffinity = true
 	if err := flb.cfg.write(
 		map[string][]service{
-			"http": httpSvc,
+			"http":  httpSvc,
 			"https": httpsSvc,
-			"tcp":  tcpSvc,
+			"tcp":   tcpSvc,
 		}, false); err != nil {
 		t.Fatalf("Expected at least one tcp or http service: %v", err)
 	}
@@ -414,9 +414,9 @@ func TestServiceAffinityWithCookies(t *testing.T) {
 	httpSvc[0].CookieStickySession = true
 	if err := flb.cfg.write(
 		map[string][]service{
-			"http": httpSvc,
+			"http":  httpSvc,
 			"https": httpsSvc,
-			"tcp":  tcpSvc,
+			"tcp":   tcpSvc,
 		}, false); err != nil {
 		t.Fatalf("Expected at least one tcp or http service: %v", err)
 	}
@@ -458,26 +458,26 @@ func TestRulesPerService(t *testing.T) {
 	svc1 := getService(svc1ServicePorts)
 	svc1.ObjectMeta.Name = "svc-1"
 	svc1.ObjectMeta.Annotations = map[string]string{
-		lbAclMatch + ".svc1-http-port": "-i /svc1-http-custom-acl",
-		lbHostKey + ".svc1-http-port": "svc1-http-custom-acl.mydomain",
-		lbHostKey + ".svc1-https-port": "svc1-https-custom-acl.mydomain",
+		lbAclMatch + ".svc1-http-port":   "-i /svc1-http-custom-acl",
+		lbHostKey + ".svc1-http-port":    "svc1-http-custom-acl.mydomain",
+		lbHostKey + ".svc1-https-port":   "svc1-https-custom-acl.mydomain",
 		lbSslBridge + ".svc1-https-port": "true",
 	}
 	svc2 := getService(svc2ServicePorts)
 	svc2.ObjectMeta.Name = "svc-2"
 	svc2.ObjectMeta.Annotations = map[string]string{
-		lbSslTerm: "true",
-		lbAclMatch + ".svc2-http-port": "-i /svc2-http-custom-acl",
-		lbHostKey + ".svc2-http-port": "svc2-http-custom-acl.mydomain",
-		lbHostKey + ".svc2-https-port": "svc2-https-custom-acl.mydomain",
+		lbSslTerm:                        "true",
+		lbAclMatch + ".svc2-http-port":   "-i /svc2-http-custom-acl",
+		lbHostKey + ".svc2-http-port":    "svc2-http-custom-acl.mydomain",
+		lbHostKey + ".svc2-https-port":   "svc2-https-custom-acl.mydomain",
 		lbSslBridge + ".svc2-https-port": "true",
 	}
 	svc3 := getService(svc3ServicePorts)
 	svc3.ObjectMeta.Name = "svc-3"
 	svc3.ObjectMeta.Annotations = map[string]string{
-		lbSslBridge: "true",
+		lbSslBridge:                       "true",
 		lbAclMatch + ".svc3-https-1-port": "-i /svc3-https-1-custom-acl",
-		lbHostKey + ".svc3-https-2-port": "svc3-https-2-custom-acl.mydomain",
+		lbHostKey + ".svc3-https-2-port":  "svc3-https-2-custom-acl.mydomain",
 	}
 
 	endpoints := []*api.Endpoints{
@@ -496,13 +496,13 @@ func TestRulesPerService(t *testing.T) {
 	cfgFile, _ := filepath.Abs("test-rules-per-svc-" + string(util.NewUUID()))
 	flb.cfg.Config = cfgFile
 
-	httpSvc, httpsTermSvc, tcpSvc, httpsSvc  := flb.getServices()
+	httpSvc, httpsTermSvc, tcpSvc, httpsSvc := flb.getServices()
 	if err := flb.cfg.write(
 		map[string][]service{
-			"http": httpSvc,
+			"http":      httpSvc,
 			"httpsTerm": httpsTermSvc,
-			"tcp":  tcpSvc,
-			"https": httpsSvc,
+			"tcp":       tcpSvc,
+			"https":     httpsSvc,
 		}, false); err != nil {
 		t.Fatalf("Expected at least one tcp or http service: %v", err)
 	}

--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -3,8 +3,9 @@
 global
     daemon
     stats socket /tmp/haproxy
-    server-state-file global       
+    server-state-file global
     server-state-base /var/state/haproxy/
+    tune.ssl.default-dh-param 2048
 
 {{ if eq .startSyslog "true" }}
     # log using a syslog socket
@@ -19,29 +20,29 @@ global
 
 defaults
     log global
-   
+
     load-server-state-from-file global
-    
+
     # Enable session redistribution in case of connection failure.
     option redispatch
-    
-    # Disable logging of null connections (haproxy connections like checks). 
+
+    # Disable logging of null connections (haproxy connections like checks).
     # This avoids excessive logs from haproxy internals.
     option dontlognull
-    
+
     # Enable HTTP connection closing on the server side.
     option http-server-close
 
-    # Enable insertion of the X-Forwarded-For header to requests sent to 
+    # Enable insertion of the X-Forwarded-For header to requests sent to
     # servers and keep client IP address.
     option forwardfor
-    
+
     # Enable HTTP keep-alive from client to server.
     option http-keep-alive
 
     # Clients should send their full http request in 5s.
     timeout http-request    5s
-    
+
     # Maximum time to wait for a connection attempt to a server to succeed.
     timeout connect         5s
 
@@ -50,16 +51,16 @@ defaults
     timeout client          50s
 
     # Inactivity timeout on the client side for half-closed connections.
-    # Applies when the client is expected to acknowledge or send data 
+    # Applies when the client is expected to acknowledge or send data
     # while one direction is already shut down.
     timeout client-fin      50s
-    
+
     # Maximum inactivity time on the server side.
     timeout server          50s
-    
+
     # timeout to use with WebSocket and CONNECT
     timeout tunnel          1h
-    
+
     # Maximum allowed time to wait for a new HTTP request to appear.
     timeout http-keep-alive 60s
 
@@ -81,6 +82,7 @@ listen stats
     stats realm Haproxy\ Statistics
     stats uri /
 
+
 {{ if ne .sslCert "" }}
 frontend httpsfrontend
     mode http
@@ -90,17 +92,26 @@ frontend httpsfrontend
     rspadd  Strict-Transport-Security:\ max-age=15768000
 
 {{range $i, $svc := .services.httpsTerm}}
-    {{ if $svc.AclMatch }} acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
-    {{else}} acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
+    {{ if $svc.AclMatch }}acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
+    {{else}}acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
     {{ end }}
-    
+
     {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
     use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
     {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
 {{ end }}
 {{end}}
-{{end}}
+{{range $i, $svc := .services.https}}
+    {{ if $svc.AclMatch }}acl https_url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
+    {{else}}acl https_url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
+    {{end}}
 
+    {{ if $svc.Host }}acl https_host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
+    use_backend https_{{$svc.Name}} if https_url_acl_{{$svc.Name}} or https_host_acl_{{$svc.Name}}
+    {{ else }}use_backend https_{{$svc.Name}} if https_url_acl_{{$svc.Name}}
+{{ end }}
+{{end}}
+{{end}}
 
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80
@@ -170,10 +181,10 @@ backend {{$svc.Name}}
 
     balance {{$svc.Algorithm}}
 
-    {{if ( not $svc.AclMatch )}}
+{{if ( not $svc.AclMatch )}}
     #Rewrite the request back to root from the url that is used for the frontend.
     reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
-    {{end}}
+{{end}}
 
 {{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
     # create a stickiness table using client IP address as key
@@ -196,6 +207,47 @@ backend {{$svc.Name}}
 {{end}}
 {{end}}
 
+{{range $i, $svc := .services.https}}
+{{ $svcName := $svc.Name }}
+backend https_{{$svc.Name}}
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance {{$svc.Algorithm}}
+
+{{if ( not $svc.AclMatch )}}
+    #Rewrite the request back to root from the url that is used for the frontend.
+    reqrep ^([^\ :]*)\ /{{$svc.Name}}[/]?(.*) \1\ /\2
+{{end}}
+
+{{if and $svc.SessionAffinity (not $svc.CookieStickySession)}}
+    # create a stickiness table using client IP address as key
+    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
+    stick-table type ip size 100k expire 30m
+    stick on src
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} check ssl
+    {{end}}
+{{end}}
+
+{{if and $svc.SessionAffinity $svc.CookieStickySession}}
+    # insert a cookie with name SERVERID to stick a client with a backend server
+    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie
+    cookie SERVERID insert indirect nocache
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} cookie s{{$j}} check ssl
+    {{end}}
+{{end}}
+
+{{if and (not $svc.SessionAffinity) (not $svc.CookieStickySession)}}
+    {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}} check ssl
+    {{end}}
+{{end}}
+{{end}}
+
 {{range $i, $svc := .services.tcp}}
 {{ $svcName := $svc.Name }}
 frontend {{$svc.Name}}
@@ -210,7 +262,7 @@ backend {{$svc.Name}}
     # create a stickiness table using client IP address as key
     # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
     stick-table type ip size 100k expire 30m
-    stick on src    
+    stick on src
 {{end}}
     {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
     {{end}}

--- a/service-loadbalancer/test-samples/TestCustomDefaultAndSvcAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestCustomDefaultAndSvcAlgorithm.cfg
@@ -3,8 +3,9 @@
 global
     daemon
     stats socket /tmp/haproxy
-    server-state-file global       
+    server-state-file global
     server-state-base /var/state/haproxy/
+    tune.ssl.default-dh-param 2048
 
 
 
@@ -12,29 +13,29 @@ global
 
 defaults
     log global
-   
+
     load-server-state-from-file global
-    
+
     # Enable session redistribution in case of connection failure.
     option redispatch
-    
-    # Disable logging of null connections (haproxy connections like checks). 
+
+    # Disable logging of null connections (haproxy connections like checks).
     # This avoids excessive logs from haproxy internals.
     option dontlognull
-    
+
     # Enable HTTP connection closing on the server side.
     option http-server-close
 
-    # Enable insertion of the X-Forwarded-For header to requests sent to 
+    # Enable insertion of the X-Forwarded-For header to requests sent to
     # servers and keep client IP address.
     option forwardfor
-    
+
     # Enable HTTP keep-alive from client to server.
     option http-keep-alive
 
     # Clients should send their full http request in 5s.
     timeout http-request    5s
-    
+
     # Maximum time to wait for a connection attempt to a server to succeed.
     timeout connect         5s
 
@@ -43,16 +44,16 @@ defaults
     timeout client          50s
 
     # Inactivity timeout on the client side for half-closed connections.
-    # Applies when the client is expected to acknowledge or send data 
+    # Applies when the client is expected to acknowledge or send data
     # while one direction is already shut down.
     timeout client-fin      50s
-    
+
     # Maximum inactivity time on the server side.
     timeout server          50s
-    
+
     # timeout to use with WebSocket and CONNECT
     timeout tunnel          1h
-    
+
     # Maximum allowed time to wait for a new HTTP request to appear.
     timeout http-keep-alive 60s
 
@@ -192,6 +193,7 @@ backend svc-2:443
     server 1.2.3.4:443 1.2.3.4:443 check port 443 inter 5
     server 5.6.7.8:443 5.6.7.8:443 check port 443 inter 5
     
+
 
 
 

--- a/service-loadbalancer/test-samples/TestDefaultAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestDefaultAlgorithm.cfg
@@ -3,8 +3,9 @@
 global
     daemon
     stats socket /tmp/haproxy
-    server-state-file global       
+    server-state-file global
     server-state-base /var/state/haproxy/
+    tune.ssl.default-dh-param 2048
 
 
 
@@ -12,29 +13,29 @@ global
 
 defaults
     log global
-   
+
     load-server-state-from-file global
-    
+
     # Enable session redistribution in case of connection failure.
     option redispatch
-    
-    # Disable logging of null connections (haproxy connections like checks). 
+
+    # Disable logging of null connections (haproxy connections like checks).
     # This avoids excessive logs from haproxy internals.
     option dontlognull
-    
+
     # Enable HTTP connection closing on the server side.
     option http-server-close
 
-    # Enable insertion of the X-Forwarded-For header to requests sent to 
+    # Enable insertion of the X-Forwarded-For header to requests sent to
     # servers and keep client IP address.
     option forwardfor
-    
+
     # Enable HTTP keep-alive from client to server.
     option http-keep-alive
 
     # Clients should send their full http request in 5s.
     timeout http-request    5s
-    
+
     # Maximum time to wait for a connection attempt to a server to succeed.
     timeout connect         5s
 
@@ -43,16 +44,16 @@ defaults
     timeout client          50s
 
     # Inactivity timeout on the client side for half-closed connections.
-    # Applies when the client is expected to acknowledge or send data 
+    # Applies when the client is expected to acknowledge or send data
     # while one direction is already shut down.
     timeout client-fin      50s
-    
+
     # Maximum inactivity time on the server side.
     timeout server          50s
-    
+
     # timeout to use with WebSocket and CONNECT
     timeout tunnel          1h
-    
+
     # Maximum allowed time to wait for a new HTTP request to appear.
     timeout http-keep-alive 60s
 
@@ -192,6 +193,7 @@ backend svc-2:443
     server 1.2.3.4:443 1.2.3.4:443 check port 443 inter 5
     server 5.6.7.8:443 5.6.7.8:443 check port 443 inter 5
     
+
 
 
 

--- a/service-loadbalancer/test-samples/TestDefaultCustomAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestDefaultCustomAlgorithm.cfg
@@ -3,8 +3,9 @@
 global
     daemon
     stats socket /tmp/haproxy
-    server-state-file global       
+    server-state-file global
     server-state-base /var/state/haproxy/
+    tune.ssl.default-dh-param 2048
 
 
 
@@ -12,29 +13,29 @@ global
 
 defaults
     log global
-   
+
     load-server-state-from-file global
-    
+
     # Enable session redistribution in case of connection failure.
     option redispatch
-    
-    # Disable logging of null connections (haproxy connections like checks). 
+
+    # Disable logging of null connections (haproxy connections like checks).
     # This avoids excessive logs from haproxy internals.
     option dontlognull
-    
+
     # Enable HTTP connection closing on the server side.
     option http-server-close
 
-    # Enable insertion of the X-Forwarded-For header to requests sent to 
+    # Enable insertion of the X-Forwarded-For header to requests sent to
     # servers and keep client IP address.
     option forwardfor
-    
+
     # Enable HTTP keep-alive from client to server.
     option http-keep-alive
 
     # Clients should send their full http request in 5s.
     timeout http-request    5s
-    
+
     # Maximum time to wait for a connection attempt to a server to succeed.
     timeout connect         5s
 
@@ -43,16 +44,16 @@ defaults
     timeout client          50s
 
     # Inactivity timeout on the client side for half-closed connections.
-    # Applies when the client is expected to acknowledge or send data 
+    # Applies when the client is expected to acknowledge or send data
     # while one direction is already shut down.
     timeout client-fin      50s
-    
+
     # Maximum inactivity time on the server side.
     timeout server          50s
-    
+
     # timeout to use with WebSocket and CONNECT
     timeout tunnel          1h
-    
+
     # Maximum allowed time to wait for a new HTTP request to appear.
     timeout http-keep-alive 60s
 
@@ -192,6 +193,7 @@ backend svc-2:443
     server 1.2.3.4:443 1.2.3.4:443 check port 443 inter 5
     server 5.6.7.8:443 5.6.7.8:443 check port 443 inter 5
     
+
 
 
 

--- a/service-loadbalancer/test-samples/TestRulesPerService.cfg
+++ b/service-loadbalancer/test-samples/TestRulesPerService.cfg
@@ -10,6 +10,9 @@ global
 
 
 
+    ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK
+    ssl-default-bind-options no-tls-tickets
+
 
 defaults
     log global
@@ -77,6 +80,50 @@ listen stats
 
 
 
+frontend httpsfrontend
+    mode http
+    bind :443 ssl crt /ssl/crt.pem ca-file /ssl/ca.crt no-sslv3
+
+    # HSTS (15768000 seconds = 6 months)
+    rspadd  Strict-Transport-Security:\ max-age=15768000
+
+
+    acl url_acl_svc-2 path_beg -i /svc2-http-custom-acl
+    
+
+    acl host_acl_svc-2 hdr(host) svc2-http-custom-acl.mydomain
+    use_backend svc-2 if url_acl_svc-2 or host_acl_svc-2
+    
+
+    acl url_acl_svc-2:443 path_beg /svc-2:443
+    
+
+    acl host_acl_svc-2:443 hdr(host) svc2-https-custom-acl.mydomain
+    use_backend svc-2:443 if url_acl_svc-2:443 or host_acl_svc-2:443
+    
+
+
+    acl https_url_acl_svc-1:443 path_beg /svc-1:443
+    
+
+    acl https_host_acl_svc-1:443 hdr(host) svc1-https-custom-acl.mydomain
+    use_backend https_svc-1:443 if https_url_acl_svc-1:443 or https_host_acl_svc-1:443
+    
+
+    acl https_url_acl_svc-3:443 path_beg -i /svc3-https-1-custom-acl
+    
+
+    use_backend https_svc-3:443 if https_url_acl_svc-3:443
+
+
+    acl https_url_acl_svc-3:443 path_beg /svc-3:443
+    
+
+    acl https_host_acl_svc-3:443 hdr(host) svc3-https-2-custom-acl.mydomain
+    use_backend https_svc-3:443 if https_url_acl_svc-3:443 or https_host_acl_svc-3:443
+    
+
+
 
 frontend httpfrontend
     # Frontend bound on all network interfaces on port 80
@@ -90,20 +137,9 @@ frontend httpfrontend
     # the style of if/else blocks is meant to preserves the format of the output config file
 
     acl url_acl_svc-1 path_beg /svc-1
-    use_backend svc-1 if url_acl_svc-1
-
-
-    acl url_acl_svc-1:443 path_beg /svc-1:443
-    use_backend svc-1:443 if url_acl_svc-1:443
-
-
-    acl url_acl_svc-2 path_beg /svc-2
-    use_backend svc-2 if url_acl_svc-2
-
-
-    acl url_acl_svc-2:443 path_beg /svc-2:443
-    use_backend svc-2:443 if url_acl_svc-2:443
-
+    acl host_acl_svc-1 hdr(host) svc1-http-custom-acl.mydomain
+    use_backend svc-1 if url_acl_svc-1 or host_acl_svc-1
+    
 
 
 
@@ -122,37 +158,13 @@ backend svc-1
     # TODO: Make the path used to access a service customizable.
     reqrep ^([^\ :]*)\ /svc-1[/]?(.*) \1\ /\2
 
-    # create a stickiness table using client IP address as key
-    # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
-    stick-table type ip size 100k expire 30m
-    stick on src
+
+
     server 1.2.3.4:80 1.2.3.4:80 check port 80 inter 5
     server 5.6.7.8:80 5.6.7.8:80 check port 80 inter 5
     
 
 
-
-
-
-backend svc-1:443
-    option  httplog
-    errorfile 400 /etc/haproxy/errors/400.http
-    errorfile 403 /etc/haproxy/errors/403.http
-    errorfile 408 /etc/haproxy/errors/408.http
-    errorfile 500 /etc/haproxy/errors/500.http
-    errorfile 502 /etc/haproxy/errors/502.http
-    errorfile 503 /etc/haproxy/errors/503.http
-    errorfile 504 /etc/haproxy/errors/504.http
-
-    balance roundrobin
-    # TODO: Make the path used to access a service customizable.
-    reqrep ^([^\ :]*)\ /svc-1:443[/]?(.*) \1\ /\2
-
-
-
-    server 1.2.3.4:443 1.2.3.4:443 check port 443 inter 5
-    server 5.6.7.8:443 5.6.7.8:443 check port 443 inter 5
-    
 
 
 
@@ -167,8 +179,9 @@ backend svc-2
     errorfile 504 /etc/haproxy/errors/504.http
 
     balance roundrobin
-    # TODO: Make the path used to access a service customizable.
-    reqrep ^([^\ :]*)\ /svc-2[/]?(.*) \1\ /\2
+
+
+
 
 
 
@@ -189,8 +202,12 @@ backend svc-2:443
     errorfile 504 /etc/haproxy/errors/504.http
 
     balance roundrobin
-    # TODO: Make the path used to access a service customizable.
+
+
+    #Rewrite the request back to root from the url that is used for the frontend.
     reqrep ^([^\ :]*)\ /svc-2:443[/]?(.*) \1\ /\2
+
+
 
 
 
@@ -202,5 +219,113 @@ backend svc-2:443
 
 
 
+backend https_svc-1:443
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
 
 
+    #Rewrite the request back to root from the url that is used for the frontend.
+    reqrep ^([^\ :]*)\ /svc-1:443[/]?(.*) \1\ /\2
+
+
+
+
+
+
+
+    server 1.2.3.4:443 1.2.3.4:443 check ssl
+    server 5.6.7.8:443 5.6.7.8:443 check ssl
+    
+
+
+
+backend https_svc-3:443
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+
+
+
+
+
+
+
+
+    server 1.2.3.4:443 1.2.3.4:443 check ssl
+    server 5.6.7.8:443 5.6.7.8:443 check ssl
+    server 1.2.3.4:443 1.2.3.4:443 check ssl
+    server 5.6.7.8:443 5.6.7.8:443 check ssl
+    
+
+
+
+backend https_svc-3:443
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+
+    balance roundrobin
+
+
+    #Rewrite the request back to root from the url that is used for the frontend.
+    reqrep ^([^\ :]*)\ /svc-3:443[/]?(.*) \1\ /\2
+
+
+
+
+
+
+
+    server 1.2.3.4:443 1.2.3.4:443 check ssl
+    server 5.6.7.8:443 5.6.7.8:443 check ssl
+    server 1.2.3.4:443 1.2.3.4:443 check ssl
+    server 5.6.7.8:443 5.6.7.8:443 check ssl
+    
+
+
+
+
+
+frontend svc-1:3306
+    bind *:3306
+    mode tcp
+    default_backend svc-1:3306
+
+backend svc-1:3306
+    balance roundrobin
+    mode tcp
+
+    server 1.2.3.4:3306 1.2.3.4:3306
+    server 5.6.7.8:3306 5.6.7.8:3306
+    
+
+
+frontend svc-2:3306
+    bind *:3306
+    mode tcp
+    default_backend svc-2:3306
+
+backend svc-2:3306
+    balance roundrobin
+    mode tcp
+
+    server 1.2.3.4:3306 1.2.3.4:3306
+    server 5.6.7.8:3306 5.6.7.8:3306
+    

--- a/service-loadbalancer/test-samples/TestServiceAffinityWithCookies.cfg
+++ b/service-loadbalancer/test-samples/TestServiceAffinityWithCookies.cfg
@@ -3,8 +3,9 @@
 global
     daemon
     stats socket /tmp/haproxy
-    server-state-file global       
+    server-state-file global
     server-state-base /var/state/haproxy/
+    tune.ssl.default-dh-param 2048
 
 
 
@@ -12,29 +13,29 @@ global
 
 defaults
     log global
-   
+
     load-server-state-from-file global
-    
+
     # Enable session redistribution in case of connection failure.
     option redispatch
-    
-    # Disable logging of null connections (haproxy connections like checks). 
+
+    # Disable logging of null connections (haproxy connections like checks).
     # This avoids excessive logs from haproxy internals.
     option dontlognull
-    
+
     # Enable HTTP connection closing on the server side.
     option http-server-close
 
-    # Enable insertion of the X-Forwarded-For header to requests sent to 
+    # Enable insertion of the X-Forwarded-For header to requests sent to
     # servers and keep client IP address.
     option forwardfor
-    
+
     # Enable HTTP keep-alive from client to server.
     option http-keep-alive
 
     # Clients should send their full http request in 5s.
     timeout http-request    5s
-    
+
     # Maximum time to wait for a connection attempt to a server to succeed.
     timeout connect         5s
 
@@ -43,16 +44,16 @@ defaults
     timeout client          50s
 
     # Inactivity timeout on the client side for half-closed connections.
-    # Applies when the client is expected to acknowledge or send data 
+    # Applies when the client is expected to acknowledge or send data
     # while one direction is already shut down.
     timeout client-fin      50s
-    
+
     # Maximum inactivity time on the server side.
     timeout server          50s
-    
+
     # timeout to use with WebSocket and CONNECT
     timeout tunnel          1h
-    
+
     # Maximum allowed time to wait for a new HTTP request to appear.
     timeout http-keep-alive 60s
 
@@ -195,6 +196,7 @@ backend svc-2:443
     server 1.2.3.4:443 1.2.3.4:443 check port 443 inter 5
     server 5.6.7.8:443 5.6.7.8:443 check port 443 inter 5
     
+
 
 
 

--- a/service-loadbalancer/test-samples/TestSvcCustomAlgorithm.cfg
+++ b/service-loadbalancer/test-samples/TestSvcCustomAlgorithm.cfg
@@ -3,8 +3,9 @@
 global
     daemon
     stats socket /tmp/haproxy
-    server-state-file global       
+    server-state-file global
     server-state-base /var/state/haproxy/
+    tune.ssl.default-dh-param 2048
 
 
 
@@ -12,29 +13,29 @@ global
 
 defaults
     log global
-   
+
     load-server-state-from-file global
-    
+
     # Enable session redistribution in case of connection failure.
     option redispatch
-    
-    # Disable logging of null connections (haproxy connections like checks). 
+
+    # Disable logging of null connections (haproxy connections like checks).
     # This avoids excessive logs from haproxy internals.
     option dontlognull
-    
+
     # Enable HTTP connection closing on the server side.
     option http-server-close
 
-    # Enable insertion of the X-Forwarded-For header to requests sent to 
+    # Enable insertion of the X-Forwarded-For header to requests sent to
     # servers and keep client IP address.
     option forwardfor
-    
+
     # Enable HTTP keep-alive from client to server.
     option http-keep-alive
 
     # Clients should send their full http request in 5s.
     timeout http-request    5s
-    
+
     # Maximum time to wait for a connection attempt to a server to succeed.
     timeout connect         5s
 
@@ -43,16 +44,16 @@ defaults
     timeout client          50s
 
     # Inactivity timeout on the client side for half-closed connections.
-    # Applies when the client is expected to acknowledge or send data 
+    # Applies when the client is expected to acknowledge or send data
     # while one direction is already shut down.
     timeout client-fin      50s
-    
+
     # Maximum inactivity time on the server side.
     timeout server          50s
-    
+
     # timeout to use with WebSocket and CONNECT
     timeout tunnel          1h
-    
+
     # Maximum allowed time to wait for a new HTTP request to appear.
     timeout http-keep-alive 60s
 
@@ -192,6 +193,7 @@ backend svc-2:443
     server 1.2.3.4:443 1.2.3.4:443 check port 443 inter 5
     server 5.6.7.8:443 5.6.7.8:443 check port 443 inter 5
     
+
 
 
 

--- a/service-loadbalancer/test-samples/TestSyslog.cfg
+++ b/service-loadbalancer/test-samples/TestSyslog.cfg
@@ -3,8 +3,9 @@
 global
     daemon
     stats socket /tmp/haproxy
-    server-state-file global       
+    server-state-file global
     server-state-base /var/state/haproxy/
+    tune.ssl.default-dh-param 2048
 
 
     # log using a syslog socket
@@ -16,29 +17,29 @@ global
 
 defaults
     log global
-   
+
     load-server-state-from-file global
-    
+
     # Enable session redistribution in case of connection failure.
     option redispatch
-    
-    # Disable logging of null connections (haproxy connections like checks). 
+
+    # Disable logging of null connections (haproxy connections like checks).
     # This avoids excessive logs from haproxy internals.
     option dontlognull
-    
+
     # Enable HTTP connection closing on the server side.
     option http-server-close
 
-    # Enable insertion of the X-Forwarded-For header to requests sent to 
+    # Enable insertion of the X-Forwarded-For header to requests sent to
     # servers and keep client IP address.
     option forwardfor
-    
+
     # Enable HTTP keep-alive from client to server.
     option http-keep-alive
 
     # Clients should send their full http request in 5s.
     timeout http-request    5s
-    
+
     # Maximum time to wait for a connection attempt to a server to succeed.
     timeout connect         5s
 
@@ -47,16 +48,16 @@ defaults
     timeout client          50s
 
     # Inactivity timeout on the client side for half-closed connections.
-    # Applies when the client is expected to acknowledge or send data 
+    # Applies when the client is expected to acknowledge or send data
     # while one direction is already shut down.
     timeout client-fin      50s
-    
+
     # Maximum inactivity time on the server side.
     timeout server          50s
-    
+
     # timeout to use with WebSocket and CONNECT
     timeout tunnel          1h
-    
+
     # Maximum allowed time to wait for a new HTTP request to appear.
     timeout http-keep-alive 60s
 
@@ -196,6 +197,7 @@ backend svc-2:443
     server 1.2.3.4:443 1.2.3.4:443 check port 443 inter 5
     server 5.6.7.8:443 5.6.7.8:443 check port 443 inter 5
     
+
 
 
 


### PR DESCRIPTION
This pull request adds support for SSL Bridge mode (re-encrypt client side traffic using LB cert) with HAProxy and ACLs per ServicePort.
Instructions are added to README. A test case is added with full regression checks.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1624)

<!-- Reviewable:end -->
