### PR TITLE
Increase kubernetes security in ansible scripts

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -99,3 +99,5 @@ dns_replicas: 1
 
 # See kube documentation for apiserver runtime config options.  Example below enables HPA, deployments features.
 # apiserver_extra_args: "--runtime-config=extensions/v1beta1/deployments=true"
+
+#private_interface: eth0

--- a/ansible/roles/etcd/tasks/install.yml
+++ b/ansible/roles/etcd/tasks/install.yml
@@ -26,7 +26,7 @@
   user:
     name=etcd
     comment="Etcd user"
-    shell=/sbin/nologin
+    shell=/usr/sbin/nologin
     state=present
     system=yes
     groups=etcd

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -45,6 +45,9 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 # pods on startup
 kube_manifest_dir: "{{ kube_config_dir }}/manifests"
 
+# This is the username that the cert creation scripts chown the
+# cert files to. Not really changeable...
+kube_cert_user: kube
 # This is the group that the cert creation scripts chgrp the
 # cert files to. Not really changeable...
 kube_cert_group: kube-cert
@@ -61,3 +64,25 @@ dns_domain: "{{ cluster_name }}"
 # the range specified as kube_service_addresses. This magic will actually
 # pick the 10th ip address in the kube_service_addresses range and use that.
 dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(10)|ipaddr('address') }}"
+
+open_cadvisor_port: false
+open_kubelet_port: false
+
+# Zero means doesn't listen cadvisor port at all, default port 4194
+kubelet_cadvisor_port: 4194
+
+# apiserver should use ssh tunnell in case when you use private interface, see enable_kube_apiserver_ssh
+kubelet_bind_address: "0.0.0.0"
+#kubelet_bind_address: "127.0.0.1"
+#kubelet_bind_address: "{{ hostvars[inventory_hostname]['ansible_'+private_interface]['ipv4']['address'] }}"
+
+# Port which kubelet should listen
+kubelet_port: 10250
+# Zero means doesn't listen kubelet read-only port at all, default port 10255
+kubelet_read_only_port: 10255
+
+# When "kubelet_bind_address" is unreachable outside the node
+# (open_kubelet_port is true or kubelet_bind_address is "127.0.0.1") we will use ssh tunnel.
+# In case when kubelet listens localhost, "exec" and "logs" commands could be inaccessible
+# until https://github.com/kubernetes/kubernetes/pull/35693 PR is merged
+enable_kube_apiserver_ssh: true

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -69,7 +69,7 @@ open_cadvisor_port: false
 open_kubelet_port: false
 
 # Zero means doesn't listen cadvisor port at all, default port 4194
-kubelet_cadvisor_port: 4194
+kubelet_cadvisor_port: 0
 
 # apiserver should use ssh tunnell in case when you use private interface, see enable_kube_apiserver_ssh
 kubelet_bind_address: "0.0.0.0"
@@ -79,7 +79,7 @@ kubelet_bind_address: "0.0.0.0"
 # Port which kubelet should listen
 kubelet_port: 10250
 # Zero means doesn't listen kubelet read-only port at all, default port 10255
-kubelet_read_only_port: 10255
+kubelet_read_only_port: 0
 
 # When "kubelet_bind_address" is unreachable outside the node
 # (open_kubelet_port is true or kubelet_bind_address is "127.0.0.1") we will use ssh tunnel.

--- a/ansible/roles/kubernetes/tasks/gen_certs.yml
+++ b/ansible/roles/kubernetes/tasks/gen_certs.yml
@@ -38,11 +38,19 @@
     HTTP_PROXY: "{{ http_proxy|default('') }}"
     HTTPS_PROXY: "{{ https_proxy|default('') }}"
 
+# FIXME This only generates a cert for one master...
+- name: Run create ssh key script on master
+  command:
+    "ssh-keygen -q -t rsa -N '' -C '{{ kube_cert_user }}@{{ ansible_hostname }}' -f '{{ kube_cert_dir }}/id_rsa'"
+  args:
+    creates: "{{ kube_cert_dir }}/id_rsa"
+  when: enable_kube_apiserver_ssh
+
 - name: Verify certificate permissions
   file:
     path={{ item }}
     group={{ kube_cert_group }}
-    owner=kube
+    owner={{ kube_cert_user }}
     mode=0440
   with_items:
     - "{{ kube_cert_dir }}/ca.crt"

--- a/ansible/roles/kubernetes/tasks/secrets.yml
+++ b/ansible/roles/kubernetes/tasks/secrets.yml
@@ -7,9 +7,9 @@
 
 - name: Create system kube user
   user:
