### PR TITLE
submit queue: truncate comments at 64k

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -52,6 +52,8 @@ const (
 
 	headerRateRemaining = "X-RateLimit-Remaining"
 	headerRateReset     = "X-RateLimit-Reset"
+
+	maxCommentLen = 65535
 )
 
 var (
@@ -1659,6 +1661,10 @@ func (obj *MungeObject) WriteComment(msg string) error {
 	glog.Infof("Commenting in %d: %q", prNum, comment)
 	if config.DryRun {
 		return nil
+	}
+	if len(msg) > maxCommentLen {
+		glog.Info("Comment in %d was larger than %d and was truncated", prNum, maxCommentLen)
+		msg = msg[:maxCommentLen]
 	}
 	if _, _, err := config.client.Issues.CreateComment(config.Org, config.Project, prNum, &github.IssueComment{Body: &msg}); err != nil {
 		glog.Errorf("%v", err)


### PR DESCRIPTION
Github gets mad at us when we do this:

github.go:1664] POST https://api.github.com/repos/kubernetes/kubernetes/issues/33381/comments: 422 Validation Failed [{Resource:IssueComment Field:body Code:custom Message:body is too long (maximum is 65536 characters)}]

and then soon:

github.go:1664] POST https://api.github.com/repos/kubernetes/kubernetes/issues/33381/comments: 403 You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later. []

Which can cause abuse failures for other calls to the API.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1829)

<!-- Reviewable:end -->
