### PR TITLE
Allow "Approvers" group in md files

### DIFF
--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -104,9 +104,14 @@ func (o *RepoInfo) walkFunc(path string, info os.FileInfo, err error) error {
 			glog.Errorf("Unable to find relative path between %q and %q: %v", o.projectDir, path, err)
 			return err
 		}
+		o.assignees[path] = sets.NewString()
 		if len(c.Assignees) > 0 {
-			o.assignees[path] = sets.NewString(c.Assignees...)
+			o.assignees[path].Union(sets.NewString(c.Assignees...))
 		}
+		if len(c.Approvers) > 0 {
+			o.assignees[path].Union(sets.NewString(c.Approvers...))
+		}
+
 		return nil
 	}
 
@@ -136,10 +141,11 @@ func (o *RepoInfo) walkFunc(path string, info os.FileInfo, err error) error {
 	if path == "." {
 		path = "/"
 	}
+	o.assignees[path] = sets.NewString()
 	if len(c.Assignees) > 0 {
-		o.assignees[path] = sets.NewString(c.Assignees...)
+		o.assignees[path].Union(sets.NewString(c.Assignees...))
 	} else if len(c.Approvers) > 0 {
-		o.assignees[path] = sets.NewString(c.Approvers...)
+		o.assignees[path].Union(sets.NewString(c.Approvers...))
 	}
 	//if len(c.Owners) > 0 {
 	//o.owners[path] = sets.NewString(c.Owners...)


### PR DESCRIPTION
And take the union of approvers and assignees for transitory cases, when/if not all files have been changed.
