### PR TITLE
Updating CLA labels to CNCF ones.

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -115,9 +115,9 @@ labels:
     color: fef2c0
   - name: 'cla: human-approved'
     color: bfe5bf
-  - name: 'cla: no'
+  - name: 'cncf-cla: no'
     color: e11d21
-  - name: 'cla: yes'
+  - name: 'cncf-cla: yes'
     color: bfe5bf
   - name: component/apiserver
     color: 0052cc


### PR DESCRIPTION
This will **not** remove the `cla:yes/no` labels, it will simply add two new ones.
The plan is to later remove (manually) the `cla:yes/no` labels on contrib, which are set by the Google CLA bot and let mungegithub set `cncf-cla: yes` and `cncf-cla: no` instead.

cc @bgrant0607

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1764)

<!-- Reviewable:end -->
