### PR TITLE
nginx-ingress: configurable ingress class

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -47,6 +47,7 @@ history-url
 http-cache-dir
 http-cache-size
 http-port
+ingress-class
 insecure-registry
 insecure-skip-verify
 issue-mungers

--- a/ingress/controllers/nginx/controller.go
+++ b/ingress/controllers/nginx/controller.go
@@ -462,7 +462,14 @@ func (lbc *loadBalancerController) sync(key string) error {
 	ngxConfig := lbc.nginx.ReadConfig(cfg)
 	ngxConfig.HealthzURL = lbc.defHealthzURL
 
-	ings := lbc.ingLister.Store.List()
+	allIngs := lbc.ingLister.Store.List()
+	ings := []interface{}{}
+	for _, ing := range allIngs {
+		curIng := ing.(*extensions.Ingress)
+		if isNGINXIngress(curIng) {
+			ings = append(ings, ing)
+		}
+	}
 	upstreams, servers := lbc.getUpstreamServers(ngxConfig, ings)
 
 	return lbc.nginx.CheckAndReload(ngxConfig, ingress.Configuration{

--- a/ingress/controllers/nginx/main.go
+++ b/ingress/controllers/nginx/main.go
@@ -51,6 +51,9 @@ var (
     namespace/name. The controller uses the first node port of this Service for
     the default backend.`)
 
+	nginxIngressClass = flags.String("ingress-class", defaultIngressClass,
+		`Name of the ingress class to route through this controller.`)
+
 	nxgConfigMap = flags.String("nginx-configmap", "",
 		`Name of the ConfigMap that containes the custom nginx configuration to use`)
 
@@ -77,7 +80,7 @@ var (
 
 	profiling = flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)
 
-	defSSLCertificate = flags.String("default-ssl-certificate", "", `Name of the secret that contains a SSL 
+	defSSLCertificate = flags.String("default-ssl-certificate", "", `Name of the secret that contains a SSL
 		certificate to be used as default for a HTTPS catch-all server`)
 
 	defHealthzURL = flags.String("health-check-path", "/ingress-controller-healthz", `Defines the URL to
@@ -90,6 +93,7 @@ func main() {
 	clientConfig := kubectl_util.DefaultClientConfig(flags)
 
 	glog.Infof("Using build: %v - %v", gitRepo, version)
+	glog.Infof("Watching for ingress class: %s", *nginxIngressClass)
 
 	if *defaultSvc == "" {
 		glog.Fatalf("Please specify --default-backend-service")

--- a/ingress/controllers/nginx/utils.go
+++ b/ingress/controllers/nginx/utils.go
@@ -260,8 +260,8 @@ const (
 	// ingressClassKey picks a specific "class" for the Ingress. The controller
 	// only processes Ingresses with this annotation either unset, or set
 	// to either nginxIngressClass or the empty string.
-	ingressClassKey   = "kubernetes.io/ingress.class"
-	nginxIngressClass = "nginx"
+	ingressClassKey     = "kubernetes.io/ingress.class"
+	defaultIngressClass = "nginx"
 )
 
 func (ing ingAnnotations) ingressClass() string {
@@ -273,10 +273,21 @@ func (ing ingAnnotations) ingressClass() string {
 }
 
 // isNGINXIngress returns true if the given Ingress either doesn't specify the
-// ingress.class annotation, or it's set to "nginx".
+// ingress.class annotation, or it's set to the value of nginxIngressClass.
 func isNGINXIngress(ing *extensions.Ingress) bool {
 	class := ingAnnotations(ing.ObjectMeta.Annotations).ingressClass()
-	return class == "" || class == nginxIngressClass
+
+	// class is equal to --ingress-class -> true
+	if *nginxIngressClass == class {
+		return true
+	}
+
+	// class is empty and --ingress-class is default -> true
+	if class == "" && *nginxIngressClass == defaultIngressClass {
+		return true
+	}
+
+	return false
 }
 
 const (


### PR DESCRIPTION
Add --ingress-class flag for configurable ingress class. Default
behavior is preserved, but adds flexibility to support, for example,
internal and external ELBs attached to nginx ingress controllers.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1880)

<!-- Reviewable:end -->
