### PR TITLE
Publisher for multiple sources

### DIFF
--- a/mungegithub/Dockerfile-publisher
+++ b/mungegithub/Dockerfile-publisher
@@ -20,4 +20,4 @@ RUN apt-get install -y -qq ca-certificates git
 CMD ["/mungegithub", "--dry-run", "--token-file=/token"]
 
 ADD mungegithub /mungegithub
-ADD mungers/publisher.sh /publisher.sh
+ADD mungers/publish.sh /publish.sh

--- a/mungegithub/Makefile
+++ b/mungegithub/Makefile
@@ -41,7 +41,7 @@ test: mungegithub
 	CGO_ENABLED=0 GOOS=linux go test ./...
 
 # build the container with the binary
-container: test
+container: mungegithub
 	docker build -t $(CONTAINER) -f Dockerfile-$(APP) .
 
 # push the container

--- a/mungegithub/mungers/publisher.sh
+++ b/mungegithub/mungers/publisher.sh
@@ -44,8 +44,11 @@ rm -rf "${DST}"
 mkdir -p "${DST}"
 git clone "${DSTURL}" "${DST}"
 pushd "${DST}" > /dev/null
-rm -r ./*
+rm -rf ./*
 cp -a "${SRC}/." "${DST}"
+# move _vendor/ to vendor/
+find "${DST}" -depth -name "_vendor" -type d -execdir mv {} "vendor" \;
+
 git add --all
 # check if there are new contents 
 if git diff --cached --exit-code &>/dev/null; then

--- a/mungegithub/publisher/deployment.yaml
+++ b/mungegithub/publisher/deployment.yaml
@@ -22,15 +22,9 @@ spec:
         - --token-file=$(TOKEN_FILE)
         - --repo-dir=$(REPO_DIR)
         - --netrc-dir=$(NETRC_DIR)
-        - --publish-command=$(PUBLISH_COMMAND)
         image: gcr.io/google_containers/publisher:2016-05-24-86f86cd
         imagePullPolicy: Always
         env:
-          - name: PUBLISH_COMMAND
-            valueFrom:
-              configMapKeyRef:
-                name: @@-publisher-config
-                key: publisher.publish-command
           - name: PERIOD
             valueFrom:
               configMapKeyRef:

--- a/mungegithub/publisher/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/publisher/deployment/kubernetes/configmap.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kubernetes-publisher-config
 data:
   # basic config options.
-  config.organization: kubernetes
+  #config.organization: kubernetes
+  config.organization: caesarxuchao
   config.project: kubernetes
   config.pr-mungers: publisher
   config.token-file: /etc/secret-volume/token

--- a/mungegithub/publisher/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/publisher/deployment/kubernetes/configmap.yaml
@@ -4,8 +4,7 @@ metadata:
   name: kubernetes-publisher-config
 data:
   # basic config options.
-  #config.organization: kubernetes
-  config.organization: caesarxuchao
+  config.organization: kubernetes
   config.project: kubernetes
   config.pr-mungers: publisher
   config.token-file: /etc/secret-volume/token
@@ -13,5 +12,4 @@ data:
   # munger specific options.
   gitrepo.repo-dir: /gitrepos
   config.period: "24h"
-  publisher.publish-command: ./publisher.sh
   publisher.netrc-dir: /netrc


### PR DESCRIPTION
Rewrite the publisher to allow gathering contents from multiple sources to the destination repository. For example, `kubernetes/client-go/1.5` gets its content from the `staging/.../1.5` in the **_master**_ branch of the main repository, and `kubernetes/client-go/1.4` gets its content from the `staging/.../1.4` in the **_release-1.4**_ branch of the main repository

Example: https://github.com/caesarxuchao/client-go/commit/a0c3ac3da0ab929aba25d0cdb6cf42885309b06b

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1719)

<!-- Reviewable:end -->
