### PR TITLE
ingress/controllers/nginx: WebSocket documentation

### DIFF
--- a/ingress/controllers/nginx/nginx.tmpl
+++ b/ingress/controllers/nginx/nginx.tmpl
@@ -92,6 +92,13 @@ http {
     resolver {{ .defResolver }} valid=30s;
     {{ end }}
 
+    {{/* Whenever nginx proxies a request without a "Connection" header, the "Connection" header is set to "close" */}}
+    {{/* when making the target request.  This means that you cannot simply use */}}
+    {{/* "proxy_set_header Connection $http_connection" for WebSocket support because in this case, the */}}
+    {{/* "Connection" header would be set to "" whenever the original request did not have a "Connection" header, */}}
+    {{/* which would mean no "Connection" header would be in the target request.  Since this would deviate from */}}
+    {{/* normal nginx behavior we have to use this approach. */}}
+    # Retain the default nginx handling of requests without a "Connection" header
     map $http_upgrade $connection_upgrade {
         default upgrade;
         ''      close;


### PR DESCRIPTION
For those that do not understand the default way in which nginx proxies
requests not containing a "Connection" header, the approach for enabling
WebSocket support might not make sense.  This commit adds documentation
that explains why things are done this way.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1808)

<!-- Reviewable:end -->
