### PR TITLE
Don't index ingress.status.ip if empty.

### DIFF
--- a/ingress/controllers/gce/Makefile
+++ b/ingress/controllers/gce/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG = 0.7.1
+TAG = 0.8.0
 PREFIX = gcr.io/google_containers/glbc
 
 server:


### PR DESCRIPTION
This can happen in some odd situations where the user has asked for invalid ingress/secrets. It results in a nil pointer deref.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1820)

<!-- Reviewable:end -->
