### PR TITLE
Cluster-autoscaler: restrict one-time cluster scale up to 100

### DIFF
--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -74,6 +74,7 @@ var (
 		"How often scale down possiblity is check")
 	scanInterval  = flag.Duration("scan-interval", 10*time.Second, "How often cluster is reevaluated for scale up or down")
 	maxNodesTotal = flag.Int("max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
+	maxScaleUp    = flag.Int("max-scale-up", 100, "Maximum number of nodes that can be requested in a single scale-up")
 
 	cloudProviderFlag = flag.String("cloud-provider", "gce", "Cloud provider type. Allowed values: gce, aws")
 )
@@ -240,8 +241,15 @@ func run(_ <-chan struct{}) {
 				} else {
 					scaleUpStart := time.Now()
 					updateLastTime("scaleup")
-					scaledUp, err := ScaleUp(unschedulablePodsToHelp, nodes, cloudProvider, kubeClient, predicateChecker, recorder,
-						*maxNodesTotal)
+					scaledUp, err := ScaleUp(
+						unschedulablePodsToHelp,
+						nodes,
+						cloudProvider,
+						kubeClient,
+						predicateChecker,
+						recorder,
+						*maxNodesTotal,
+						*maxScaleUp)
 
 					updateDuration("scaleup", scaleUpStart)
 

--- a/cluster-autoscaler/scale_up.go
+++ b/cluster-autoscaler/scale_up.go
@@ -39,7 +39,7 @@ type ExpansionOption struct {
 // false if it didn't and error if an error occured. Assumes that all nodes in the cluster are
 // ready and in sync with instance groups.
 func ScaleUp(unschedulablePods []*kube_api.Pod, nodes []*kube_api.Node, cloudProvider cloudprovider.CloudProvider, kubeClient *kube_client.Client,
-	predicateChecker *simulator.PredicateChecker, recorder kube_record.EventRecorder, maxNodesTotal int) (bool, error) {
+	predicateChecker *simulator.PredicateChecker, recorder kube_record.EventRecorder, maxNodesTotal, maxScaleUp int) (bool, error) {
 
 	// From now on we only care about unschedulable pods that were marked after the newest
 	// node became available for the scheduler.
@@ -113,6 +113,11 @@ func ScaleUp(unschedulablePods []*kube_api.Pod, nodes []*kube_api.Node, cloudPro
 		glog.V(1).Info(bestOption.estimator.GetDebug())
 		glog.V(1).Info(report)
 		glog.V(1).Infof("Estimated %d nodes needed in %s", estimate, bestOption.nodeGroup.Id())
+
+		if estimate > maxScaleUp {
+			glog.V(1).Infof("Capping size to max scale up (%d)", maxScaleUp)
+			estimate = maxScaleUp
+		}
 
 		currentSize, err := bestOption.nodeGroup.TargetSize()
 		if err != nil {

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -61,6 +61,7 @@ label-file
 last-release-pr
 left-build-number
 max-pr-number
+max-scale-up
 max-sync-failures
 max-nodes-total
 min-pr-number


### PR DESCRIPTION
So that a small mistake doesn't result in requesting 700 nodes.

cc: @piosz @fgrzadkowski @jsz

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1989)
<!-- Reviewable:end -->
