### PR TITLE
Fix cluster autoscaler deployment spec, AWS implementation

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -57,7 +57,7 @@ spec:
               memory: 300Mi
           command:
             - ./cluster-autoscaler
-            - -v=4
+            - --v=4
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
             - --nodes={{ ASG MIN e.g. 1 }}:{{ASG MAX e.g. 5}}:{{ASG NAME e.g. k8s-worker-asg}}


### PR DESCRIPTION
Fix verbose flag to `cluster-autoscaler` command line, so it actually runs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1726)

<!-- Reviewable:end -->
