### PR TITLE
ansible: Enabled on-the-fly docker reconfiguration

### DIFF
--- a/ansible/roles/docker/files/daemon.json
+++ b/ansible/roles/docker/files/daemon.json
@@ -1,0 +1,3 @@
+{
+    "live-restore": true
+}

--- a/ansible/roles/docker/handlers/main.yml
+++ b/ansible/roles/docker/handlers/main.yml
@@ -2,6 +2,9 @@
 - name: reload systemd
   command: systemctl --system daemon-reload
 
+- name: reload docker
+  service: name=docker state=reloaded
+
 - name: restart docker
   command: /bin/true
   notify:

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -75,6 +75,12 @@
     - restart docker
   tags: configure
 
+- name: Write docker daemon.conf file
+  copy: src=daemon.json dest=/etc/docker/daemon.json
+  notify:
+    - reload docker
+  tags: configure
+
 - name: Enable Docker
   service: name=docker enabled=yes
   notify:


### PR DESCRIPTION
Since 1.12 docker supports [live-restore](https://docs.docker.com/engine/admin/live-restore/) option. Which can restart docker daemon without killing the containers unless you made storage driver reconfiguration or another significant configuration change.

[More info](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file) about docker daemon configuration file.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1964)
<!-- Reviewable:end -->
