### PR TITLE
issue-triager: Temporarily deactivate update

### DIFF
--- a/mungegithub/mungers/issue-categorizer.go
+++ b/mungegithub/mungers/issue-categorizer.go
@@ -76,12 +76,13 @@ func (lm *LabelMunger) Munge(obj *github.MungeObject) {
 
 	if len(tLabels) == 0 && len(cLabels) == 0 {
 		obj.AddLabels(getRoutingLabels(lm.TriagerUrl, obj.Issue.Title, obj.Issue.Body))
-	} else {
-		newLabels := needsUpdate(obj)
-		if len(newLabels) != 0 {
-			updateModel(lm.TriagerUrl, obj.Issue.Title, obj.Issue.Body, newLabels)
-		}
 	}
+	// else {
+	// 	newLabels := needsUpdate(obj)
+	// 	if len(newLabels) != 0 {
+	// 		updateModel(lm.TriagerUrl, obj.Issue.Title, obj.Issue.Body, newLabels)
+	// 	}
+	// }
 }
 
 func updateModel(triagerUrl string, title, body *string, newLabels []string) {


### PR DESCRIPTION
This is doing a lot of uncached request to ListIssueEvents. Let's
deactivate it until we have a better solution.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1668)

<!-- Reviewable:end -->
