### PR TITLE
[ansible]remove kube_master_api_port from group_vars

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -37,9 +37,6 @@ insecure_registrys:
 #https_proxy: "http://proxy.example.com:3128"
 #no_proxy: "127.0.0.1,localhost,docker-registry.somecorporation.com"
 
-# The port that the Kubernetes apiserver component listens on.
-kube_master_api_port: 443
-
 # Kubernetes internal network for services.
 # Kubernetes services will get fake IP addresses from this range.
 # This range must not conflict with anything in your infrastructure. These


### PR DESCRIPTION
kube_master_api_port has defined in roles/kubernetes/defaults/main.yml
In [README doc](https://github.com/kubernetes/contrib/tree/master/ansible#kubernetes-source-type) also describe that if we want change secure port , just change kube_master_api_port under roles/kubernetes/defaults/main.yml

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1635)

<!-- Reviewable:end -->
