### PR TITLE
Cluster-autoscaler: allow unschedulable nodes

### DIFF
--- a/cluster-autoscaler/simulator/predicates.go
+++ b/cluster-autoscaler/simulator/predicates.go
@@ -63,6 +63,10 @@ func NewTestPredicateChecker() *PredicateChecker {
 // FitsAny checks if the given pod can be place on any of the given nodes.
 func (p *PredicateChecker) FitsAny(pod *kube_api.Pod, nodeInfos map[string]*schedulercache.NodeInfo) (string, error) {
 	for name, nodeInfo := range nodeInfos {
+		// Be sure that the node is schedulable.
+		if nodeInfo.Node().Spec.Unschedulable {
+			continue
+		}
 		if err := p.CheckPredicates(pod, nodeInfo); err == nil {
 			return name, nil
 		}

--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -102,9 +102,6 @@ func (readyNodeLister *ReadyNodeLister) List() ([]*kube_api.Node, error) {
 	}
 	readyNodes := make([]*kube_api.Node, 0, len(nodes.Items))
 	for i, node := range nodes.Items {
-		if node.Spec.Unschedulable {
-			continue
-		}
 		for _, condition := range node.Status.Conditions {
 			if condition.Type == kube_api.NodeReady && condition.Status == kube_api.ConditionTrue {
 				readyNodes = append(readyNodes, &nodes.Items[i])


### PR DESCRIPTION
Unschedulable nodes that belong to some autoscaling-enabled node pool are perfectly fine.

cc: @fgrzadkowski @piosz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1935)

<!-- Reviewable:end -->
