### PR TITLE
Cluster-autoscaler: use binpacking estimation algorithm by default

### DIFF
--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -85,7 +85,7 @@ var (
 
 	// AvailableEstimators is a list of available estimators.
 	AvailableEstimators = []string{BasicEstimatorName, BinpackingEstimatorName}
-	estimatorFlag       = flag.String("estimator", BasicEstimatorName,
+	estimatorFlag       = flag.String("estimator", BinpackingEstimatorName,
 		"Type of resource estimator to be used in scale up. Available values: ["+strings.Join(AvailableEstimators, ",")+"]")
 )
 


### PR DESCRIPTION
Should actually be better than basic for most of the users:
* If only 1 type of pod is pending CA is guaranteed to provide the best estimate.
* Only 1 iteration is needed to grow cluster to correct state.
* It should not be much worse than multi-phase iterative algorithm for mixed pending pods.

cc: @fgrzadkowski @piosz @jszczepkowski

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/1999)
<!-- Reviewable:end -->
