### PR TITLE
Update kubernetes job list to use ci- prefixes

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -17,37 +17,43 @@ data:
   # submit-queue options.
   submit-queue.required-contexts: "Jenkins GCE Node e2e"
   submit-queue.nonblocking-jenkins-jobs: "\
-    kubernetes-cross-build,\
-    kubernetes-e2e-gke-staging,\
-    kubernetes-e2e-gke-staging-parallel,\
-    kubernetes-e2e-gce-serial,\
-    kubernetes-e2e-gke-serial,\
-    kubernetes-e2e-gke-test,\
-    kubernetes-e2e-gce-examples,\
-    kubernetes-e2e-gce-federation,\
-    kubernetes-e2e-gce-scalability,\
-    kubernetes-soak-continuous-e2e-gce,\
-    kubernetes-soak-continuous-e2e-gke,\
-    kubernetes-kubemark-5-gce,\
-    kubernetes-kubemark-gce-scale,\
+    ci-kubernetes-e2e-aws,\
+    ci-kubernetes-e2e-gce-examples,\
+    ci-kubernetes-e2e-gce-federation,\
+    ci-kubernetes-e2e-gce-multizone,\
+    ci-kubernetes-e2e-gce-scalability,\
+    ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4,\
+    ci-kubernetes-e2e-gci-gce-autoscaling,\
+    ci-kubernetes-e2e-gci-gce-autoscaling-migs,\
+    ci-kubernetes-e2e-gci-gce-es-logging,\
+    ci-kubernetes-e2e-gci-gce-etcd3,\
+    ci-kubernetes-e2e-gci-gce-examples,\
+    ci-kubernetes-e2e-gci-gce-federation,\
+    ci-kubernetes-e2e-gci-gce-flannel,\
+    ci-kubernetes-e2e-gci-gce-ingress,\
+    ci-kubernetes-e2e-gci-gce-ingress-release-1.4,\
+    ci-kubernetes-e2e-gci-gce-kubenet,\
+    ci-kubernetes-e2e-gci-gce-petset,\
+    ci-kubernetes-e2e-gci-gce-proto,\
+    ci-kubernetes-e2e-gci-gce-reboot,\
+    ci-kubernetes-e2e-gci-gce-reboot-release-1.4,\
+    ci-kubernetes-e2e-gci-gce-release-1.4,\
+    ci-kubernetes-e2e-gci-gce-scalability,\
+    ci-kubernetes-e2e-gci-gce-scalability-release-1.4,\
+    ci-kubernetes-e2e-gci-gce-serial,\
+    ci-kubernetes-e2e-gci-gce-serial-release-1.4,\
+    ci-kubernetes-e2e-gci-gce-slow-release-1.4,\
+    ci-kubernetes-kubemark-5-gce,\
+    ci-kubernetes-kubemark-gce-scale,\
+    continuous-e2e-docker-validation-gci,\
     kubelet-serial-gce-e2e-ci,\
-    kubernetes-e2e-gci-gce-alpha-features-release-1.4,\
-    kubernetes-e2e-gci-gce-flannel,\
-    kubernetes-e2e-gci-gce-es-logging,\
-    kubernetes-e2e-gci-gce-examples,\
-    kubernetes-e2e-gci-gce-federation,\
-    kubernetes-e2e-gci-gce-release-1.4,\
-    kubernetes-e2e-gci-gce-scalability,\
-    kubernetes-e2e-gci-gce-serial,\
-    kubernetes-e2e-gci-gce-serial-release-1.4,\
-    kubernetes-e2e-gci-gce-slow-release-1.4,\
-    kubernetes-e2e-gci-gce-ingress,\
-    kubernetes-e2e-gci-gce-ingress-release-1.4,\
-    kubernetes-e2e-gci-gce-petset,\
-    kubernetes-e2e-gci-gce-reboot-release-1.4,\
-    kubernetes-e2e-gci-gce-scalability-release-1.4,\
+    kuberentes-e2e-gce-enormous-deploy,\
+    kuberentes-e2e-gce-enormous-teardown,\
+    kubernetes-cross-build,\
+    kubernetes-e2e-gce-enormous-cluster,\
+    kubernetes-e2e-gce-serial,\
+    kubernetes-e2e-gci-gke-alpha-features,\
     kubernetes-e2e-gci-gke-autoscaling,\
-    kubernetes-e2e-gci-gke-serial,\
     kubernetes-e2e-gci-gke-ingress,\
     kubernetes-e2e-gci-gke-ingress-release-1.4,\
     kubernetes-e2e-gci-gke-multizone,\
@@ -58,6 +64,7 @@ data:
     kubernetes-e2e-gci-gke-reboot,\
     kubernetes-e2e-gci-gke-reboot-release-1.4,\
     kubernetes-e2e-gci-gke-release-1.4,\
