### PR TITLE
Use host name for instance.

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -55,6 +55,7 @@ jenkins-host
 jenkins-jobs
 kube-api-content-type
 kubelet-host
+kubelet-instance
 kubelet-port
 label-file
 last-release-pr

--- a/kubelet-to-gcm/monitor/controller/source.go
+++ b/kubelet-to-gcm/monitor/controller/source.go
@@ -35,7 +35,7 @@ type Source struct {
 // NewSource creates a new Source for a kube-controller.
 func NewSource(cfg *monitor.SourceConfig) (*Source, error) {
 	// Create objects for controller monitoring.
-	trans := NewTranslator(cfg.Zone, cfg.Project, cfg.Cluster, cfg.Host, cfg.Resolution)
+	trans := NewTranslator(cfg.Zone, cfg.Project, cfg.Cluster, cfg.Instance, cfg.Resolution)
 
 	// NewClient validates its own inputs.
 	client, err := NewClient(cfg.Host, cfg.Port, &http.Client{})

--- a/kubelet-to-gcm/monitor/kubelet/source.go
+++ b/kubelet-to-gcm/monitor/kubelet/source.go
@@ -35,7 +35,7 @@ type Source struct {
 // NewSource creates a new Source for a kubelet.
 func NewSource(cfg *monitor.SourceConfig) (*Source, error) {
 	// Create objects for kubelet monitoring.
-	trans := NewTranslator(cfg.Zone, cfg.Project, cfg.Cluster, cfg.Host, cfg.Resolution)
+	trans := NewTranslator(cfg.Zone, cfg.Project, cfg.Cluster, cfg.Instance, cfg.Resolution)
 
 	// NewClient validates its own inputs.
 	client, err := NewClient(cfg.Host, cfg.Port, &http.Client{})

--- a/kubelet-to-gcm/monitor/kubelet/translate.go
+++ b/kubelet-to-gcm/monitor/kubelet/translate.go
@@ -205,7 +205,7 @@ func (t *Translator) translateContainers(pods []stats.PodStats) ([]*v3.TimeSerie
 			uptimePoint := &v3.Point{
 				Interval: &v3.TimeInterval{
 					EndTime:   now.Format(time.RFC3339),
-					StartTime: now.Add(-1 * t.resolution).Format(time.RFC3339),
+					StartTime: container.StartTime.Time.Format(time.RFC3339),
 				},
 				Value: &v3.TypedValue{
 					DoubleValue:     monitor.Float64Ptr(float64(time.Since(container.StartTime.Time).Seconds())),

--- a/kubelet-to-gcm/monitor/main/daemon.go
+++ b/kubelet-to-gcm/monitor/main/daemon.go
@@ -40,12 +40,13 @@ const (
 
 var (
 	// Flags to identify the Kubelet.
-	zone        = pflag.String("zone", "use-gce", "The zone where this kubelet lives.")
-	project     = pflag.String("project", "use-gce", "The project where this kubelet's host lives.")
-	cluster     = pflag.String("cluster", "use-gce", "The cluster where this kubelet holds membership.")
-	kubeletHost = pflag.String("kubelet-host", "use-gce", "The kubelet's host name.")
-	kubeletPort = pflag.Uint("kubelet-port", 10255, "The kubelet's port.")
-	ctrlPort    = pflag.Uint("controller-manager-port", 10252, "The kube-controller's port.")
+	zone            = pflag.String("zone", "use-gce", "The zone where this kubelet lives.")
+	project         = pflag.String("project", "use-gce", "The project where this kubelet's host lives.")
+	cluster         = pflag.String("cluster", "use-gce", "The cluster where this kubelet holds membership.")
+	kubeletInstance = pflag.String("kubelet-instance", "use-gce", "The instance name the kubelet resides on.")
+	kubeletHost     = pflag.String("kubelet-host", "use-gce", "The kubelet's host name.")
+	kubeletPort     = pflag.Uint("kubelet-port", 10255, "The kubelet's port.")
+	ctrlPort        = pflag.Uint("controller-manager-port", 10252, "The kube-controller's port.")
 	// Flags to control runtime behavior.
 	res         = pflag.Uint("resolution", 10, "The time, in seconds, to poll the Kubelet.")
 	gcmEndpoint = pflag.String("gcm-endpoint", "", "The GCM endpoint to hit. Defaults to the default endpoint.")
@@ -61,7 +62,7 @@ func main() {
 	resolution := time.Second * time.Duration(*res)
 
 	// Initialize the configuration.
-	kubeletCfg, ctrlCfg, err := config.NewConfigs(*zone, *project, *cluster, *kubeletHost, *kubeletPort, *ctrlPort, resolution)
+	kubeletCfg, ctrlCfg, err := config.NewConfigs(*zone, *project, *cluster, *kubeletHost, *kubeletInstance, *kubeletPort, *ctrlPort, resolution)
 	if err != nil {
 		log.Fatalf("Failed to initialize configuration: %v", err)
 	}

--- a/kubelet-to-gcm/monitor/poll.go
+++ b/kubelet-to-gcm/monitor/poll.go
@@ -26,9 +26,9 @@ import (
 // SourceConfig is the set of data required to configure a kubernetes
 // data source (e.g., kubelet or kube-controller).
 type SourceConfig struct {
-	Zone, Project, Cluster, Host string
-	Port                         uint
-	Resolution                   time.Duration
+	Zone, Project, Cluster, Host, Instance string
+	Port                                   uint
+	Resolution                             time.Duration
 }
 
 // MetricsSource is an object that provides kubernetes metrics in


### PR DESCRIPTION
It turns out alarming is inaccurate without this (due to IP conflicts).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1883)

<!-- Reviewable:end -->
