### PR TITLE
Fix link to auth example

### DIFF
--- a/ingress/controllers/nginx/configuration.md
+++ b/ingress/controllers/nginx/configuration.md
@@ -103,7 +103,7 @@ The secret must be created in the same namespace than the Ingress rule
 ingress.kubernetes.io/auth-realm:"realm string"
 ```
 
-Please check the [auth](examples/custom-upstream-check/README.md) example
+Please check the [auth](examples/auth/README.md) example
 
 
 ### Rewrite


### PR DESCRIPTION
The link to the authentication example is incorrect. This fixes it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1775)

<!-- Reviewable:end -->
