### PR TITLE
extend the list of supported libvirt OSes to Ubuntu-14.04 and Ubuntu-16.04

### DIFF
--- a/ansible/vagrant/README.md
+++ b/ansible/vagrant/README.md
@@ -88,6 +88,8 @@ Supported images:
 * `centos7` (default) - CentOS 7 supported on OpenStack, VirtualBox, Libvirt providers.
 * `coreos` - [CoreOS](https://coreos.com/) supported on VirtualBox provider.
 * `fedora` - supported at least on Libvirt provider
+* `ubuntu14` - supported on Libvirt provider, based on Ubuntu-14.04
+* `ubuntu16` - supported on Libvirt provider, based on Ubuntu-16.04
 
 ### Start your cluster
 

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -84,6 +84,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       config.vm.box = "fedora/23-cloud-base"
     when :fedoraatomic
       config.vm.box = "fedora/23-atomic-host"
+    when :ubuntu14
+      config.vm.box = "baremettle/ubuntu-14.04"
+    when :ubuntu16
+      config.vm.box = "yk0/ubuntu-xenial"
     end
   end
 


### PR DESCRIPTION
SSIA

depends on:
- https://github.com/kubernetes/contrib/pull/1698
- https://github.com/kubernetes/contrib/pull/1700

Once merged, both version of Ubuntu can be used.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1701)

<!-- Reviewable:end -->
