### PR TITLE
Bump up dnsmasq to 1.4 for graceful termination

### DIFF
--- a/dnsmasq/Changelog
+++ b/dnsmasq/Changelog
@@ -4,3 +4,5 @@
  - Multiple Architecture builds and upgraded to Alpine 3.4
 ## Version 1.3 (Fri June 11 2016 Lucas Käldström <lucas.kaldstrom@hotmail.co.uk>)
  - Patched the multi-architecture images, so they'll work
+## Version 1.4 (Thu September 29 2016 Zihong Zheng <zihongz@google.com>)
+ - Redirect STOPSIGNAL for graceful termination

--- a/dnsmasq/Makefile
+++ b/dnsmasq/Makefile
@@ -20,7 +20,7 @@
 #   [TAG=1.3] [REGISTRY=gcr.io/google_containers] make (build|push)
 
 # Default registry, arch and tag. This can be overwritten by arguments to make
-TAG?=1.3
+TAG?=1.4
 REGISTRY?=gcr.io/google_containers
 ARCH?=amd64
 KUBE_CROSS_IMAGE:=$(REGISTRY)/kube-cross:v1.6.2-2


### PR DESCRIPTION
Below images are built and pushed:
- gcr.io/google_containers/kube-dnsmasq-amd64:1.4
- gcr.io/google_containers/kube-dnsmasq-arm:1.4
- gcr.io/google_containers/kube-dnsmasq-arm64:1.4
- gcr.io/google_containers/kube-dnsmasq-ppc64le:1.4

I will soon send out another PR to bump up kube-dns addon in the kubernetes repo.

@thockin @bprashanth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1804)
<!-- Reviewable:end -->
