### PR TITLE
Use http instead of https for the batch URL.

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -110,7 +110,7 @@ data:
   submit-queue.admin-port: "9999"
   submit-queue.chart-url: http://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg
   submit-queue.history-url: http://storage.googleapis.com/kubernetes-test-history/static/index.html
-  submit-queue.batch-url: https://prow.k8s.io/data.js
+  submit-queue.batch-url: http://prow.k8s.io/data.js
 
   # options used by the GCS feature.
   gcs.gcs-bucket: kubernetes-jenkins


### PR DESCRIPTION
Error reading batch jobs from Prow URL https://prow.k8s.io/data.js: Get
https://prow.k8s.io/data.js: x509: certificate signed by unknown
authority

We'll dig into why this is happening tomorrow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2092)
<!-- Reviewable:end -->
