### PR TITLE
ansible: Don't upgrade key cluster components on every playbook run

### DIFF
--- a/ansible/roles/docker/tasks/apt-docker-install.yml
+++ b/ansible/roles/docker/tasks/apt-docker-install.yml
@@ -14,4 +14,4 @@
   action: "{{ ansible_pkg_mgr }}"
   args:
     name: docker-engine
-    state: latest
+    state: present

--- a/ansible/roles/docker/tasks/debian-install.yml
+++ b/ansible/roles/docker/tasks/debian-install.yml
@@ -7,4 +7,4 @@
   action: "{{ ansible_pkg_mgr }}"
   args:
     name: docker.io
-    state: latest
+    state: present

--- a/ansible/roles/docker/tasks/generic-install.yml
+++ b/ansible/roles/docker/tasks/generic-install.yml
@@ -3,5 +3,5 @@
   action: "{{ ansible_pkg_mgr }}"
   args:
     name: "{{ docker_package_name }}"
-    state: latest
+    state: present
   when: not is_atomic

--- a/ansible/roles/etcd/tasks/install.yml
+++ b/ansible/roles/etcd/tasks/install.yml
@@ -54,8 +54,8 @@
 - name: Install etcd via package manager
   action: "{{ ansible_pkg_mgr }}"
   args:
-        name: etcd
-        state: latest
+    name: etcd
+    state: present
   when: etcd_source_type == "package-manager"
 
 - name: Set the etcd_modified fact to true

--- a/ansible/roles/flannel/tasks/client.yml
+++ b/ansible/roles/flannel/tasks/client.yml
@@ -9,8 +9,8 @@
 - name: Install Flannel with package manager
   action: "{{ ansible_pkg_mgr }}"
   args:
-        name: flannel
-        state: latest
+    name: flannel
+    state: present
   when: not is_atomic and flannel_source_type != "github-release"
 
 - set_fact: 


### PR DESCRIPTION
Latest software is good, but it should be under control.

Otherwise docker/etcd/flannel will be updated simultaneously on all nodes.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1959)
<!-- Reviewable:end -->
