### PR TITLE
Bump kubernetes to 1.4.5, Bump libvirt fedora virtbox to 24-cloud-base

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of Kubernetes binaries
-kube_version: 1.2.4
+kube_version: 1.4.5
 
 # Set source of kubernetes binaries
 # Available: packageManager, localBuild, github-release, distribution-rpm

--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -81,7 +81,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     when :centosatomic
       config.vm.box = "centos/atomic-host"
     when :fedora
-      config.vm.box = "fedora/23-cloud-base"
+      config.vm.box = "fedora/24-cloud-base"
     when :fedoraatomic
       config.vm.box = "fedora/23-atomic-host"
     end


### PR DESCRIPTION
Fixes: #1953

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2049)
<!-- Reviewable:end -->