-    name=kube
+    name={{ kube_cert_user }}
     comment="Kubernetes user"
-    shell=/sbin/nologin
+    shell=/usr/sbin/nologin
     state=present
     system=yes
     groups={{ kube_cert_group }}
@@ -30,6 +30,19 @@
 
 - include: gen_certs.yml
   when: inventory_hostname == groups['masters'][0]
+
+- name: Read back the SSH public key
+  slurp:
+    src: "{{ kube_cert_dir }}/id_rsa.pub"
+  register: ssh_pub_key
+  run_once: true
+  delegate_to: "{{ groups['masters'][0] }}"
+  when: enable_kube_apiserver_ssh
+
+- name: Register the SSH public key as a fact so it can be used later
+  set_fact:
+    kube_ssh_pub_key: "{{ ssh_pub_key.content }}"
+  when: enable_kube_apiserver_ssh
 
 - name: Read back the CA certificate
   slurp:
@@ -58,6 +71,13 @@
 
 - name: Place CA certificate and kube_cfg credentials everywhere
   copy: content="{{ kube_api_key }}" dest="{{ kube_cert_dir }}/kubecfg.key"
+
+- name: Place SSH public key everywhere
+  authorized_key:
+    user: "{{ kube_cert_user }}"
+    key: "{{ kube_ssh_pub_key|b64decode }}"
+    key_options: 'no-pty,no-user-rc,no-X11-forwarding,command="/bin/false"'
+  when: enable_kube_apiserver_ssh
 
 - name: Read back the kubecfg cert
   slurp:

--- a/ansible/roles/master/defaults/main.yml
+++ b/ansible/roles/master/defaults/main.yml
@@ -7,6 +7,15 @@ admission_controllers: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuo
 kube_apiserver_bind_address: "0.0.0.0"
 kube_apiserver_insecure_bind_address: "127.0.0.1"
 
+kube_scheduler_bind_address: "127.0.0.1"
+kube_scheduler_profiling: false
+
+kube_scheduler_bind_address: "127.0.0.1"
+kube_scheduler_profiling: false
+
+kube_controller_manager_bind_address: "127.0.0.1"
+kube_controller_manager_profiling: false
+
 services_enabled: true
 apiserver_modified: false
 controller_manager_modified: false

--- a/ansible/roles/master/templates/apiserver.j2
+++ b/ansible/roles/master/templates/apiserver.j2
@@ -22,5 +22,11 @@ KUBE_ETCD_SERVERS="--etcd-servers={% for node in groups['etcd'] %}http://{{ node
 # default admission control policies
 KUBE_ADMISSION_CONTROL="--admission-control={{ admission_controllers }}"
 
+{% set apiserver_ssh_options = [] -%}
+{% if enable_kube_apiserver_ssh -%}
+{{ apiserver_ssh_options.append('--ssh-keyfile=' + kube_cert_dir + '/id_rsa') -}}
+{{ apiserver_ssh_options.append('--ssh-user=' + kube_cert_user) -}}
+{% endif -%}
+
 # Add your own!
-KUBE_API_ARGS="{{ apiserver_extra_args | default('') }} --tls-cert-file={{ kube_cert_dir }}/server.crt --tls-private-key-file={{ kube_cert_dir }}/server.key --client-ca-file={{ kube_cert_dir }}/ca.crt --token-auth-file={{ kube_token_dir }}/known_tokens.csv --service-account-key-file={{ kube_cert_dir }}/server.crt --bind-address={{ kube_apiserver_bind_address }}"
+KUBE_API_ARGS="{{ apiserver_extra_args | default('') }} --tls-cert-file={{ kube_cert_dir }}/server.crt --tls-private-key-file={{ kube_cert_dir }}/server.key --client-ca-file={{ kube_cert_dir }}/ca.crt --token-auth-file={{ kube_token_dir }}/known_tokens.csv --service-account-key-file={{ kube_cert_dir }}/server.crt --bind-address={{ kube_apiserver_bind_address }} {{ apiserver_ssh_options|join(' ') }}"

--- a/ansible/roles/master/templates/controller-manager.j2
+++ b/ansible/roles/master/templates/controller-manager.j2
@@ -4,4 +4,4 @@
 # defaults from config and apiserver should be adequate
 
 # Add your own!
