### PR TITLE
Update kubernetes addons scripts

### DIFF
--- a/ansible/roles/kubernetes-addons/files/common/kube-addon-update.sh
+++ b/ansible/roles/kubernetes-addons/files/common/kube-addon-update.sh
@@ -51,6 +51,7 @@ if [[ ! -x ${KUBECTL} ]]; then
     echo "ERROR: kubectl command (${KUBECTL}) not found or is not executable" 1>&2
     exit 1
 fi
+KUBECTL_OPTS=${KUBECTL_OPTS:-}
 
 # If an add-on definition is incorrect, or a definition has just disappeared
 # from the local directory, the script will still keep on retrying.
@@ -133,7 +134,7 @@ try:
             try:
                 print "%s/%s" % (y["metadata"]["namespace"], y["metadata"]["name"])
             except Exception, ex:
-                print "default/%s" % y["metadata"]["name"]
+                print "/%s" % y["metadata"]["name"]
 except Exception, ex:
         print "ERROR"
     '''
@@ -198,7 +199,7 @@ function run-until-success() {
 # returns a list of <namespace>/<name> pairs (nsnames)
 function get-addon-nsnames-from-server() {
     local -r obj_type=$1
-    "${KUBECTL}" get "${obj_type}" --all-namespaces -o go-template="{{range.items}}{{.metadata.namespace}}/{{.metadata.name}} {{end}}" --api-version=v1 -l kubernetes.io/cluster-service=true
+    "${KUBECTL}" "${KUBECTL_OPTS}" get "${obj_type}" --all-namespaces -o go-template="{{range.items}}{{.metadata.namespace}}/{{.metadata.name}} {{end}}" --api-version=v1 -l kubernetes.io/cluster-service=true | sed 's/<no value>//g'
 }
 
 # returns the characters after the last separator (including)
@@ -244,7 +245,7 @@ function stop-object() {
     local -r obj_name=$3
     log INFO "Stopping ${obj_type} ${namespace}/${obj_name}"
 
-    run-until-success "${KUBECTL} stop --namespace=${namespace} ${obj_type} ${obj_name}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+    run-until-success "${KUBECTL} "${KUBECTL_OPTS}" stop --namespace=${namespace} ${obj_type} ${obj_name}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
 }
 
 function create-object() {
@@ -262,7 +263,11 @@ function create-object() {
     log INFO "Creating new ${obj_type} from file ${file_path} in namespace ${namespace}, name: ${obj_name}"
     # this will keep on failing if the ${file_path} disappeared in the meantime.
     # Do not use too many retries.
-    run-until-success "${KUBECTL} create --namespace=${namespace} -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+    if [[ -n "${namespace}" ]]; then
+        run-until-success "${KUBECTL} "${KUBECTL_OPTS}" create --namespace=${namespace} -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+    else
+        run-until-success "${KUBECTL} "${KUBECTL_OPTS}" create -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+    fi
 }
 
 function update-object() {
@@ -476,6 +481,7 @@ function update-addons() {
     # be careful, reconcile-objects uses global variables
     reconcile-objects ${addon_path} ReplicationController "-" &
     reconcile-objects ${addon_path} Deployment "-" &
+    reconcile-objects ${addon_path} DaemonSet "-" &
 
     # We don't expect names to be versioned for the following kinds, so
     # we match the entire name, ignoring version suffix.
@@ -485,6 +491,7 @@ function update-addons() {
     reconcile-objects ${addon_path} Service "" &
     reconcile-objects ${addon_path} PersistentVolume "" &
     reconcile-objects ${addon_path} PersistentVolumeClaim "" &
+    reconcile-objects ${addon_path} ConfigMap "" &
 
     wait-for-jobs
     if [[ $? -eq 0 ]]; then

--- a/ansible/roles/kubernetes-addons/files/common/kube-addons.sh
+++ b/ansible/roles/kubernetes-addons/files/common/kube-addons.sh
@@ -18,8 +18,9 @@
 # was already enforced by salt, and /etc/kubernetes/addons is the
 # managed result is of that. Start everything below that directory.
 KUBECTL=${KUBECTL_BIN:-/usr/local/bin/kubectl}
+KUBECTL_OPTS=${KUBECTL_OPTS:-}
 
-ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC:-600}
+ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC:-60}
 
 SYSTEM_NAMESPACE=kube-system
 token_dir=${TOKEN_DIR:-/srv/kubernetes}
@@ -126,7 +127,7 @@ function create-resource-from-string() {
   local -r config_name=$4;
   local -r namespace=$5;
   while [ ${tries} -gt 0 ]; do
-    echo "${config_string}" | ${KUBECTL} --namespace="${namespace}" create -f - && \
+    echo "${config_string}" | ${KUBECTL} "${KUBECTL_OPTS}" --namespace="${namespace}" create -f - && \
         echo "== Successfully started ${config_name} in namespace ${namespace} at $(date -Is)" && \
         return 0;
     let tries=tries-1;
@@ -191,7 +192,7 @@ start_addon /etc/kubernetes/addons/namespace.yaml 100 10 "" &
 token_found=""
 while [ -z "${token_found}" ]; do
   sleep .5
-  token_found=$(${KUBECTL} get --namespace="${SYSTEM_NAMESPACE}" serviceaccount default -o go-template="{{with index .secrets 0}}{{.name}}{{end}}" || true)
+  token_found=$(${KUBECTL} "${KUBECTL_OPTS}" get --namespace="${SYSTEM_NAMESPACE}" serviceaccount default -o go-template="{{with index .secrets 0}}{{.name}}{{end}}" || true)
 done
 
 echo "== default service account in the ${SYSTEM_NAMESPACE} namespace has token ${token_found} =="

--- a/ansible/roles/kubernetes-addons/templates/kube-addons.service.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-addons.service.j2
@@ -8,6 +8,7 @@ Environment="TOKEN_DIR={{ kube_token_dir }}"
 Environment="KUBECTL_BIN={{ bin_dir }}/kubectl"
 Environment="KUBERNETES_MASTER_NAME={{ groups['masters'][0] }}"
 Environment="TRUSTY_MASTER=true"
+Environment="KUBECTL_OPTS=--kubeconfig={{ kube_config_dir }}/kubectl.kubeconfig"
 ExecStart={{ kube_script_dir }}/kube-addons.sh
 
 [Install]

--- a/ansible/roles/kubernetes-addons/templates/kube-addons.upstart.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-addons.upstart.j2
@@ -7,5 +7,6 @@ env TOKEN_DIR={{ kube_token_dir }}
 env KUBECTL_BIN={{ bin_dir }}/kubectl
 env KUBERNETES_MASTER_NAME={{ groups['masters'][0] }}
 env TRUSTY_MASTER=true
+env KUBECTL_OPTS="--kubeconfig=/etc/kubernetes/kubectl.kubeconfig"
 
 exec {{ kube_script_dir }}/kube-addons.sh


### PR DESCRIPTION
When deploying kube-apiserver listening on secure port, kubernetes addons are not deployed as the script calling kubectl does not posses kubeconfig.

The first commits cherry picks changes from [1].

[1] https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1660)

<!-- Reviewable:end -->
