### PR TITLE
Update SQ job list to include more bootstrap-migrated jobs

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -21,6 +21,7 @@ data:
     ci-kubernetes-e2e-gce-examples,\
     ci-kubernetes-e2e-gce-federation,\
     ci-kubernetes-e2e-gce-multizone,\
+    ci-kubernetes-e2e-gce-serial,\
     ci-kubernetes-e2e-gce-scalability,\
     ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4,\
     ci-kubernetes-e2e-gci-gce-autoscaling,\
@@ -43,14 +44,6 @@ data:
     ci-kubernetes-e2e-gci-gce-serial,\
     ci-kubernetes-e2e-gci-gce-serial-release-1.4,\
     ci-kubernetes-e2e-gci-gce-slow-release-1.4,\
-    ci-kubernetes-kubemark-5-gce,\
-    continuous-e2e-docker-validation-gci,\
-    kubelet-serial-gce-e2e-ci,\
-    kuberentes-e2e-gce-enormous-deploy,\
-    kuberentes-e2e-gce-enormous-teardown,\
-    kubernetes-cross-build,\
-    kubernetes-e2e-gce-enormous-cluster,\
-    kubernetes-e2e-gce-serial,\
     ci-kubernetes-e2e-gci-gke-alpha-features,\
     ci-kubernetes-e2e-gci-gke-autoscaling,\
     ci-kubernetes-e2e-gci-gke-ingress,\
@@ -76,25 +69,33 @@ data:
     ci-kubernetes-e2e-gke-staging,\
     ci-kubernetes-e2e-gke-staging-parallel,\
     ci-kubernetes-e2e-gke-test,\
+    ci-kubernetes-kubemark-5-gce,\
+    ci-kubernetes-node-kubelet-serial,\
+    ci-kubernetes-soak-gce-deploy,\
+    ci-kubernetes-soak-gce-test,\
+    ci-kubernetes-soak-gci-gce-deploy,\
+    ci-kubernetes-soak-gci-gce-test,\
+    ci-kubernetes-soak-gke-deploy,\
+    ci-kubernetes-soak-gke-gci-deploy,\
+    ci-kubernetes-soak-gke-gci-test,\
+    ci-kubernetes-soak-gke-test,\
+    kubernetes-cross-build,\
+    kubernetes-e2e-gce-enormous-cluster,\
+    kubernetes-e2e-gce-enormous-deploy,\
+    kubernetes-e2e-gce-enormous-teardown,\
     kubernetes-garbagecollector-gci-feature,\
-    kubernetes-soak-continuous-e2e-gce,\
-    kubernetes-soak-continuous-e2e-gci-gce-1.4,\
-    kubernetes-soak-continuous-e2e-gke,\
-    kubernetes-soak-continuous-e2e-gke-gci,\
-    kubernetes-soak-weekly-deploy-gci-gce-1.4,\
-    kubernetes-soak-weekly-deploy-gke-gci,\
     kubernetes-e2e-kops-aws-updown"
   submit-queue.jenkins-jobs: "\
+    ci-kubernetes-node-kubelet,\
     ci-kubernetes-e2e-gce-etcd3,\
     ci-kubernetes-e2e-gci-gce,\
     ci-kubernetes-e2e-gci-gce-slow,\
+    ci-kubernetes-e2e-gci-gke,\
+    ci-kubernetes-e2e-gci-gke-slow,\
     ci-kubernetes-kubemark-500-gce,\
     ci-kubernetes-test-go,\
     ci-kubernetes-verify-master,\
-    kubelet-gce-e2e-ci,\
     kubernetes-build,\
-    ci-kubernetes-e2e-gci-gke,\
-    ci-kubernetes-e2e-gci-gke-slow,\
     kubernetes-e2e-kops-aws"
   submit-queue.presubmit-jobs: "\
     kubernetes-pull-build-test-e2e-gce,\


### PR DESCRIPTION
continuous-e2e-docker-validation-gci is not the name of a valid job so dropping it.

ref kubernetes/test-infra#1021 https://github.com/kubernetes/test-infra/issues/1022 https://github.com/kubernetes/test-infra/issues/1108

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2063)
<!-- Reviewable:end -->