-KUBE_CONTROLLER_MANAGER_ARGS="--kubeconfig={{ kube_config_dir }}/controller-manager.kubeconfig --service-account-private-key-file={{ kube_cert_dir }}/server.key --root-ca-file={{ kube_cert_dir }}/ca.crt"
+KUBE_CONTROLLER_MANAGER_ARGS="--address={{ kube_controller_manager_bind_address }} --profiling={{ kube_controller_manager_profiling }} --kubeconfig={{ kube_config_dir }}/controller-manager.kubeconfig --service-account-private-key-file={{ kube_cert_dir }}/server.key --root-ca-file={{ kube_cert_dir }}/ca.crt"

--- a/ansible/roles/master/templates/kubelet.j2
+++ b/ansible/roles/master/templates/kubelet.j2
@@ -2,10 +2,16 @@
 # kubernetes kubelet (node) config
 
 # The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
-KUBELET_ADDRESS="--address=0.0.0.0"
+KUBELET_ADDRESS="--address={{ kubelet_bind_address }}"
 
 # The port for the info server to serve on
-# KUBELET_PORT="--port=10250"
+KUBELET_PORT="--port={{ kubelet_port }}"
+
+# The read-only port for the info server to serve on
+KUBELET_READONLY_PORT="--read-only-port={{ kubelet_read_only_port }}"
+
+# The cAdvisor port
+KUBELET_CADVISOR_PORT="--cadvisor-port={{ kubelet_cadvisor_port }}"
 
 # You may leave this blank to use the actual hostname
 KUBELET_HOSTNAME="--hostname-override={{ inventory_hostname }}"

--- a/ansible/roles/master/templates/scheduler.j2
+++ b/ansible/roles/master/templates/scheduler.j2
@@ -4,4 +4,4 @@
 # default config should be adequate
 
 # Add your own!
-KUBE_SCHEDULER_ARGS="--kubeconfig={{ kube_config_dir }}/scheduler.kubeconfig"
+KUBE_SCHEDULER_ARGS="--address={{ kube_scheduler_bind_address }} --profiling={{ kube_scheduler_profiling }} --kubeconfig={{ kube_config_dir }}/scheduler.kubeconfig"

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -1,6 +1,5 @@
 kubelet_working_dir: /var/lib/kubelet
 localBuildOutput: ../../../_output/local/go/bin
-open_cadvisor_port: false
 
 services_enabled: true
 kubelet_modified: false

--- a/ansible/roles/node/tasks/firewalld.yml
+++ b/ansible/roles/node/tasks/firewalld.yml
@@ -1,21 +1,23 @@
 ---
 - name: Open firewalld port for the kubelet
-  firewalld: port=10250/tcp permanent=false state=enabled
+  firewalld: port={{ kubelet_port }}/tcp permanent=false state=enabled
   ignore_errors: yes
+  when: open_kubelet_port
 
 - name: Save firewalld port for the kubelet
-  firewalld: port=10250/tcp permanent=true state=enabled
+  firewalld: port={{ kubelet_port }}/tcp permanent=true state=enabled
   ignore_errors: yes
+  when: open_kubelet_port
 
 - name: Open firewalld port for the cadvisor
-  firewalld: port=4194/tcp permanent=false state=enabled
+  firewalld: port={{ kubelet_cadvisor_port }}/tcp permanent=false state=enabled
   ignore_errors: yes
-  when: open_cadvisor_port
+  when: open_cadvisor_port and kubelet_cadvisor_port > 0
 
 - name: Save firewalld port for the cadvisor
-  firewalld: port=4194/tcp permanent=true state=enabled
+  firewalld: port={{ kubelet_cadvisor_port }}/tcp permanent=true state=enabled
   ignore_errors: yes
-  when: open_cadvisor_port
+  when: open_cadvisor_port and kubelet_cadvisor_port > 0
 
 # this is needed if the kube-proxy is running in userspace mode
 - name: Open redirected service traffic

--- a/ansible/roles/node/tasks/iptables.yml
+++ b/ansible/roles/node/tasks/iptables.yml
@@ -8,8 +8,12 @@
   service: name=iptables enabled=yes state=started
 
 - name: Open kubelet port with iptables
-  command: /sbin/iptables -I INPUT 1 -p tcp --dport 10250 -j ACCEPT -m comment --comment "kubelet"
-  when: "'kubelet' not in iptablesrules.stdout"
+  command: /sbin/iptables -I INPUT 1 -p tcp --dport {{ kubelet_port }} -j ACCEPT -m comment --comment "kubelet"
+  when: "'kubelet' not in iptablesrules.stdout and open_kubelet_port"
+
+- name: Close kubelet port with iptables
+  command: /sbin/iptables -I INPUT 1 -p tcp --dport {{ kubelet_port }} -j DROP -m comment --comment "kubelet-drop"
+  when: "'kubelet-drop' in iptablesrules.stdout and not open_kubelet_port"
 
 # this is needed if the kube-proxy is running in userspace mode
 - name: Allow redirected service traffic

