### PR TITLE
matchers: Fix matching on multi-lines comments

### DIFF
--- a/mungegithub/mungers/matchers/comment/command.go
+++ b/mungegithub/mungers/matchers/comment/command.go
@@ -34,7 +34,7 @@ var (
 	// - Line that starts with slash
 	// - followed by non-space characteres,
 	// - (optional) followed by space and arguments
-	commandRegex = regexp.MustCompile(`^/([^\s]+)\s?(.*)$`)
+	commandRegex = regexp.MustCompile(`^/([^\s]+) *?([^\n]*)`)
 )
 
 // ParseCommand attempts to read a command from a comment

--- a/mungegithub/mungers/matchers/comment/command_test.go
+++ b/mungegithub/mungers/matchers/comment/command_test.go
@@ -37,12 +37,24 @@ func TestParseCommand(t *testing.T) {
 			comment:         " /COMMAND Line can't start with spaces",
 		},
 		{
+			expectedCommand: nil,
+			comment:         "Command not at the beginning:\n/COMMAND\nAnd something else...",
+		},
+		{
 			expectedCommand: &Command{Name: "COMMAND"},
 			comment:         "/COMMAND",
 		},
 		{
 			expectedCommand: &Command{Name: "COMMAND", Arguments: "Valid command"},
 			comment:         "/COMMAND Valid command",
+		},
+		{
+			expectedCommand: &Command{Name: "COMMAND", Arguments: "Multiple Lines"},
+			comment:         "/COMMAND Multiple Lines\nAnd something else...",
+		},
+		{
+			expectedCommand: &Command{Name: "COMMAND", Arguments: "Args"},
+			comment:         "/COMMAND Args\n/OTHERCOMMAND OtherArgs",
 		},
 		{
 			expectedCommand: &Command{Name: "COMMAND", Arguments: "Command name is upper-cased"},

--- a/mungegithub/mungers/matchers/comment/notification.go
+++ b/mungegithub/mungers/matchers/comment/notification.go
@@ -33,7 +33,7 @@ type Notification struct {
 
 var (
 	// Matches a notification: [NOTIFNAME] Arguments
-	notificationRegex = regexp.MustCompile(`^\[([^\]\s]+)\]\s?(.*)$`)
+	notificationRegex = regexp.MustCompile(`^\[([^\]\s]+)\] *?([^\n]*)`)
 )
 
 // ParseNotification attempts to read a notification from a comment

--- a/mungegithub/mungers/matchers/comment/notification_test.go
+++ b/mungegithub/mungers/matchers/comment/notification_test.go
@@ -45,8 +45,16 @@ func TestParseNotification(t *testing.T) {
 			comment: "[NOTIF]",
 		},
 		{
+			notif:   nil,
+			comment: "Notif must be at the very beginning:\n[NOTIF]\nAnd something else...",
+		},
+		{
 			notif:   &Notification{Name: "NOTIF", Arguments: "Valid notification"},
 			comment: "[NOTIF] Valid notification",
+		},
+		{
+			notif:   &Notification{Name: "NOTIF", Arguments: "Multiple Lines"},
+			comment: "[NOTIF]   Multiple Lines  \nAnd something else...",
 		},
 		{
 			notif:   &Notification{Name: "NOTIF", Arguments: "Notif name is upper-cased"},


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1655)

<!-- Reviewable:end -->
