### PR TITLE
Use underscore in kube-* Ansible variables

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -83,10 +83,10 @@ cluster_logging: true
 cluster_monitoring: true
 
 # Turn to false to disable the kube-ui addon for this cluster
-kube-ui: false
+kube_ui: false
 
 # Turn to false to disable the kube-dash addon for this cluster
-kube-dash: false
+kube_dash: false
 
 # Turn this varable to 'false' to disable whole DNS configuration.
 dns_setup: true

--- a/ansible/roles/kubernetes-addons/tasks/main.yml
+++ b/ansible/roles/kubernetes-addons/tasks/main.yml
@@ -26,10 +26,10 @@
   when: cluster_logging
 
 - include: kube-ui.yml
-  when: kube-ui
+  when: kube_ui
 
 - include: kube-dash.yml
-  when: kube-dash
+  when: kube_dash
 
 - name: Get kube-addons script from Kubernetes
   copy:


### PR DESCRIPTION
According to the Ansible documentation [1](http://docs.ansible.com/ansible/playbooks_variables.html#what-makes-a-valid-variable-name), variable names with dash are
considered invalid. This commit replaces kube-ui and kube-dash with
kube_ui and kube_dash, respectively.

Fixes #1925.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1938)

<!-- Reviewable:end -->