--- a/ansible/roles/node/templates/kubelet-default.j2
+++ b/ansible/roles/node/templates/kubelet-default.j2
@@ -8,4 +8,6 @@ KUBELET_OPTS="$KUBE_LOGTOSTDERR \
               $KUBELET_PORT \
               $KUBELET_HOSTNAME \
               $KUBE_ALLOW_PRIV \
+              $KUBELET_READONLY_PORT \
+              $KUBELET_CADVISOR_PORT \
               $KUBELET_ARGS"

--- a/ansible/roles/node/templates/kubelet.j2
+++ b/ansible/roles/node/templates/kubelet.j2
@@ -2,10 +2,16 @@
 # kubernetes kubelet (node) config
 
 # The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
-KUBELET_ADDRESS="--address=0.0.0.0"
+KUBELET_ADDRESS="--address={{ kubelet_bind_address }}"
 
 # The port for the info server to serve on
-# KUBELET_PORT="--port=10250"
+KUBELET_PORT="--port={{ kubelet_port }}"
+
+# The read-only port for the info server to serve on
+KUBELET_READONLY_PORT="--read-only-port={{ kubelet_read_only_port }}"
+
+# The cAdvisor port
+KUBELET_CADVISOR_PORT="--cadvisor-port={{ kubelet_cadvisor_port }}"
 
 # You may leave this blank to use the actual hostname
 KUBELET_HOSTNAME="--hostname-override={{ inventory_hostname }}"

--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -1,10 +1,14 @@
+ansible/roles/master/templates/kubelet.j2:KUBELET_PORT="--port={{ kubelet_port }}"
+ansible/roles/node/tasks/firewalld.yml:  firewalld: port={{ kubelet_port }}/tcp permanent=false state=enabled
+ansible/roles/node/tasks/firewalld.yml:  firewalld: port={{ kubelet_port }}/tcp permanent=true state=enabled
+ansible/roles/node/tasks/iptables.yml:  command: /sbin/iptables -I INPUT 1 -p tcp --dport {{ kubelet_port }} -j ACCEPT -m comment --comment "kubelet"
+ansible/roles/node/tasks/iptables.yml:  command: /sbin/iptables -I INPUT 1 -p tcp --dport {{ kubelet_port }} -j DROP -m comment --comment "kubelet-drop"
+ansible/roles/node/templates/kubelet.j2:KUBELET_PORT="--port={{ kubelet_port }}"
 ingress/controllers/nginx/configuration.md:**custom-http-errors:** Enables which HTTP codes should be passed for processing with the [error_page directive](http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page)
 ingress/controllers/nginx/configuration.md:Setting at least one code this also enables [proxy_intercept_errors](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors) (required to process error_page)
 ingress/controllers/nginx/nginx.tmpl:        require("error_page")
 ingress/controllers/nginx/nginx.tmpl:    error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
 ingress/controllers/nginx/nginx/config/config.go:	// enables which HTTP codes should be passed for processing with the error_page directive
-kubelet-to-gcm/monitor/kubelet/translate.go:				"container_name": containerName,
-kubelet-to-gcm/monitor/kubelet/translate.go:		"container_name": "",
 mungegithub/mungers/submit-queue.go:		sq.e2e = &fake_e2e.FakeE2ETester{
 mungegithub/mungers/submit-queue.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"
 mungegithub/mungers/submit-queue_test.go:	e2e := sq.e2e.(*fake_e2e.FakeE2ETester)


### PR DESCRIPTION
Inspired by https://github.com/kubernetes/kubernetes/issues/11816
By default the following locations are available through the internet:
- http://host:10251/configz
- http://host:10251/debug/pprof/heap
- http://host:10252/configz
- http://host:10252/debug/pprof/heap
- http://host:10255/metrics
- http://host:4194
- https://host:10250
- http://host:10255

Let's reduce probability to access them.

Forcing kubelet to listen the localhost interface results in inaccessible `kubectl exec` and `kubectl logs`. I'm trying to resolve this issue within https://github.com/kubernetes/kubernetes/pull/35693

Anyway it is recommended to set the following custom variables:
- `private_interface: "eth0"`
- `kubelet_bind_address: "{{ hostvars[inventory_hostname]['ansible_'+private_interface]['ipv4']['address'] }}"`
- `has_iptables: true`

And then `kubectl exec` and `kubectl logs` will work flawlessly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1940)

<!-- Reviewable:end -->
