### PR TITLE
quote bash arguments when passed to ansible playbook

### DIFF
--- a/ansible/scripts/init.sh
+++ b/ansible/scripts/init.sh
@@ -30,5 +30,5 @@ check_inventory() {
 ansible_playbook() {
 	inventory=$1
 	check_inventory ${inventory}
-	ansible-playbook -i $@
+	ansible-playbook -i "$@"
 }


### PR DESCRIPTION
If not, value of ``--extra-vars`` is not quoted and the ``ansible-playbook`` ends with en error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2050)
<!-- Reviewable:end -->
