### PR TITLE
Code freeze everything except 1.4

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -106,7 +106,7 @@ data:
     kubernetes-pull-build-test-gci-e2e-gke,\
     kubernetes-pull-build-test-gci-kubemark-e2e-gce"
   submit-queue.weak-stable-jobs: "\"\""
-  submit-queue.do-not-merge-milestones: "next-candidate,v1.6,"
+  submit-queue.do-not-merge-milestones: "next-candidate,v1.6,v1.5,"
   submit-queue.admin-port: "9999"
   submit-queue.chart-url: http://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg
   submit-queue.history-url: http://storage.googleapis.com/kubernetes-test-history/static/index.html


### PR DESCRIPTION
This PR is intended to institute a "complete merge freeze" as outlined in https://groups.google.com/forum/#!topic/kubernetes-dev/n-vqlX-HHSM

It blocks the Kubernetes submit queue from merging PRs with `v1.5`, `v1.6`, `next-candidate`, and no milestones. `v1.4` will still be allowed to enable merges to the 1.4 branch.

Ok to review. But PR shouldn't be merged until morning of Wed Nov 23 (marking `do-not-merge` until then).

CC @dchen1107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2075)
<!-- Reviewable:end -->
