### PR TITLE
Make map_hash_bucket_size configurable

### DIFF
--- a/ingress/controllers/nginx/nginx.tmpl
+++ b/ingress/controllers/nginx/nginx.tmpl
@@ -59,6 +59,7 @@ http {
     types_hash_max_size 2048;
     server_names_hash_max_size {{ $cfg.serverNameHashMaxSize }};
     server_names_hash_bucket_size {{ $cfg.serverNameHashBucketSize }};
+    map_hash_bucket_size {{ $cfg.mapHashBucketSize }};
 
     include /etc/nginx/mime.types;
     default_type text/html;

--- a/ingress/controllers/nginx/nginx/config/config.go
+++ b/ingress/controllers/nginx/nginx/config/config.go
@@ -141,6 +141,11 @@ type Configuration struct {
 	// http://nginx.org/en/docs/ngx_core_module.html#worker_connections
 	MaxWorkerConnections int `structs:"max-worker-connections,omitempty"`
 
+	// Sets the bucket size for the map variables hash tables.
+	// Default value depends on the processor’s cache line size.
+	// http://nginx.org/en/docs/http/ngx_http_map_module.html#map_hash_bucket_size
+	MapHashBucketSize int `structs:"map-hash-bucket-size,omitempty"`
+
 	// Defines a timeout for establishing a connection with a proxied server.
 	// It should be noted that this timeout cannot usually exceed 75 seconds.
 	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_connect_timeout
@@ -279,6 +284,7 @@ func NewDefault() Configuration {
 		GzipTypes:                gzipTypes,
 		KeepAlive:                75,
 		MaxWorkerConnections:     16384,
+		MapHashBucketSize:        64,
 		ProxyConnectTimeout:      5,
 		ProxyRealIPCIDR:          defIPCIDR,
 		ProxyReadTimeout:         60,


### PR DESCRIPTION
I was getting an error while trying to run the nginx controller in minikube.  This allows this nginx configuration option to be passed in through a configmap.  

The default value depends on the processor's cache line size (32 | 64 | 128), however ServerNameHashBucketSize is determined similarly, so I've set it to the same default (64).

Fixes #1817

ref https://github.com/kubernetes/minikube/issues/611

cc @bprashanth

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1879)

<!-- Reviewable:end -->
