### PR TITLE
Don't make subdirs when publishing client-go

### DIFF
--- a/mungegithub/publisher/deployment.yaml
+++ b/mungegithub/publisher/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         - --token-file=$(TOKEN_FILE)
         - --repo-dir=$(REPO_DIR)
         - --netrc-dir=$(NETRC_DIR)
+        - --alsologtostderr
         image: gcr.io/google_containers/publisher:2016-05-24-86f86cd
         imagePullPolicy: Always
         env:


### PR DESCRIPTION
Part of the client-go restructuring effort. This PR make publisher not to create subdirectories in client-go.

The latest commit in https://github.com/caesarxuchao/client-go/commits/master is a sample commit.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1895)

<!-- Reviewable:end -->
