### PR TITLE
Add assign and unassign functionality

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -223,6 +223,7 @@ type analytics struct {
 	SetStatus            analytic
 	GetPR                analytic
 	AssignPR             analytic
+	UnassignPR           analytic
 	ClosePR              analytic
 	OpenPR               analytic
 	GetContents          analytic
@@ -1496,6 +1497,22 @@ func (obj *MungeObject) GetPR() (*github.PullRequest, error) {
 	}
 	obj.pr = pr
 	return pr, nil
+}
+
+// UnassignPR removes the passed-in assignees from the github PR's assignees list
+func (obj *MungeObject) UnassignPR(assignees ...string) error {
+	config := obj.config
+	prNum := *obj.Issue.Number
+	config.analytics.UnassignPR.Call(config, nil)
+	glog.Infof("Unassigning %v from PR# %d  to %v", assignees, prNum)
+	if config.DryRun {
+		return nil
+	}
+	if _, _, err := config.client.Issues.RemoveAssignees(config.Org, config.Project, prNum, assignees); err != nil {
+		glog.Errorf("Error unassigning %v from PR# %d  to %v", assignees, prNum)
+		return err
+	}
+	return nil
 }
 
 // AssignPR will assign `prNum` to the `owner` where the `owner` is asignee's github login

--- a/mungegithub/mungers/assign-unassign-handler.go
+++ b/mungegithub/mungers/assign-unassign-handler.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"bytes"
+	"fmt"
+
+	"k8s.io/contrib/mungegithub/features"
+	"k8s.io/contrib/mungegithub/github"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/golang/glog"
+	githubapi "github.com/google/go-github/github"
+	"github.com/spf13/cobra"
+	c "k8s.io/contrib/mungegithub/mungers/matchers/comment"
+)
+
+const (
+	assignCommand   = "assign"
+	unassignCommand = "unassign"
+	invalidReviewer = "ASSIGN_NOTIFIER"
+)
+
+// AssignUnassignHandler will
+// - will assign a github user to a PR if they comment "/assign"
+// - will unassign a github user to a PR if they comment "/unassign"
+type AssignUnassignHandler struct {
+	features *features.Features
+}
+
+func init() {
+	dh := &AssignUnassignHandler{}
+	RegisterMungerOrDie(dh)
+}
+
+// Name is the name usable in --pr-mungers
+func (AssignUnassignHandler) Name() string { return "assign-unassign-handler" }
+
+// RequiredFeatures is a slice of 'features' that must be provided
+func (AssignUnassignHandler) RequiredFeatures() []string { return []string{} }
+
+// Initialize will initialize the munger
+func (h *AssignUnassignHandler) Initialize(config *github.Config, features *features.Features) error {
+	h.features = features
+	return nil
+}
+
+// EachLoop is called at the start of every munge loop
+func (AssignUnassignHandler) EachLoop() error { return nil }
+
+// AddFlags will add any request flags to the cobra `cmd`
+func (h AssignUnassignHandler) AddFlags(cmd *cobra.Command, config *github.Config) {
+}
+
+// Munge is the workhorse the will actually make updates to the PR
+func (h AssignUnassignHandler) Munge(obj *github.MungeObject) {
+	if !obj.IsPR() {
+		return
+	}
+
+	comments, err := obj.ListComments()
+	if err != nil {
+		glog.Errorf("unexpected error getting comments: %v", err)
+		return
+	}
+
+	fileList, err := obj.ListFiles()
+	if err != nil {
+		glog.Errorf("Could not list the files for PR %v: %v", obj.Issue.Number, err)
+		return
+	}
+
+	//get ALL (not just leaf) the people that could potentially own the file based on the blunderbuss.go implementation
+	potentialOwners, _ := getPotentialOwners(*obj.Issue.User.Login, h.features, fileList, false)
+
+	toAssign, toUnassign := h.getAssigneesAndUnassignees(obj, comments, fileList, potentialOwners)
+	for _, username := range toAssign.List() {
+		obj.AssignPR(username)
+	}
+	obj.UnassignPR(toUnassign.List()...)
+}
+
+// getAssigneesAndUnassignees checks to see when someone comments "/assign" or "/unassign"
+// returns two sets.String
+// 1. github handles to be assigned
+// 2. github handles to be unassigned
+// Note* Could possibly assign directly in the function call, but easier to test if function returns toAssign, toUnassign
+func (h *AssignUnassignHandler) getAssigneesAndUnassignees(obj *github.MungeObject, comments []*githubapi.IssueComment, fileList []*githubapi.CommitFile, potentialOwners weightMap) (toAssign, toUnassign sets.String) {
+	toAssign = sets.String{}
+	toUnassign = sets.String{}
+
+	assignComments := c.FilterComments(comments, c.CommandName(assignCommand))
+	unassignComments := c.FilterComments(comments, c.CommandName(unassignCommand))
+	invalidUsers := sets.String{}
+
+	//collect all the people that should be assigned
+	for _, cmt := range assignComments {
+		if isValidReviewer(potentialOwners, cmt.User) {
+			obj.DeleteComment(cmt)
+			toAssign.Insert(*cmt.User.Login)
+		} else {
+			// build the set of people who asked to be assigned but aren't in reviewers
+			// use the @ as a prefix so github notifies invalid users
+			invalidUsers.Insert("@" + *cmt.User.Login)
+		}
+
+	}
+
+	// collect all the people that should be unassigned
+	for _, cmt := range unassignComments {
+		if isAssignee(obj.Issue.Assignees, cmt.User) {
+			obj.DeleteComment(cmt)
+			toUnassign.Insert(*cmt.User.Login)
+		}
+	}
+
+	// Create a notification if someone tried to self assign, but could not because they weren't in the owners files
+	if invalidUsers.Len() != 0 {
+		previousNotifications := c.FilterComments(comments, c.MungerNotificationName(invalidReviewer))
+		if assignComments.Empty() || (!previousNotifications.Empty() && previousNotifications.GetLast().CreatedAt.After(*assignComments.GetLast().CreatedAt)) {
+			// if there were no assign comments, no need to notify
+			// if the last notification happened after the last assign comment, no need to notify again
+			return toAssign, toUnassign
+		}
+		if !previousNotifications.Empty() {
+			for _, c := range previousNotifications {
+				obj.DeleteComment(c)
+			}
+		}
+		context := bytes.NewBufferString("The following people cannot be assigned because they are not in the OWNERS files\n")
+		for user := range invalidUsers {
+			context.WriteString(fmt.Sprintf("- %s\n", user))
+		}
+		context.WriteString("\n")
+		c.Notification{Name: invalidReviewer, Arguments: "", Context: context.String()}.Post(obj)
+
+	}
+	return toAssign, toUnassign
+}
+
+func isValidReviewer(potentialOwners weightMap, commenter *githubapi.User) bool {
+	if commenter == nil || commenter.Login == nil {
+		return false
+	}
+	if _, ok := potentialOwners[*commenter.Login]; ok {
+		return true
+	}
+	return false
+}
+
+func isAssignee(assignees []*githubapi.User, someUser *githubapi.User) bool {
+	for _, assignee := range assignees {
+		if assignee.Login == nil || someUser.Login == nil {
+			continue
+		}
+		if *assignee.Login == *someUser.Login && *someUser.ID == *assignee.ID {
+			return true
+		}
+	}
+	return false
+}

