### PR TITLE
[nginx-ingress-controller] Update image version

### DIFF
--- a/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
+++ b/ingress/controllers/nginx/examples/custom-configuration/rc-custom-configuration.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/custom-errors/rc-custom-errors.yaml
+++ b/ingress/controllers/nginx/examples/custom-errors/rc-custom-errors.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
+++ b/ingress/controllers/nginx/examples/custom-template/custom-template.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
+++ b/ingress/controllers/nginx/examples/daemonset/as-daemonset.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/default/rc-default.yaml
+++ b/ingress/controllers/nginx/examples/default/rc-default.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/full/rc-full.yaml
+++ b/ingress/controllers/nginx/examples/full/rc-full.yaml
@@ -21,7 +21,7 @@ spec:
         secret:
           secretName: dhparam-example
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
+++ b/ingress/controllers/nginx/examples/proxy-protocol/nginx-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
+++ b/ingress/controllers/nginx/examples/sysctl/change-proc-values-rc.yaml
@@ -89,7 +89,7 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
+++ b/ingress/controllers/nginx/examples/tcp/rc-tcp.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
+++ b/ingress/controllers/nginx/examples/tls/rc-ssl.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/examples/udp/rc-udp.yaml
+++ b/ingress/controllers/nginx/examples/udp/rc-udp.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:

--- a/ingress/controllers/nginx/rc.yaml
+++ b/ingress/controllers/nginx/rc.yaml
@@ -68,7 +68,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
fixes #1652
#1571 introduced the error because it was merged after the `0.8.3` release

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1653)

<!-- Reviewable:end -->
