### PR TITLE
Redirect STOPSIGNAL for kube-dns graceful termination

### DIFF
--- a/dnsmasq/Dockerfile
+++ b/dnsmasq/Dockerfile
@@ -16,4 +16,6 @@ FROM alpine:3.4
 MAINTAINER Girish Kalele <gkalele@google.com>
 RUN apk --no-cache add dnsmasq
 COPY dnsmasq.conf /etc/dnsmasq.conf
+# Replace SIGTERM with SIGCONT as stop signal to support graceful termination
+STOPSIGNAL SIGCONT
 ENTRYPOINT ["/usr/sbin/dnsmasq", "--keep-in-foreground"]

--- a/dnsmasq/Dockerfile.cross
+++ b/dnsmasq/Dockerfile.cross
@@ -19,5 +19,7 @@ CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 MAINTAINER Girish Kalele <gkalele@google.com>
 COPY dnsmasq.conf /etc/dnsmasq.conf
 COPY dnsmasq /usr/sbin/dnsmasq
+# Replace SIGTERM with SIGCONT as stop signal to support graceful termination
+STOPSIGNAL SIGCONT
 RUN mkdir /var/run/
 ENTRYPOINT ["/usr/sbin/dnsmasq", "--keep-in-foreground"]


### PR DESCRIPTION
Fixes kubernetes/kubernetes#33050.

Current `dnsmasq` container exit immediately after docker sends STOPSIGNAL. In order to support graceful termination as kubernetes/kubernetes#31807 indicated, we need to delay this operation.

Similar to that we do in `kubedns` --- ignoring the SIGTERM and exit when SIGKILL from docker occurs, @thockin's solution is to redirect docker's STOPSIGNAL to SIGCONT. I did a couple rounds of test and it works as expected.

The tag should be bumped up when we need to get the graceful termination feature in.

@girishkalele @ArtfulCoder @luxas

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1756)

<!-- Reviewable:end -->
