### PR TITLE
Cluster-autoscaler: pick one of the matching node groups at random

### DIFF
--- a/cluster-autoscaler/utils.go
+++ b/cluster-autoscaler/utils.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"time"
 
@@ -181,7 +182,8 @@ func GetNodeInfosForGroups(nodes []*kube_api.Node, cloudProvider cloudprovider.C
 // BestExpansionOption picks the best cluster expansion option.
 func BestExpansionOption(expansionOptions []ExpansionOption) *ExpansionOption {
 	if len(expansionOptions) > 0 {
-		return &expansionOptions[0]
+		pos := rand.Int31n(int32(len(expansionOptions)))
+		return &expansionOptions[pos]
 	}
 	return nil
 }


### PR DESCRIPTION
Currently the first matching node group is picked for scale up. CA should select it at random so that all node groups grow in a similar way.

cc: @fgrzadkowski @piosz @jszczepkowski

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1670)

<!-- Reviewable:end -->
