### PR TITLE
submit-queue: Add kubernetes-e2e-kops-aws to the blocking list

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -16,9 +16,94 @@ data:
 
   # submit-queue options.
   submit-queue.required-contexts: "Jenkins GCE Node e2e"
-  submit-queue.nonblocking-jenkins-jobs: kubernetes-cross-build,kubernetes-e2e-gke-staging,kubernetes-e2e-gke-staging-parallel,kubernetes-e2e-gce-serial,kubernetes-e2e-gke-serial,kubernetes-e2e-gke-test,kubernetes-e2e-gce-examples,kubernetes-e2e-gce-federation,kubernetes-e2e-gce-scalability,kubernetes-soak-continuous-e2e-gce,kubernetes-soak-continuous-e2e-gke,kubernetes-kubemark-5-gce,kubernetes-kubemark-gce-scale,kubelet-serial-gce-e2e-ci,kubernetes-e2e-gci-gce-alpha-features-release-1.4,kubernetes-e2e-gci-gce-flannel,kubernetes-e2e-gci-gce-es-logging,kubernetes-e2e-gci-gce-examples,kubernetes-e2e-gci-gce-federation,kubernetes-e2e-gci-gce-release-1.4,kubernetes-e2e-gci-gce-scalability,kubernetes-e2e-gci-gce-serial,kubernetes-e2e-gci-gce-serial-release-1.4,kubernetes-e2e-gci-gce-slow-release-1.4,kubernetes-e2e-gci-gce-ingress,kubernetes-e2e-gci-gce-ingress-release-1.4,kubernetes-e2e-gci-gce-petset,kubernetes-e2e-gci-gce-reboot-release-1.4,kubernetes-e2e-gci-gce-scalability-release-1.4,kubernetes-e2e-gci-gke-autoscaling,kubernetes-e2e-gci-gke-serial,kubernetes-e2e-gci-gke-ingress,kubernetes-e2e-gci-gke-ingress-release-1.4,kubernetes-e2e-gci-gke-multizone,kubernetes-e2e-gci-gke-pre-release,kubernetes-e2e-gci-gke-prod,kubernetes-e2e-gci-gke-prod-parallel,kubernetes-e2e-gci-gke-prod-smoke,kubernetes-e2e-gci-gke-reboot,kubernetes-e2e-gci-gke-reboot-release-1.4,kubernetes-e2e-gci-gke-release-1.4,kubernetes-e2e-gci-gke-serial-release-1.4,kubernetes-e2e-gci-gke-slow-release-1.4,kubernetes-e2e-gci-gke-staging,kubernetes-e2e-gci-gke-staging-parallel,kubernetes-e2e-gci-gke-subnet,kubernetes-e2e-gci-gke-test,kubernetes-e2e-gci-gke-updown,continuous-e2e-docker-validation-gci,kubernetes-e2e-gci-gce-autoscaling,kubernetes-e2e-gci-gce-autoscaling-migs,kubernetes-e2e-gci-gce-etcd3,kubernetes-e2e-gci-gce-kubenet,kubernetes-e2e-gci-gce-proto,kubernetes-e2e-gci-gce-reboot,kubernetes-e2e-gci-gke-alpha-features,kubernetes-garbagecollector-gci-feature,kubernetes-soak-continuous-e2e-gci-gce-1.4,kubernetes-soak-continuous-e2e-gke-gci,kubernetes-soak-weekly-deploy-gci-gce-1.4,kubernetes-soak-weekly-deploy-gke-gci,kubernetes-e2e-gce-multizone,kubernetes-e2e-gce-enormous-cluster,kuberentes-e2e-gce-enormous-deploy,kuberentes-e2e-gce-enormous-teardown,kubernetes-e2e-gke-large-cluster,kubernetes-e2e-aws,kubernetes-e2e-kops-aws-updown
-  submit-queue.jenkins-jobs: kubelet-gce-e2e-ci,kubernetes-build,ci-kubernetes-test-go,ci-kubernetes-verify-master,kubernetes-e2e-gci-gce,kubernetes-e2e-gci-gce-slow,kubernetes-e2e-gci-gke,kubernetes-e2e-gci-gke-slow,kubernetes-kubemark-500-gce,ci-kubernetes-e2e-gce-etcd3
-  submit-queue.presubmit-jobs: kubernetes-pull-build-test-e2e-gce,kubernetes-pull-build-test-e2e-gke,kubernetes-pull-build-test-federation-e2e-gce,node-pull-build-e2e-test,kubernetes-pull-build-test-gci-e2e-gce,kubernetes-pull-build-test-gci-e2e-gke,kubernetes-pull-build-test-gci-kubemark-e2e-gce
+  submit-queue.nonblocking-jenkins-jobs: "\
+    kubernetes-cross-build,\
+    kubernetes-e2e-gke-staging,\
+    kubernetes-e2e-gke-staging-parallel,\
+    kubernetes-e2e-gce-serial,\
+    kubernetes-e2e-gke-serial,\
+    kubernetes-e2e-gke-test,\
+    kubernetes-e2e-gce-examples,\
+    kubernetes-e2e-gce-federation,\
+    kubernetes-e2e-gce-scalability,\
+    kubernetes-soak-continuous-e2e-gce,\
+    kubernetes-soak-continuous-e2e-gke,\
+    kubernetes-kubemark-5-gce,\
+    kubernetes-kubemark-gce-scale,\
+    kubelet-serial-gce-e2e-ci,\
+    kubernetes-e2e-gci-gce-alpha-features-release-1.4,\
+    kubernetes-e2e-gci-gce-flannel,\
+    kubernetes-e2e-gci-gce-es-logging,\
+    kubernetes-e2e-gci-gce-examples,\
+    kubernetes-e2e-gci-gce-federation,\
+    kubernetes-e2e-gci-gce-release-1.4,\
+    kubernetes-e2e-gci-gce-scalability,\
+    kubernetes-e2e-gci-gce-serial,\
+    kubernetes-e2e-gci-gce-serial-release-1.4,\
+    kubernetes-e2e-gci-gce-slow-release-1.4,\
+    kubernetes-e2e-gci-gce-ingress,\
+    kubernetes-e2e-gci-gce-ingress-release-1.4,\
+    kubernetes-e2e-gci-gce-petset,\
+    kubernetes-e2e-gci-gce-reboot-release-1.4,\
+    kubernetes-e2e-gci-gce-scalability-release-1.4,\
+    kubernetes-e2e-gci-gke-autoscaling,\
+    kubernetes-e2e-gci-gke-serial,\
+    kubernetes-e2e-gci-gke-ingress,\
+    kubernetes-e2e-gci-gke-ingress-release-1.4,\
+    kubernetes-e2e-gci-gke-multizone,\
+    kubernetes-e2e-gci-gke-pre-release,\
+    kubernetes-e2e-gci-gke-prod,\
+    kubernetes-e2e-gci-gke-prod-parallel,\
+    kubernetes-e2e-gci-gke-prod-smoke,\
+    kubernetes-e2e-gci-gke-reboot,\
+    kubernetes-e2e-gci-gke-reboot-release-1.4,\
+    kubernetes-e2e-gci-gke-release-1.4,\
+    kubernetes-e2e-gci-gke-serial-release-1.4,\
+    kubernetes-e2e-gci-gke-slow-release-1.4,\
+    kubernetes-e2e-gci-gke-staging,\
+    kubernetes-e2e-gci-gke-staging-parallel,\
+    kubernetes-e2e-gci-gke-subnet,\
+    kubernetes-e2e-gci-gke-test,\
+    kubernetes-e2e-gci-gke-updown,\
+    continuous-e2e-docker-validation-gci,\
+    kubernetes-e2e-gci-gce-autoscaling,\
+    kubernetes-e2e-gci-gce-autoscaling-migs,\
+    kubernetes-e2e-gci-gce-etcd3,\
+    kubernetes-e2e-gci-gce-kubenet,\
+    kubernetes-e2e-gci-gce-proto,\
+    kubernetes-e2e-gci-gce-reboot,\
+    kubernetes-e2e-gci-gke-alpha-features,\
+    kubernetes-garbagecollector-gci-feature,\
+    kubernetes-soak-continuous-e2e-gci-gce-1.4,\
+    kubernetes-soak-continuous-e2e-gke-gci,\
+    kubernetes-soak-weekly-deploy-gci-gce-1.4,\
+    kubernetes-soak-weekly-deploy-gke-gci,\
+    kubernetes-e2e-gce-multizone,\
+    kubernetes-e2e-gce-enormous-cluster,\
+    kuberentes-e2e-gce-enormous-deploy,\
+    kuberentes-e2e-gce-enormous-teardown,\
+    kubernetes-e2e-gke-large-cluster,\
+    kubernetes-e2e-aws,\
+    kubernetes-e2e-kops-aws-updown"
+  submit-queue.jenkins-jobs: "\
+    kubelet-gce-e2e-ci,\
+    kubernetes-build,\
+    ci-kubernetes-test-go,\
+    ci-kubernetes-verify-master,\
+    kubernetes-e2e-gci-gce,\
+    kubernetes-e2e-gci-gce-slow,\
+    kubernetes-e2e-gci-gke,\
+    kubernetes-e2e-gci-gke-slow,\
+    kubernetes-kubemark-500-gce,\
+    ci-kubernetes-e2e-gce-etcd3"
+  submit-queue.presubmit-jobs: "\
+    kubernetes-pull-build-test-e2e-gce,\
+    kubernetes-pull-build-test-e2e-gke,\
+    kubernetes-pull-build-test-federation-e2e-gce,\
+    node-pull-build-e2e-test,\
+    kubernetes-pull-build-test-gci-e2e-gce,\
+    kubernetes-pull-build-test-gci-e2e-gke,\
+    kubernetes-pull-build-test-gci-kubemark-e2e-gce"
   submit-queue.weak-stable-jobs: "\"\""
   submit-queue.do-not-merge-milestones: "next-candidate,v1.6,"
   submit-queue.admin-port: "9999"

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -95,7 +95,8 @@ data:
     kubernetes-e2e-gci-gke,\
     kubernetes-e2e-gci-gke-slow,\
     kubernetes-kubemark-500-gce,\
-    ci-kubernetes-e2e-gce-etcd3"
+    ci-kubernetes-e2e-gce-etcd3,\
+    kubernetes-e2e-kops-aws"
   submit-queue.presubmit-jobs: "\
     kubernetes-pull-build-test-e2e-gce,\
     kubernetes-pull-build-test-e2e-gke,\


### PR DESCRIPTION
Now that https://github.com/kubernetes/test-infra/pull/1015 is in, this can be blocking. (Keeping the `kops-updown` variant in the non-blocking list for deployment health tracking.)

Along the way: Reformat the configmap (commits are split up for easy review).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2045)
<!-- Reviewable:end -->
