### PR TITLE
[ansible] extend kube-addons pyyaml workaround to fedora atomic

### DIFF
--- a/ansible/roles/kubernetes-addons/files/common/kube-addons.sh
+++ b/ansible/roles/kubernetes-addons/files/common/kube-addons.sh
@@ -26,7 +26,7 @@ token_dir=${TOKEN_DIR:-/srv/kubernetes}
 trusty_master=${TRUSTY_MASTER:-false}
 
 function ensure_python() {
-  if ! python --version > /dev/null 2>&1; then    
+  if ! python -c "import yaml" > /dev/null 2>&1; then    
     echo "No python on the machine, will use a python image"
     local -r PYTHON_IMAGE=python:2.7-slim-pyyaml
     export PYTHON="docker run --interactive --rm --net=none ${PYTHON_IMAGE} python"

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -50,12 +50,12 @@
   copy:
     src=common/python-image/
     dest={{ kube_script_dir }}/python-image
-  when: is_coreos
+  when: is_coreos or (ansible_distribution == "Fedora" and is_atomic)
   register: kube_addons_python_image_dockerfile
 
 - name: Build Python image to use in Kubernetes Addons
   shell: "docker build -t python:2.7-slim-pyyaml {{ kube_script_dir }}/python-image"
-  when: is_coreos and kube_addons_python_image_dockerfile | changed
+  when: is_coreos or (ansible_distribution == "Fedora" and is_atomic) and kube_addons_python_image_dockerfile | changed
 
 - name: Run kube-gen-token script to create {{ kube_token_dir }}/known_tokens.csv
   command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item }}"


### PR DESCRIPTION
The script that sets up  kube-addons requires PyYAML, which
ansible installs on distros capable of package installation.
For CoreOS, this is worked-around by running python in a container.

This commit extends the same workaround to Fedora Atomic (the
workaround isn't needed for CentOS Atomic, because its image
already includes PyYAML.)

The commit changes the check for whether the workaround is required
from "is python here" to "is pyyaml importable." This is necessary
because Fedora does include python, so just checking for python
isn't sufficient to trigger the workaround.

I tested this on coreos and on fedora atomic.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1669)

<!-- Reviewable:end -->
