### PR TITLE
Honor lgtm label applied manually.

### DIFF
--- a/mungegithub/github/testing/github.go
+++ b/mungegithub/github/testing/github.go
@@ -106,12 +106,12 @@ func Issue(user string, number int, labels []string, isPR bool) *github.Issue {
 
 // MultiIssueEvents packages up events for when you have multiple issues in the
 // test server.
-func MultiIssueEvents(issueToEvents map[int][]LabelTime) (out []*github.IssueEvent) {
+func MultiIssueEvents(issueToEvents map[int][]LabelTime, eventName string) (out []*github.IssueEvent) {
 	for issueNum, events := range issueToEvents {
 		for _, l := range events {
 			out = append(out, &github.IssueEvent{
 				Issue: &github.Issue{Number: intPtr(issueNum)},
-				Event: stringPtr("labeled"),
+				Event: stringPtr(eventName),
 				Label: &github.Label{
 					Name: stringPtr(l.Label),
 				},

--- a/mungegithub/mungers/lgtm_handler.go
+++ b/mungegithub/mungers/lgtm_handler.go
@@ -127,8 +127,7 @@ func (h *LGTMHandler) addLGTMIfCommented(obj *github.MungeObject, comments []*gi
 
 func (h *LGTMHandler) removeLGTMIfCancelled(obj *github.MungeObject, comments []*githubapi.IssueComment, events []*githubapi.IssueEvent, reviewers mungerutil.UserSet) {
 	// Get time when the last (unlabeled, lgtm) event occurred.
-	addLGTMTime := e.LastEvent(events, e.And{e.RemoveLabel{}, e.LabelName(lgtmLabel), e.HumanActor()}, nil)
-
+	addLGTMTime := e.LastEvent(events, e.And{e.AddLabel{}, e.LabelName(lgtmLabel), e.HumanActor()}, nil)
 	for i := len(comments) - 1; i >= 0; i-- {
 		comment := comments[i]
 		if !mungerutil.IsValidUser(comment.User) {

--- a/mungegithub/mungers/matchers/event/event.go
+++ b/mungegithub/mungers/matchers/event/event.go
@@ -50,6 +50,17 @@ func (a AddLabel) Match(event *github.IssueEvent) bool {
 	return *event.Event == "labeled"
 }
 
+// RemoveLabel searches for "unlabeled" event.
+type RemoveLabel struct{}
+
+// Match if the event is of type "unlabeled"
+func (r RemoveLabel) Match(event *github.IssueEvent) bool {
+	if event == nil || event.Event == nil {
+		return false
+	}
+	return *event.Event == "unlabeled"
+}
+
 // LabelPrefix searches for event whose label starts with the string
 type LabelPrefix string
 
@@ -59,6 +70,17 @@ func (l LabelPrefix) Match(event *github.IssueEvent) bool {
 		return false
 	}
 	return strings.HasPrefix(*event.Label.Name, string(l))
+}
+
+// LabelName searches for event whose label starts with the string
+type LabelName string
+
+// Match if the label is exactly provided string
+func (l LabelName) Match(event *github.IssueEvent) bool {
+	if event == nil || event.Label == nil || event.Label.Name == nil {
+		return false
+	}
+	return *event.Label.Name == string(l)
 }
 
 // CreatedAfter looks for event created after time

--- a/mungegithub/mungers/matchers/event/finder.go
+++ b/mungegithub/mungers/matchers/event/finder.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package event
 
-import "github.com/google/go-github/github"
+import (
+	"time"
+
+	"github.com/google/go-github/github"
+)
 
 // FilteredEvents is a list of events
 type FilteredEvents []*github.IssueEvent
@@ -42,4 +46,13 @@ func FilterEvents(events []*github.IssueEvent, matcher Matcher) FilteredEvents {
 	}
 
 	return matches
+}
+
+// LastEvent returns the creation date of the last event that matches. Or deflt if there is no such event.
+func LastEvent(events []*github.IssueEvent, matcher Matcher, deflt *time.Time) *time.Time {
+	matches := FilterEvents(events, matcher)
+	if matches.Empty() {
+		return deflt
+	}
+	return matches.GetLast().CreatedAt
 }

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -314,7 +314,7 @@ func TestQueueOrder(t *testing.T) {
 	}
 	for testNum, test := range tests {
 		config := &github_util.Config{}
-		client, server, mux := github_test.InitServer(t, nil, nil, github_test.MultiIssueEvents(test.issueToEvents), nil, nil, nil, nil)
+		client, server, mux := github_test.InitServer(t, nil, nil, github_test.MultiIssueEvents(test.issueToEvents, "labeled"), nil, nil, nil, nil)
 		config.Org = "o"
 		config.Project = "r"
 		config.SetClient(client)


### PR DESCRIPTION
Should prevent issues like https://github.com/kubernetes/contrib/pull/1719#issuecomment-248719633
This teaches the bot to allow human users to override the `/lgtm` and `/lgtm cancel` behaviors by directly adding/removing the label.

This is the last blocker to rolling out `/lgtm` to the main repository.

cc @kubernetes/contributor-experience @bgrant0607 @anguslees @eparis @grodrigues3 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1811)

<!-- Reviewable:end -->
