### PR TITLE
Added domain name and server port into nginx logs

### DIFF
--- a/ingress/controllers/nginx/nginx.tmpl
+++ b/ingress/controllers/nginx/nginx.tmpl
@@ -73,8 +73,8 @@ http {
 
     client_max_body_size "{{ $cfg.bodySize }}";
 
-    log_format upstreaminfo '{{ if $cfg.useProxyProtocol }}$proxy_protocol_addr{{ else }}$remote_addr{{ end }} - '
-        '[$proxy_add_x_forwarded_for] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" '
+    log_format upstreaminfo '{{ if $cfg.useProxyProtocol }}$proxy_protocol_addr{{ else }}$remote_addr{{ end }} $host '
+        '[$proxy_add_x_forwarded_for] $server_port $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" '
         '$request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status';
 
     {{/* map urls that should not appear in access.log */}}


### PR DESCRIPTION
I replaced dashes so it shouldn't brake log parsers.
In addition here are the [fluentd rules](https://github.com/kayrus/elk-kubernetes/blob/a3727fdf1411114da7e2fe921cf693afa97ea478/docker/fluentd/td-agent.conf#L262..L269) which parse these logs (requires https://github.com/tagomoris/fluent-plugin-parser plugin)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1813)

<!-- Reviewable:end -->
