### PR TITLE
mungegithub: Make approval label mimick lgtm label

### DIFF
--- a/mungegithub/mungers/approve-lgtm.go
+++ b/mungegithub/mungers/approve-lgtm.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"k8s.io/contrib/mungegithub/features"
+	"k8s.io/contrib/mungegithub/github"
+	"k8s.io/contrib/mungegithub/mungers/matchers/event"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+// ApproveFollowsLGTM will try to follow the LGTM label closely. If it doesn't have LGTM, then removes approve.
+// If LGTM is there, then print a warning to let people know that this is not going to work forever.
+// No warning yet.
+type ApproveFollowsLGTM struct {
+}
+
+func init() {
+	a := &ApproveFollowsLGTM{}
+	RegisterMungerOrDie(a)
+}
+
+// Name is the name usable in --pr-mungers
+func (ApproveFollowsLGTM) Name() string { return "approve-lgtm" }
+
+// RequiredFeatures is a slice of 'features' that must be provided
+func (ApproveFollowsLGTM) RequiredFeatures() []string { return []string{} }
+
+// Initialize will initialize the munger
+func (ApproveFollowsLGTM) Initialize(config *github.Config, features *features.Features) error {
+	return nil
+}
+
+// EachLoop is called at the start of every munge loop
+func (ApproveFollowsLGTM) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (ApproveFollowsLGTM) AddFlags(cmd *cobra.Command, config *github.Config) {
+}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (ApproveFollowsLGTM) Munge(obj *github.MungeObject) {
+	if !obj.IsPR() {
+		return
+	}
+
+	events, err := obj.GetEvents()
+	if err != nil {
+		return
+	}
+
+	// Find last lgtm or approved label add/remove
+	lgtmOrApproved := event.FilterEvents(events,
+		event.Or{
+			event.LabelName(lgtmLabel),
+			event.LabelName(approvedLabel),
+		},
+	)
+	if lgtmOrApproved.Empty() {
+		return
+	}
+
+	lastLabel := lgtmOrApproved.GetLast()
+	// There is no such event, or the Event field is missing
+	if lastLabel == nil || lastLabel.Event == nil {
+		return
+	}
+
+	if *lastLabel.Event == "labeled" {
+		obj.AddLabels([]string{approvedLabel, lgtmLabel})
+	} else if *lastLabel.Event == "unlabeled" {
+		obj.RemoveLabel(approvedLabel)
+		obj.RemoveLabel(lgtmLabel)
+	} else {
+		glog.Error("Received unexpected event: ", *lastLabel.Event)
+	}
+}


### PR DESCRIPTION
Our goal is to move from **LGTM** to **approved** as the gating label for the submit-queue.
In order to transition smoothly, we will first begin by having both LGTM and Approved
labels that behave identically.  Initially, only LGTM will be needed for merge, though the approved label will be present, and eventually only the approved label will be needed.  

Notes: this implementation always adds and removes the two labels synchronously

The plan is to start warning about LGTM use later, indicating that its use will be phased out in favor of approved.  Then, it will be downgraded to be the prerequisite for approved.  

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1889)

<!-- Reviewable:end -->
