### PR TITLE
Fixed a couple of typos in cluster-autoscaler

### DIFF
--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -270,7 +270,7 @@ func run(_ <-chan struct{}) {
 						lastScaleUpTime, lastScaleDownFailedTrial, schedulablePodsPresent)
 
 					updateLastTime("findUnneeded")
-					glog.V(4).Infof("Calculating unneded nodes")
+					glog.V(4).Infof("Calculating unneeded nodes")
 
 					usageTracker.CleanUp(time.Now().Add(-(*scaleDownUnneededTime)))
 					unneededNodes, podLocationHints = FindUnneededNodes(

--- a/cluster-autoscaler/scale_down.go
+++ b/cluster-autoscaler/scale_down.go
@@ -74,7 +74,7 @@ func FindUnneededNodes(nodes []*kube_api.Node,
 		glog.V(4).Infof("Node %s - utilization %f", node.Name, utilization)
 
 		if utilization >= utilizationThreshold {
-			glog.V(4).Infof("Node %s is not suitable for removal - utilization to big (%f)", node.Name, utilization)
+			glog.V(4).Infof("Node %s is not suitable for removal - utilization too big (%f)", node.Name, utilization)
 			continue
 		}
 		currentlyUnneededNodes = append(currentlyUnneededNodes, node)


### PR DESCRIPTION
This pull request fixes a couple of typos/grammatical errors in the logging output of the cluster-autoscaler addon

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1981)
<!-- Reviewable:end -->