--- a/mungegithub/mungers/assign-unassign-handler_test.go
+++ b/mungegithub/mungers/assign-unassign-handler_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mungers
+
+import (
+	"runtime"
+	"testing"
+
+	"k8s.io/contrib/mungegithub/github"
+	github_test "k8s.io/contrib/mungegithub/github/testing"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	goGithub "github.com/google/go-github/github"
+)
+
+var (
+	testUsername = "test-user"
+	testUser     = goGithub.User{ID: intPtr(-1), Name: &testUsername}
+)
+
+func TestAssignComment(t *testing.T) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	tests := []struct {
+		testName          string
+		comments          []*goGithub.IssueComment
+		existingAssignees []*goGithub.User
+		newAssignees      sets.String
+		removedAssignees  sets.String
+	}{
+		{
+			testName: "Assign cmd should add to existing assignees",
+			comments: []*goGithub.IssueComment{
+				github_test.IssueComment(1, assignCommand, "user 1", 0),
+			},
+			existingAssignees: []*goGithub.User{},
+			newAssignees:      sets.NewString("user 1"),
+			removedAssignees:  sets.NewString(),
+		},
+		{
+			testName: "Assign cmd should not modify existing assignees",
+			comments: []*goGithub.IssueComment{
+				github_test.IssueComment(1, assignCommand, "user 1", 0),
+			},
+			existingAssignees: []*goGithub.User{{Login: testUser.Name}},
+			newAssignees:      sets.NewString("user 1"),
+			removedAssignees:  sets.NewString(),
+		},
+		{
+			testName: "Unassign should remove existing assignee",
+			comments: []*goGithub.IssueComment{
+				github_test.IssueComment(1, unassignCommand, *testUser.Name, 0),
+			},
+			existingAssignees: []*goGithub.User{{Login: testUser.Name}},
+			newAssignees:      sets.NewString(""),
+			removedAssignees:  sets.NewString(*testUser.Name),
+		},
+		{
+			testName: "Reassign by someone else should leave assignees in tact",
+			comments: []*goGithub.IssueComment{
+				github_test.IssueComment(2, unassignCommand, "NotAUser", 1),
+			},
+			existingAssignees: []*goGithub.User{{Login: testUser.Name}},
+			newAssignees:      sets.NewString(),
+			removedAssignees:  sets.NewString(),
+		},
+	}
+
+	for testNum, test := range tests {
+		pr := github.MungeObject{}
+		pr.Issue = &goGithub.Issue{}
+		pr.Issue.Assignees = test.existingAssignees
+		ah := AssignUnassignHandler{}
+		assignees, unassignees := ah.getAssigneesAndUnassignees(&pr, test.comments, []*goGithub.CommitFile{}, weightMap{"user 1": 1})
+		if assignees.Difference(test.newAssignees).Len() != 0 {
+			t.Errorf("For test %v, the expected new assignees did not match the returned new assignees %v %v", testNum, test.newAssignees, assignees)
+		}
+		if unassignees.Difference(test.removedAssignees).Len() != 0 {
+			t.Errorf("Existing Assignees %v", *pr.Issue.Assignees[0])
+			t.Errorf("For test %v, the expected removed assignees %v actual removed assignees %v", testNum, test.removedAssignees, unassignees)
+		}
+	}
+}

