### PR TITLE
mungegithub: Remove generated file from deployment

### DIFF
--- a/mungegithub/Dockerfile-submit-queue
+++ b/mungegithub/Dockerfile-submit-queue
@@ -23,7 +23,6 @@ CMD ["--dry-run", "--token-file=/token"]
 
 ADD path-label.txt /path-label.txt
 ADD block-path.yaml /block-path.yaml
-ADD generated-files.txt /generated-files.txt
 # User lists for submit-queue and 'needs-ok-to-merge'
 ADD committers.txt /committers.txt
 ADD whitelist.txt /whitelist.txt


### PR DESCRIPTION
Fixes a bug introduced by: https://github.com/kubernetes/contrib/pull/2024

The file has been removed but is still referenced in the Dockerfile. Let's remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2051)
<!-- Reviewable:end -->
