### PR TITLE
AWS Cluster Autoscaler: NodeGroupForNode should return nil if instance is not in any known ASG

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -118,6 +118,17 @@ func TestNodeGroupForNode(t *testing.T) {
 	assert.Equal(t, group.Id(), "test-asg")
 	assert.Equal(t, group.MinSize(), 1)
 	assert.Equal(t, group.MaxSize(), 5)
+
+	// test node in cluster that is not in a group managed by cluster autoscaler
+	nodeNotInGroup := &kube_api.Node{
+		Spec: kube_api.NodeSpec{
+			ProviderID: "aws:///us-east-1a/test-instance-id-not-in-group",
+		},
+	}
+
+	group, err = provider.NodeGroupForNode(nodeNotInGroup)
+	assert.NoError(t, err)
+	assert.Nil(t, group)
 }
 
 func TestAwsRefFromProviderId(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -175,7 +175,8 @@ func (m *AwsManager) GetAsgForInstance(instance *AwsRef) (*Asg, error) {
 	if config, found := m.asgCache[*instance]; found {
 		return config, nil
 	}
-	return nil, fmt.Errorf("Instance %+v does not belong to any known ASG", *instance)
+	// instance does not belong to any configured ASG
+	return nil, nil
 }
 
 func (m *AwsManager) regenerateCache() error {


### PR DESCRIPTION
https://github.com/kubernetes/contrib/issues/1311

We ran into a bug where the `CheckGroupsAndNodes` check fails once we added a second ASG to our cluster that was not maintained by CA. And that's because in `GetAsgForInstance` we should be returning a nil group if the instance doesn't belong to any of the groups that the CA is aware of.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1721)

<!-- Reviewable:end -->
