### PR TITLE
Cluster Autoscaler Value for Node Not Needed Time (10 minutes) is Not Configurable

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -70,7 +70,7 @@ manifest-run pods or pods created by daemonsets).
 * There are no pods with local storage. Applications with local storage would lose their 
 data if a node is deleted, even if they are replicated.
 
-If a node is not needed for more than 10 min (configurable) then it can be deleted. Cluster Autoscaler
+If a node is not needed for more than 10 minutes then it can be deleted. Cluster Autoscaler
 deletes one node at a time to reduce the risk of creating new unschedulable pods. The next node 
 can be deleted when it is also not needed for more than 10 min. It may happen just after
 the previous node is fully deleted or after some longer time.


### PR DESCRIPTION
According to the docs page, "If a node is not needed for more than 10 min (configurable) then it can be deleted."
Where would I configure that 10 minute value. Since it will wait for 10 minutes per node it needs to delete, it could take a while to remove all the cruft if I have a lot of overage.

"I believe the value is not configurable." - David Oppenheimer from GCP.

If this value is configurable, please close this PR and document how to configure it. If it really isn't configurable, this is a missing feature.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1973)
<!-- Reviewable:end -->
