### PR TITLE
Bumping kubelet-to-gcm to 1.2.1

### DIFF
--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -26,7 +26,7 @@ OUT_DIR = build
 PACKAGE = k8s.io/contrib/kubelet-to-gcm
 #PREFIX = gcr.io/google_containers
 PREFIX = gcr.io/gke-test-us-central1-b-0
-TAG = 1.2
+TAG = 1.2.1
 
 # Rules for building the real image for deployment to gcr.io
 


### PR DESCRIPTION
I'd like to bump the minor version so I can distinguish the latest version.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1887)

<!-- Reviewable:end -->
