### PR TITLE
implement approval handler

### DIFF
--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"path"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"k8s.io/contrib/mungegithub/features"
+	"k8s.io/contrib/mungegithub/github"
+	"k8s.io/contrib/mungegithub/mungers/mungerutil"
+)
+
+// ApprovalHandler will try to add "approved" label once
+// all files of change has been approved by approvers.
+type ApprovalHandler struct {
+	features *features.Features
+}
+
+func init() {
+	h := &ApprovalHandler{}
+	RegisterMungerOrDie(h)
+}
+
+// Name is the name usable in --pr-mungers
+func (*ApprovalHandler) Name() string { return "approval-handler" }
+
+// RequiredFeatures is a slice of 'features' that must be provided
+func (*ApprovalHandler) RequiredFeatures() []string {
+	return []string{features.RepoFeatureName, features.AliasesFeature}
+}
+
+// Initialize will initialize the munger
+func (h *ApprovalHandler) Initialize(config *github.Config, features *features.Features) error {
+	h.features = features
+	return nil
+}
+
+// EachLoop is called at the start of every munge loop
+func (*ApprovalHandler) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (*ApprovalHandler) AddFlags(cmd *cobra.Command, config *github.Config) {}
+
+// Munge is the workhorse the will actually make updates to the PR
+// The algorithm goes as:
+// - Initially, we set up approverMap
+//   - Go through all comments after latest commit. If any approver said "/approve", add him to approverMap.
+// - For each file, we see if any approver of this file is in approverMap.
+//   - An approver of a file is defined as:
+//     - It's known that each dir has a list of approvers. (This might not hold true. For usability, current situation is enough.)
+//     - Approver of a dir is also the approver of child dirs.
+//   - We look at only top 3 dir level's approvers .
+// - Iff all files has been approved, the bot will add "approved" label.
+func (h *ApprovalHandler) Munge(obj *github.MungeObject) {
+	if !obj.IsPR() {
+		return
+	}
+	files, err := obj.ListFiles()
+	if err != nil {
+		glog.Errorf("failed to list files in this PR: %v", err)
+		return
+	}
+
+	comments, err := getCommentsAfterLastModified(obj)
+	if err != nil {
+		glog.Errorf("failed to get comments in this PR: %v", err)
+		return
+	}
+
+	approverMap := map[string]struct{}{}
+
+	// from oldest to latest
+	for i := len(comments) - 1; i >= 0; i-- {
+		c := comments[i]
+
+		if !mungerutil.IsValidUser(c.User) {
+			continue
+		}
+
+		fields := strings.Fields(strings.TrimSpace(*c.Body))
+
+		if len(fields) == 1 && strings.ToLower(fields[0]) == "/approve" {
+			approverMap[*c.User.Login] = struct{}{}
+			continue
+		}
+
+		if len(fields) == 2 && strings.ToLower(fields[0]) == "/approve" && strings.ToLower(fields[1]) == "cancel" {
+			delete(approverMap, *c.User.Login)
+		}
+	}
+
+	for _, file := range files {
+		if !h.hasApproval(*file.Filename, approverMap) {
+			return
+		}
+	}
+	obj.AddLabel(approvedLabel)
+}
+
+func (h *ApprovalHandler) hasApproval(filename string, approverMap map[string]struct{}) bool {
+	paths := strings.Split(filename, "/")
+	var p string
+	for i := 0; i < len(paths) && i < 3; i++ {
+		if i == 0 {
+			p = paths[0]
+		} else {
+			p = path.Join(p, paths[i])
+		}
+
+		fileOwners := h.features.Repos.LeafAssignees(p)
+		if fileOwners.Len() == 0 {
+			glog.Warningf("Couldn't find an owner for path (%s)", p)
+			continue
+		}
+
+		if h.features.Aliases != nil && h.features.Aliases.IsEnabled {
+			fileOwners = h.features.Aliases.Expand(fileOwners)
+		}
+
+		for _, owner := range fileOwners.List() {
+			if _, exist := approverMap[owner]; exist {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/mungegithub/mungers/lgtm_handler.go
+++ b/mungegithub/mungers/lgtm_handler.go
@@ -64,7 +64,7 @@ func (h LGTMHandler) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	comments, err := getComments(obj)
+	comments, err := getCommentsAfterLastModified(obj)
 	if err != nil {
 		glog.Errorf("unexpected error getting comments: %v", err)
 		return
@@ -151,7 +151,7 @@ func getReviewers(obj *github.MungeObject) mungerutil.UserSet {
 	return mungerutil.GetUsers(allAssignees...)
 }
 
-func getComments(obj *github.MungeObject) ([]*githubapi.IssueComment, error) {
+func getCommentsAfterLastModified(obj *github.MungeObject) ([]*githubapi.IssueComment, error) {
 	afterLastModified := func(opt *githubapi.IssueListCommentsOptions) *githubapi.IssueListCommentsOptions {
 		// Only comments updated at or after this time are returned.
 		// One possible case is that reviewer might "/lgtm" first, contributor updated PR, and reviewer updated "/lgtm".

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -47,6 +47,7 @@ import (
 )
 
 const (
+	approvedLabel                  = "approved"
 	lgtmLabel                      = "lgtm"
 	retestNotRequiredLabel         = "retest-not-required"
 	retestNotRequiredDocsOnlyLabel = "retest-not-required-docs-only"


### PR DESCRIPTION
ref: https://github.com/kubernetes/contrib/issues/1389

What?
This PR adds ApprovalHandler that will try to add "approved" label once all files of change has been approved by approvers.

```
// The algorithm goes as:
// - Initially, we set up approverMap
//   - Go through all comments after latest commit. If any approver said "/approve", add him to approverMap.
// - For each file, we see if any approver of this file is in approverMap.
//   - An approver of a file is defined as:
//     - It's known that each dir has a list of approvers. (This might not hold true. For usability, current situation is enough.)
//     - Approver of a dir is also the approver of child dirs.
//   - We look at only top 3 dir level's approvers .
// - Iff all files has been approved, the bot will add "approved" label.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1727)

<!-- Reviewable:end -->