--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -86,9 +86,11 @@ func printChance(owners weightMap, total int64) {
 	}
 }
 
-func (b *BlunderbussMunger) potentialOwners(issue *githubapi.Issue, files []*githubapi.CommitFile, leafOnly bool) (weightMap, int64) {
+func getPotentialOwners(author string, feats *features.Features, files []*githubapi.CommitFile, leafOnly bool) (weightMap, int64) {
 	potentialOwners := weightMap{}
 	weightSum := int64(0)
+	aliases := feats.Aliases
+
 	for _, file := range files {
 		if file == nil {
 			continue
@@ -103,20 +105,20 @@ func (b *BlunderbussMunger) potentialOwners(issue *githubapi.Issue, files []*git
 		fileWeight = int64(math.Log10(float64(fileWeight))) + 1
 		fileOwners := sets.String{}
 		if leafOnly {
-			fileOwners = b.features.Repos.LeafAssignees(*file.Filename)
+			fileOwners = feats.Repos.LeafAssignees(*file.Filename)
 		} else {
-			fileOwners = b.features.Repos.Assignees(*file.Filename)
+			fileOwners = feats.Repos.Assignees(*file.Filename)
 		}
 		if fileOwners.Len() == 0 {
 			glog.Warningf("Couldn't find an owner for: %s", *file.Filename)
 		}
 
-		if b.features.Aliases != nil && b.features.Aliases.IsEnabled {
-			fileOwners = b.features.Aliases.Expand(fileOwners)
+		if aliases != nil && aliases.IsEnabled {
+			fileOwners = aliases.Expand(fileOwners)
 		}
 
 		for _, owner := range fileOwners.List() {
-			if owner == *issue.User.Login {
+			if owner == author {
 				continue
 			}
 			potentialOwners[owner] = potentialOwners[owner] + fileWeight
@@ -143,9 +145,9 @@ func (b *BlunderbussMunger) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	potentialOwners, weightSum := b.potentialOwners(issue, files, true)
+	potentialOwners, weightSum := getPotentialOwners(*obj.Issue.User.Login, b.features, files, true)
 	if len(potentialOwners) == 0 {
-		potentialOwners, weightSum = b.potentialOwners(issue, files, false)
+		potentialOwners, weightSum = getPotentialOwners(*obj.Issue.User.Login, b.features, files, false)
 		if len(potentialOwners) == 0 {
 			glog.Errorf("No OWNERS found for PR %d", *issue.Number)
 			return


### PR DESCRIPTION
Fixes #1927 

Allow people to add self-assign PRs or decline PRs that have been assigned to them.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1945)

<!-- Reviewable:end -->
