### PR TITLE
Gate merge on exclusively approved label

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -783,7 +783,7 @@ func (sq *SubmitQueue) getMetaData() []byte {
 const (
 	unknown                 = "unknown failure"
 	noCLA                   = "PR is missing CLA label; needs one of " + claYesLabel + ", " + cncfClaYesLabel + " or " + claHumanLabel
-	noLGTM                  = "PR does not have " + lgtmLabel + " label or " + approvedLabel + " label (needs at least one)."
+	noLgtmOrApproved        = "PR is missing the " + lgtmLabel + " label or the " + approvedLabel + " label."
 	lgtmEarly               = "The PR was changed after the LGTM label was added."
 	unmergeable             = "PR is unable to be automatically merged. Needs rebase."
 	undeterminedMergability = "Unable to determine is PR is mergeable. Will try again later."
@@ -880,9 +880,9 @@ func (sq *SubmitQueue) validForMerge(obj *github.MungeObject) bool {
 		}
 	}
 
-	// Clearly
-	if !(obj.HasLabel(lgtmLabel) || obj.HasLabel(approvedLabel)) {
-		sq.SetMergeStatus(obj, noLGTM)
+	// Clearly, if obj is missing either label, do not merge
+	if !obj.HasLabel(lgtmLabel) || !obj.HasLabel(approvedLabel) {
+		sq.SetMergeStatus(obj, noLgtmOrApproved)
 		return false
 	}
 

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -86,9 +86,12 @@ func BareIssue() *github.Issue {
 func LGTMIssue() *github.Issue {
 	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel}, true)
 }
+func LGTMApprovedIssue() *github.Issue {
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel}, true)
+}
 
 func DoNotMergeIssue() *github.Issue {
-	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, doNotMergeLabel}, true)
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, doNotMergeLabel}, true)
 }
 
 func DoNotMergeMilestoneIssue() *github.Issue {
@@ -109,7 +112,7 @@ func NoLGTMIssue() *github.Issue {
 }
 
 func NoRetestIssue() *github.Issue {
-	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, retestNotRequiredLabel}, true)
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, retestNotRequiredLabel}, true)
 }
 
 func OldLGTMEvents() []*github.IssueEvent {
@@ -482,7 +485,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Test1",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
 			ciStatus:        SuccessStatus(),
@@ -499,7 +502,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:               "Test1+emergencyStop",
 			pr:                 ValidPR(),
-			issue:              LGTMIssue(),
+			issue:              LGTMApprovedIssue(),
 			events:             NewLGTMEvents(),
 			commits:            Commits(), // Modified at time.Unix(7), 8, and 9
 			ciStatus:           SuccessStatus(),
@@ -518,7 +521,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Test1+prevsuccess",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
 			ciStatus:        SuccessStatus(),
@@ -540,7 +543,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Test2",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(),
 			ciStatus:        SuccessStatus(),
@@ -573,7 +576,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:   "Test5",
 			pr:     UnMergeablePR(),
-			issue:  LGTMIssue(),
+			issue:  LGTMApprovedIssue(),
 			reason: unmergeable,
 			state:  "pending",
 			// To avoid false errors in logs
@@ -585,7 +588,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:   "Test6",
 			pr:     UndeterminedMergeablePR(),
-			issue:  LGTMIssue(),
+			issue:  LGTMApprovedIssue(),
 			reason: undeterminedMergability,
 			state:  "pending",
 			// To avoid false errors in logs
@@ -609,7 +612,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:   "Test8",
 			pr:     ValidPR(),
-			issue:  LGTMIssue(),
+			issue:  LGTMApprovedIssue(),
 			reason: ciFailure,
 			state:  "pending",
 			// To avoid false errors in logs
@@ -623,7 +626,7 @@ func TestSubmitQueue(t *testing.T) {
 			pr:       ValidPR(),
 			issue:    NoLGTMIssue(),
 			ciStatus: SuccessStatus(),
-			reason:   noLGTM,
+			reason:   noLgtmOrApproved,
 			state:    "pending",
 			// To avoid false errors in logs
 			lastBuildNumber: LastBuildNumber(),
@@ -634,7 +637,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:     "Test11",
 			pr:       ValidPR(),
-			issue:    LGTMIssue(),
+			issue:    LGTMApprovedIssue(),
 			ciStatus: SuccessStatus(),
 			reason:   unknown,
 			state:    "failure",
@@ -647,7 +650,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:     "Test12",
 			pr:       ValidPR(),
-			issue:    LGTMIssue(),
+			issue:    LGTMApprovedIssue(),
 			ciStatus: SuccessStatus(),
 			events:   OldLGTMEvents(),
 			commits:  Commits(), // Modified at time.Unix(7), 8, and 9
@@ -658,7 +661,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Test13",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			ciStatus:        SuccessStatus(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
@@ -672,7 +675,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Test14",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			ciStatus:        SuccessStatus(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(),
@@ -686,7 +689,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Test15",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			ciStatus:        SuccessStatus(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
@@ -703,7 +706,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Test16",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			ciStatus:        SuccessStatus(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
@@ -716,7 +719,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Fail because E2E pass, but unit test fail",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
 			ciStatus:        SuccessStatus(),
@@ -731,7 +734,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Fail because E2E fail, but unit test pass",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
 			ciStatus:        SuccessStatus(),
@@ -777,7 +780,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Fail because retest status fail",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
 			ciStatus:        RetestFailStatus(),
@@ -792,7 +795,7 @@ func TestSubmitQueue(t *testing.T) {
 		{
 			name:            "Fail because noretest status fail",
 			pr:              ValidPR(),
-			issue:           LGTMIssue(),
+			issue:           LGTMApprovedIssue(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
 			ciStatus:        NoRetestFailStatus(),


### PR DESCRIPTION
Will merge after

- [ ] "/approved" command works
- [ ] blunderbuss/bot read reviewers and approvers
- [ ] OWNERS files up to date
- [ ] approved label after ALL files have been approved by valid approver
- [ ] notification explaining why approved label has not yet been merged

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2002)
<!-- Reviewable:end -->
