### PR TITLE
Added token file to ignore list.

### DIFF
--- a/mungegithub/.gitignore
+++ b/mungegithub/.gitignore
@@ -1,1 +1,2 @@
 mungegithub
+token


### PR DESCRIPTION
The secrets generation depends on a file named `token` containing the github token, but that file should be ignored.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1736)

<!-- Reviewable:end -->
