### PR TITLE
Add health checking from NGINX to individual endpoints.

### DIFF
--- a/images/nginx-slim/build.sh
+++ b/images/nginx-slim/build.sh
@@ -28,6 +28,7 @@ export LUA_RESTY_HTTP_VERSION=0.07
 export LUA_UPSTREAM_VERSION=0.06
 export MORE_HEADERS_VERSION=0.32
 export NGINX_DIGEST_AUTH=7955af9c77598c697ac292811914ce1e2b3b824c
+export UPSTREAM_CHECK_VERSION=d6341aeeb86911d4798fbceab35015c63178e66f
 export NGINX_SUBSTITUTIONS=bc58cb11844bc42735bbaef7085ea86ace46d05b
 
 export BUILD_PATH=/tmp/build
@@ -105,6 +106,8 @@ get_src 9b1d0075df787338bb607f14925886249bda60b6b3156713923d5d59e99a708b \
 get_src 8eabbcd5950fdcc718bb0ef9165206c2ed60f67cd9da553d7bc3e6fe4e338461 \
         "https://github.com/yaoweibin/ngx_http_substitutions_filter_module/archive/$NGINX_SUBSTITUTIONS.tar.gz"
 
+get_src 35983b0b6ae812bee9fb4de37db6bf68cea68f7e82a9fc274ab29d574e321e98 \
+        "https://github.com/yaoweibin/nginx_upstream_check_module/archive/$UPSTREAM_CHECK_VERSION.tar.gz"
 
 #https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/
 curl -sSL -o nginx__dynamic_tls_records.patch https://raw.githubusercontent.com/cloudflare/sslconfig/master/patches/nginx__1.11.5_dynamic_tls_records.patch
@@ -114,6 +117,9 @@ cd "$BUILD_PATH/nginx-$NGINX_VERSION"
 
 echo "Applying tls nginx patches..."
 patch -p1 < $BUILD_PATH/nginx__dynamic_tls_records.patch
+
+echo "Applying nginx_upstream_check patch.."
+patch -p0 < $BUILD_PATH/nginx_upstream_check_module-$UPSTREAM_CHECK_VERSION/check_$NGINX_VERSION+.patch
 
 ./configure \
   --prefix=/usr/share/nginx \
@@ -158,6 +164,7 @@ patch -p1 < $BUILD_PATH/nginx__dynamic_tls_records.patch
   --add-module="$BUILD_PATH/nginx-goodies-nginx-sticky-module-ng-$STICKY_SESSIONS_VERSION" \
   --add-module="$BUILD_PATH/nginx-http-auth-digest-$NGINX_DIGEST_AUTH" \
   --add-module="$BUILD_PATH/ngx_http_substitutions_filter_module-$NGINX_SUBSTITUTIONS" \
+  --add-module="$BUILD_PATH/nginx_upstream_check_module-$UPSTREAM_CHECK_VERSION" \
   --add-module="$BUILD_PATH/lua-upstream-nginx-module-$LUA_UPSTREAM_VERSION" || exit 1 \
   && make || exit 1 \
   && make install || exit 1

--- a/ingress/controllers/nginx/Dockerfile
+++ b/ingress/controllers/nginx/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/nginx-slim:0.9
+FROM gcr.io/google_containers/nginx-slim:0.10
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   diffutils \

--- a/ingress/controllers/nginx/configuration.md
+++ b/ingress/controllers/nginx/configuration.md
@@ -301,6 +301,7 @@ The default mime type list to compress is: `application/atom+xml application/jav
 
 **use-http2:** Enables or disables the [HTTP/2](http://nginx.org/en/docs/http/ngx_http_v2_module.html) support in secure connections 
 
+**use-upstream-health-checks:** Enables or disables the use of upstream health checks provided by the [nginx_upstream_check_module](https://github.com/yaoweibin/nginx_upstream_check_module) module. If enabled, NGINX will do health checking based on the `readinessProbe` in the pod definition.
 
 **gzip-types:** Sets the MIME types in addition to "text/html" to compress. The special value "*"" matches any MIME type.
 Responses with the "text/html" type are always compressed if `use-gzip` is enabled

--- a/ingress/controllers/nginx/nginx.tmpl
+++ b/ingress/controllers/nginx/nginx.tmpl
@@ -177,6 +177,12 @@ http {
         {{ else -}}
         least_conn;
         {{- end }}
+
+        {{ if $upstream.UpstreamCheck -}}
+        check interval={{ $upstream.UpstreamCheck.IntervalMillis }} rise={{ $upstream.UpstreamCheck.Rise }} fall={{ $upstream.UpstreamCheck.Fall }} timeout={{ $upstream.UpstreamCheck.TimeoutMillis }} port={{ $upstream.UpstreamCheck.Port }} type=http;
+        check_http_send "{{ $upstream.UpstreamCheck.HttpSend }}";
+        {{- end }}
+
         {{ range $server := $upstream.Backends }}server {{ $server.Address }}:{{ $server.Port }} max_fails={{ $server.MaxFails }} fail_timeout={{ $server.FailTimeout }};
         {{ end }}
     }
@@ -331,6 +337,13 @@ http {
             access_log off;
             return 200;
         }
+
+            
+        {{- if $cfg.useUpstreamHealthChecks }}
+        location /upstream_status {
+            check_status html;
+        }
+        {{ end -}}
        
         location /nginx_status {
             {{ if $cfg.enableVtsStatus -}}

--- a/ingress/controllers/nginx/nginx/config/config.go
+++ b/ingress/controllers/nginx/nginx/config/config.go
@@ -242,6 +242,11 @@ type Configuration struct {
 	// Default: 0, ie use platform liveness probe
 	UpstreamFailTimeout int `structs:"upstream-fail-timeout,omitempty"`
 
+	// Enables or disables the use of upstream health checks provided by the
+	// nginx_upstream_check_module module. If enabled, NGINX will do health checking
+	// based on the readinessProbe in the pod definition.
+	UseUpstreamHealthChecks bool `structs:"use-upstream-health-checks"`
+
 	// Enables or disables the use of the PROXY protocol to receive client connection
 	// (real IP address) information passed through proxy servers and load balancers
 	// such as HAproxy and Amazon Elastic Load Balancer (ELB).

--- a/ingress/controllers/nginx/nginx/ingress/nginx.go
+++ b/ingress/controllers/nginx/nginx/ingress/nginx.go
@@ -32,11 +32,22 @@ type Configuration struct {
 	UDPUpstreams []*Location
 }
 
+// UpstreamCheck is used to configure nginx_upstream_check_module
+type UpstreamCheck struct {
+	HttpSend       string
+	Port           int
+	IntervalMillis int32
+	Fall           int32
+	Rise           int32
+	TimeoutMillis  int32
+}
+
 // Upstream describes an NGINX upstream
 type Upstream struct {
-	Name     string
-	Backends []UpstreamServer
-	Secure   bool
+	Name          string
+	Backends      []UpstreamServer
+	Secure        bool
+	UpstreamCheck *UpstreamCheck
 }
 
 // UpstreamByNameServers sorts upstreams by name


### PR DESCRIPTION
This change adds the [nginx_upstream_check_module](https://github.com/yaoweibin/nginx_upstream_check_module) into NGINX and configures upstreams with health checks based on the `readinessProbe` in the service's pod(s).

It is configurable with ConfigMap (default disabled):

**use-upstream-health-checks**

If the upstream health checking is enabled there is also an additional endpoint at `/upstream_status`.

This is related to #953.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2072)
<!-- Reviewable:end -->