### PR TITLE
Fixed #1628: kube-down should not delete multi-user.target.wants dir

### DIFF
--- a/ansible/playbooks/adhoc/uninstall.yml
+++ b/ansible/playbooks/adhoc/uninstall.yml
@@ -138,7 +138,14 @@
         - /etc/systemd/system/kube-scheduler.service
         - /etc/systemd/system/flanneld.service
         - /etc/systemd/system/flanneld.service.wants
-        - /etc/systemd/system/multi-user.target.wants
+        - /etc/systemd/system/multi-user.target.wants/etcd.service
+        - /etc/systemd/system/multi-user.target.wants/flanneld.service
+        - /etc/systemd/system/multi-user.target.wants/kubelet.service
+        - /etc/systemd/system/multi-user.target.wants/kube-proxy.service
+        - /etc/systemd/system/multi-user.target.wants/kube-apiserver.service
+        - /etc/systemd/system/multi-user.target.wants/kube-scheduler.service
+        - /etc/systemd/system/multi-user.target.wants/kube-controller-manager.service
+        - /etc/systemd/system/multi-user.target.wants/kube-addons.service
         - /etc/systemd/system/delay-master-services.target
         - /etc/systemd/system/delay-node-services.target
         - /etc/sysconfig/flanneld


### PR DESCRIPTION
On Centos, there are some other service in multi-user.target.wants directory, so we should not just delete it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1629)

<!-- Reviewable:end -->
