### PR TITLE
Cluster-autoscaler: more explicit logging on scale down.

### DIFF
--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -117,6 +117,7 @@ func run(_ <-chan struct{}) {
 	lastScaleDownFailedTrial := time.Now()
 	unneededNodes := make(map[string]time.Time)
 	podLocationHints := make(map[string]string)
+	nodeUtilizationMap := make(map[string]float64)
 	usageTracker := simulator.NewUsageTracker()
 
 	recorder := createEventRecorder(kubeClient)
@@ -273,7 +274,7 @@ func run(_ <-chan struct{}) {
 					glog.V(4).Infof("Calculating unneded nodes")
 
 					usageTracker.CleanUp(time.Now().Add(-(*scaleDownUnneededTime)))
-					unneededNodes, podLocationHints = FindUnneededNodes(
+					unneededNodes, podLocationHints, nodeUtilizationMap = FindUnneededNodes(
 						nodes,
 						unneededNodes,
 						*scaleDownUtilizationThreshold,
@@ -298,6 +299,7 @@ func run(_ <-chan struct{}) {
 
 						result, err := ScaleDown(
 							nodes,
+							nodeUtilizationMap,
 							unneededNodes,
 							*scaleDownUnneededTime,
 							allScheduled,

--- a/cluster-autoscaler/scale_down_test.go
+++ b/cluster-autoscaler/scale_down_test.go
@@ -55,7 +55,7 @@ func TestFindUnneededNodes(t *testing.T) {
 	n3 := BuildTestNode("n3", 1000, 10)
 	n4 := BuildTestNode("n4", 10000, 10)
 
-	result, hints := FindUnneededNodes([]*kube_api.Node{n1, n2, n3, n4}, map[string]time.Time{}, 0.35,
+	result, hints, utilization := FindUnneededNodes([]*kube_api.Node{n1, n2, n3, n4}, map[string]time.Time{}, 0.35,
 		[]*kube_api.Pod{p1, p2, p3, p4}, simulator.NewTestPredicateChecker(), make(map[string]string),
 		simulator.NewUsageTracker(), time.Now())
 
@@ -63,9 +63,10 @@ func TestFindUnneededNodes(t *testing.T) {
 	addTime, found := result["n2"]
 	assert.True(t, found)
 	assert.Contains(t, hints, p2.Namespace+"/"+p2.Name)
+	assert.Equal(t, 4, len(utilization))
 
 	result["n1"] = time.Now()
-	result2, hints := FindUnneededNodes([]*kube_api.Node{n1, n2, n3, n4}, result, 0.35,
+	result2, hints, utilization := FindUnneededNodes([]*kube_api.Node{n1, n2, n3, n4}, result, 0.35,
 		[]*kube_api.Pod{p1, p2, p3, p4}, simulator.NewTestPredicateChecker(), hints,
 		simulator.NewUsageTracker(), time.Now())
 
@@ -73,4 +74,5 @@ func TestFindUnneededNodes(t *testing.T) {
 	addTime2, found := result2["n2"]
 	assert.True(t, found)
 	assert.Equal(t, addTime, addTime2)
+	assert.Equal(t, 4, len(utilization))
 }

--- a/cluster-autoscaler/scale_up.go
+++ b/cluster-autoscaler/scale_up.go
@@ -132,7 +132,7 @@ func ScaleUp(unschedulablePods []*kube_api.Pod, nodes []*kube_api.Node, cloudPro
 			}
 		}
 
-		glog.V(1).Infof("Setting %s size to %d", bestOption.nodeGroup.Id(), newSize)
+		glog.V(0).Infof("Scale-up: setting group %s size to %d", bestOption.nodeGroup.Id(), newSize)
 
 		if err := bestOption.nodeGroup.IncreaseSize(newSize - currentSize); err != nil {
 			return false, fmt.Errorf("failed to increase node group size: %v", err)


### PR DESCRIPTION
* Return pods to be rescheduled from simulations. First step towards graceful node deletion.
* Print node utilization and pods to be rescheduled on node scale down. 
* Consistent messages on scale down and scale up.

cc: @fgrzadkowski @piosz

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1954)
<!-- Reviewable:end -->
