### PR TITLE
Target linux binaries by default so you can follow the build instruct…

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -3,13 +3,14 @@ all: build
 TAG?=dev
 FLAGS=
 ENVVAR=
+GOOS?=linux
 
 deps:
 	go get github.com/tools/godep
 
 build: clean deps
-	$(ENVVAR) godep go build ./...
-	$(ENVVAR) godep go build -o cluster-autoscaler 
+	$(ENVVAR) GOOS=$(GOOS) godep go build ./...
+	$(ENVVAR) GOOS=$(GOOS) godep go build -o cluster-autoscaler
 
 test-unit: clean deps build
 	$(ENVVAR) godep go test --test.short -race ./... $(FLAGS)


### PR DESCRIPTION
…ions on a Mac and still build a valid image.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1863)

<!-- Reviewable:end -->
