### PR TITLE
Cluster-autoscaler: get rid of -alpha in version

### DIFF
--- a/cluster-autoscaler/version.go
+++ b/cluster-autoscaler/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package main
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "0.4.0-alpha1"
+const ClusterAutoscalerVersion = "0.4.0"


### PR DESCRIPTION
Small follow-up fix after premature lgtm in #1993

cc: @fgrzadkowski

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2000)
<!-- Reviewable:end -->
