### PR TITLE
Remove service should remove the deployments

### DIFF
--- a/netperf-tester/netperf_tester.go
+++ b/netperf-tester/netperf_tester.go
@@ -156,7 +156,7 @@ func removeServices() {
 }
 
 func removeService(serviceName string) {
-	args := []string{"delete", "rc/" + serviceName}
+	args := []string{"delete", "deployments/" + serviceName}
 	err := runCommandInShell(kubectl, args)
 	if err != nil {
 		logger.Printf("Error running command: %v", err)


### PR DESCRIPTION
I was trying to use this package with any newer Kubernetes version. But it always fails to cleanup the services cause it tries to remove the replica controllers.  It should remove the deployments instead when using the current version.

I wanted to add some other improvements but I want to start with something smaller :).

ping @mikedanese

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1952)

<!-- Reviewable:end -->
