### PR TITLE
add condition,fix an error in ubuntu14.04

### DIFF
--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: reload systemd
   command: systemctl --system daemon-reload
+  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 15)


### PR DESCRIPTION
[ansible] An error occurred while installing on the ubuntu14.04, increasing the judgment condition, modifying the error，and the error is as follows:
RUNNING HANDLER [common : reload systemd] **************************************
fatal: [10.114.51.55]: FAILED! => {"changed": false, "cmd": "systemctl --system daemon-reload", "failed": true, "msg": "[Errno 2] No such file or directory", "rc": 2}

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1970)
<!-- Reviewable:end -->
