### PR TITLE
handle the case where release note not on same line as tag

### DIFF
--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -167,7 +167,7 @@ func determineReleaseNoteLabel(obj *github.MungeObject) string {
 // getReleaseNote returns the release note from a PR body
 // assumes that the PR body followed the PR template
 func getReleaseNote(body string) string {
-	noteMatcher := regexp.MustCompile("Release note.*```(.+)```")
+	noteMatcher := regexp.MustCompile(`Release note\*\*:\s*` + "```" + `(.+?)` + "```")
 	potentialMatch := noteMatcher.FindStringSubmatch(body)
 	if potentialMatch == nil {
 		return ""

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -244,17 +244,22 @@ func TestGetReleaseNote(t *testing.T) {
 		expectedReleaseNoteVariable string
 	}{
 		{
-			body:                        "**Release note**: <other unimportant information> ```NONE```",
+			body:                        "**Release note**:  ```NONE```",
 			expectedReleaseNote:         "NONE",
 			expectedReleaseNoteVariable: releaseNoteNone,
 		},
 		{
-			body:                        "**Release note**: <other unimportant information> ```This is a description of my feature```",
+			body:                        "**Release note**:\n\n ```NONE```",
+			expectedReleaseNote:         "NONE",
+			expectedReleaseNoteVariable: releaseNoteNone,
+		},
+		{
+			body:                        "**Release note**:\n\n  ```This is a description of my feature```",
 			expectedReleaseNote:         "This is a description of my feature",
 			expectedReleaseNoteVariable: releaseNote,
 		},
 		{
-			body:                        "**Release note**: <other unimportant information> ```This is my feature. There is some action required for my feature.```",
+			body:                        "**Release note**: ```This is my feature. There is some action required for my feature.```",
 			expectedReleaseNote:         "This is my feature. There is some action required for my feature.",
 			expectedReleaseNoteVariable: releaseNoteActionRequired,
 		},


### PR DESCRIPTION
The (?s) flag allows the wildcard operator to match newlines as well.

fixes #2054

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2056)
<!-- Reviewable:end -->
