### PR TITLE
set live-restore only for docker => 1.12

### DIFF
--- a/ansible/roles/docker/files/detect-docker-version.sh
+++ b/ansible/roles/docker/files/detect-docker-version.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ver=$(docker version -f '{{ .Server.Version }}' 2>/dev/null)
+if [ $? -ne 0 ]; then
+	ver=$(docker version -f '{{ .Client.Version }}' 2>/dev/null)
+fi
+
+echo ${ver}

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -75,8 +75,21 @@
     - restart docker
   tags: configure
 
+# The client version is enough for this deployment as the installer will always sync
+# client and server version.
+# As the server is not yet running the command exits with non-zero value.
+# The carriage return char is related to https://github.com/docker/docker/issues/8513
+- name: Detect docker version
+  script: detect-docker-version.sh
+  register: docker_version
+
+- name: Detected version
+  debug:
+    msg: "{{ docker_version.stdout | regex_replace('(\\r\\n)','') }}"
+
 - name: Write docker daemon.conf file
   copy: src=daemon.json dest=/etc/docker/daemon.json
+  when: "{{ docker_version.stdout | regex_replace('(\\r\\n)','') | version_compare('1.12', '>=') }}"
   notify:
     - reload docker
   tags: configure


### PR DESCRIPTION
Fix the cluster deployment for older version of docker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2042)
<!-- Reviewable:end -->