+    kubernetes-e2e-gci-gke-serial,\
     kubernetes-e2e-gci-gke-serial-release-1.4,\
     kubernetes-e2e-gci-gke-slow-release-1.4,\
     kubernetes-e2e-gci-gke-staging,\
@@ -65,37 +72,30 @@ data:
     kubernetes-e2e-gci-gke-subnet,\
     kubernetes-e2e-gci-gke-test,\
     kubernetes-e2e-gci-gke-updown,\
-    continuous-e2e-docker-validation-gci,\
-    kubernetes-e2e-gci-gce-autoscaling,\
-    kubernetes-e2e-gci-gce-autoscaling-migs,\
-    kubernetes-e2e-gci-gce-etcd3,\
-    kubernetes-e2e-gci-gce-kubenet,\
-    kubernetes-e2e-gci-gce-proto,\
-    kubernetes-e2e-gci-gce-reboot,\
-    kubernetes-e2e-gci-gke-alpha-features,\
+    kubernetes-e2e-gke-large-cluster,\
+    kubernetes-e2e-gke-serial,\
+    kubernetes-e2e-gke-staging,\
+    kubernetes-e2e-gke-staging-parallel,\
+    kubernetes-e2e-gke-test,\
     kubernetes-garbagecollector-gci-feature,\
+    kubernetes-soak-continuous-e2e-gce,\
     kubernetes-soak-continuous-e2e-gci-gce-1.4,\
+    kubernetes-soak-continuous-e2e-gke,\
     kubernetes-soak-continuous-e2e-gke-gci,\
     kubernetes-soak-weekly-deploy-gci-gce-1.4,\
     kubernetes-soak-weekly-deploy-gke-gci,\
-    kubernetes-e2e-gce-multizone,\
-    kubernetes-e2e-gce-enormous-cluster,\
-    kuberentes-e2e-gce-enormous-deploy,\
-    kuberentes-e2e-gce-enormous-teardown,\
-    kubernetes-e2e-gke-large-cluster,\
-    kubernetes-e2e-aws,\
     kubernetes-e2e-kops-aws-updown"
   submit-queue.jenkins-jobs: "\
-    kubelet-gce-e2e-ci,\
-    kubernetes-build,\
+    ci-kubernetes-e2e-gce-etcd3,\
+    ci-kubernetes-e2e-gci-gce,\
+    ci-kubernetes-e2e-gci-gce-slow,\
+    ci-kubernetes-kubemark-500-gce,\
     ci-kubernetes-test-go,\
     ci-kubernetes-verify-master,\
-    kubernetes-e2e-gci-gce,\
-    kubernetes-e2e-gci-gce-slow,\
+    kubelet-gce-e2e-ci,\
+    kubernetes-build,\
     kubernetes-e2e-gci-gke,\
     kubernetes-e2e-gci-gke-slow,\
-    kubernetes-kubemark-500-gce,\
-    ci-kubernetes-e2e-gce-etcd3,\
     kubernetes-e2e-kops-aws"
   submit-queue.presubmit-jobs: "\
     kubernetes-pull-build-test-e2e-gce,\


### PR DESCRIPTION
Add ci- prefix for jobs we migrated.
Migrate three additional critical jobs:
```
ci-kubernetes-e2e-gci-gce
ci-kubernetes-e2e-gci-gce-slow
ci-kubernetes-kubemark-500-gce
```

See https://github.com/kubernetes/test-infra/pull/1089

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2047)
<!-- Reviewable:end -->
