### PR TITLE
Add playbook to install 1-node cluster from within running host machine

### DIFF
--- a/ansible/playbooks/deploy-preansible.yml
+++ b/ansible/playbooks/deploy-preansible.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: false
+  become: yes
+  roles:
+    - pre-ansible
+  tags:
+    - pre-ansible

--- a/ansible/scripts/deploy-local-cluster.sh
+++ b/ansible/scripts/deploy-local-cluster.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. ./init.sh
+
+inventory=${INVENTORY_DIR}/localhost.ini
+
+# use localhost inventory
+# run etcd playbook
+# run docker playbook
+# run kubernetes-master playbook
+# run add-ons playbook
+# run kubernetes-node playbook
+
+# kubernetes roles takes care of token and certs generating
+
+# skipping configure tasks as we don't want to override default configuration
+# of etcd and docker.
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-preansible.yml "$@"
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-etcd.yml --skip-tags="configure" "$@"
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-docker.yml --skip-tags="configure" "$@"
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-master.yml "$@"
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-addons.yml "$@"
+ansible-playbook -i ${inventory} ${PLAYBOOKS_DIR}/deploy-node.yml "$@"


### PR DESCRIPTION
The playbook is useful for starting users of kubernetes. It just runs through etcd, docker and kubernetes roles. So user can run&play without need to generate certificates or tokens.

It skips configuration of etcd and docker in case a user has already any of them installed.
On the other hand, kubernetes configuration is always carried as tokens/certs require config files update.

**TODO**
- [x] refactor `docker` role (at least introduce `configure` tag) https://github.com/kubernetes/contrib/pull/1690

Fixes: #1325

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1689)

<!-- Reviewable:end -->
