### PR TITLE
README.md: fix typo for echoheaders-y deployment

### DIFF
--- a/ingress/controllers/nginx/examples/README.md
+++ b/ingress/controllers/nginx/examples/README.md
@@ -4,5 +4,5 @@ All the examples references the services `echoheaders-x` and `echoheaders-y`
 ```
 kubectl run echoheaders --image=gcr.io/google_containers/echoserver:1.4 --replicas=1 --port=8080
 kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-x
-kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-x
+kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-y
 ```


### PR DESCRIPTION
  This now matches up to:
  https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx#http

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1934)

<!-- Reviewable:end -->
