### PR TITLE
Vagrant script improvements

### DIFF
--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -114,8 +114,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       _config['security_group'] = []
     end
 
-    config.ssh.username = "fedora"
-    config.ssh.private_key_path = "~/.ssh/id_rsa"
+    config.ssh.username = _config["os_instance_username"]
+    config.ssh.private_key_path = _config['os_ssh_pub_key_path']
     config.vm.boot_timeout = 60*10
 
     ### The below parameters need to be modified per your openstack instance.

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -45,6 +45,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "aws"
   config.vm.provider "openstack"
 
+  # By default, Vagrant itself assumes that sudo requires no
+  # password, therefore it does not need a tty. Some OS images
+  # instead require a tty in order to run sudo.
+  # Below configuration enable the tty on Vagrant 1.4+
+  # See https://goo.gl/fC5sPW for details
+  config.ssh.pty = true
+
   def set_openstack_box(config)
     case $os_image
     when :centos7

--- a/ansible/vagrant/openstack_config.yml.example
+++ b/ansible/vagrant/openstack_config.yml.example
@@ -10,3 +10,5 @@ os_security_groups:
   - "default"
  #- some_other_group
 os_floating_ip_pool: "os1_public"
+os_ssh_pub_key_path: "~/.ssh/id_rsa"
+os_instance_username: "fedora"


### PR DESCRIPTION
- Solve issue described in #1881 
- Parametrise user and ssh public key for OpenStack provider from the configuration file. This avoid to modify `Vagrantfile` for custom deployments

I'm currently not a contributor but I will follow the procedure if the PR will be reviewed positively.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1918)

<!-- Reviewable:end -->
