### PR TITLE
CRI: Add cri benchmark test in node perf dash.

### DIFF
--- a/node-perf-dash/node-perf-dash-deployment.yaml
+++ b/node-perf-dash/node-perf-dash-deployment.yaml
@@ -22,6 +22,7 @@ spec:
           -   --builds=30
           -   --datasource=google-gcs
           -   --tracing=true
+          -   --jenkins-job=kubelet-benchmark-gce-e2e-ci,continuous-node-e2e-docker-benchmark,kubelet-cri-benchmark-gce-e2e-ci
         imagePullPolicy: Always
         name: node-perf-dash
         ports:


### PR DESCRIPTION
For kubernetes/kubernetes#31459.

This depends on https://github.com/kubernetes/test-infra/pull/761 and https://github.com/kubernetes/kubernetes/pull/34141.

After this gets merged, I'll restart node perf dash. Then we should be able to monitor benchmark result with cri enabled.

@yujuhong @feiskyer 
/cc @kubernetes/sig-node 
