### PR TITLE
Allow customisation of the nginx proxy_buffer_size directive via ConfigMap

### DIFF
--- a/ingress/controllers/nginx/configuration.md
+++ b/ingress/controllers/nginx/configuration.md
@@ -198,6 +198,9 @@ http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout
 **proxy-send-timeout:** Sets the timeout in seconds for [transmitting a request to the proxied server](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout). The timeout is set only between two successive write operations, not for the transmission of the whole request.
 
 
+**proxy-buffer-size:** Sets the size of the buffer used for [reading the first part of the response](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) received from the proxied server. This part usually contains a small response header.`
+
+
 **resolver:** Configures name servers used to [resolve](http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver) names of upstream servers into addresses
 
 

--- a/ingress/controllers/nginx/nginx.tmpl
+++ b/ingress/controllers/nginx/nginx.tmpl
@@ -252,6 +252,7 @@ http {
 
             proxy_redirect                          off;
             proxy_buffering                         off;
+            proxy_buffer_size                       {{ $cfg.proxyBufferSize }};
 
             proxy_http_version                      1.1;
 

--- a/ingress/controllers/nginx/nginx/config/config.go
+++ b/ingress/controllers/nginx/nginx/config/config.go
@@ -157,6 +157,11 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
 	ProxySendTimeout int `structs:"proxy-send-timeout,omitempty"`
 
+	// Sets the size of the buffer used for reading the first part of the response received from the
+	// proxied server. This part usually contains a small response header.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size)
+	ProxyBufferSize string `structs:"proxy-buffer-size,omitempty"`
+
 	// Configures name servers used to resolve names of upstream servers into addresses
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
 	Resolver string `structs:"resolver,omitempty"`
@@ -275,6 +280,7 @@ func NewDefault() Configuration {
 		ProxyRealIPCIDR:          defIPCIDR,
 		ProxyReadTimeout:         60,
 		ProxySendTimeout:         60,
+		ProxyBufferSize:          "4k",
 		ServerNameHashMaxSize:    512,
 		ServerNameHashBucketSize: 64,
 		SSLRedirect:              true,


### PR DESCRIPTION
I'm opening a new PR with the same changes as #1693 because I pushed the latter with an email address that can't be used to sign the CLA. Description from the previous PR:

When using nginx as a proxy we can run into the following error:

```
upstream sent too big header while reading response header from upstream
```

In order to fix this, we need to be able to configure the proxy_buffer_size nginx directive to increase its value. This PR updates the nginx-ingress-controller to allow that.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1743)

<!-- Reviewable:end -->
