### PR TITLE
building for s390x architecture (aka IBM mainframe)

### DIFF
--- a/exec-healthz/Makefile
+++ b/exec-healthz/Makefile
@@ -30,7 +30,7 @@ ARCH ?= amd64
 
 SRC_DIRS := cmd pkg # directories which hold app source (not vendored)
 
-ALL_ARCH := amd64 arm arm64 ppc64le
+ALL_ARCH := amd64 arm arm64 ppc64le s390x
 
 # Set default base image dynamically for each arch
 ifeq ($(ARCH),amd64)
@@ -40,11 +40,15 @@ ifeq ($(ARCH),arm)
     BASEIMAGE?=armel/busybox
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=aarch64/busybox
+    BASEIMAGE?=aarch64alpine
 endif
 ifeq ($(ARCH),ppc64le)
     BASEIMAGE?=ppc64le/busybox
 endif
+ifeq ($(ARCH),s390x)
+    BASEIMAGE?=s390x/busybox
+endif
+
 
 IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)
 


### PR DESCRIPTION
building support for s390x architecture, as already supported by golang1.7

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1800)

<!-- Reviewable:end -->
