### PR TITLE
Mark kops-aws as nonblocking job

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -84,6 +84,7 @@ data:
     ci-kubernetes-e2e-gce-enormous-deploy,\
     ci-kubernetes-e2e-gce-enormous-teardown,\
     kubernetes-garbagecollector-gci-feature,\
+    kubernetes-e2e-kops-aws,\
     kubernetes-e2e-kops-aws-updown"
   submit-queue.jenkins-jobs: "\
     ci-kubernetes-build,\
@@ -95,8 +96,7 @@ data:
     ci-kubernetes-kubemark-500-gce,\
     ci-kubernetes-node-kubelet,\
     ci-kubernetes-test-go,\
-    ci-kubernetes-verify-master,\
-    kubernetes-e2e-kops-aws"
+    ci-kubernetes-verify-master"
   submit-queue.presubmit-jobs: "\
     kubernetes-pull-build-test-e2e-gce,\
     kubernetes-pull-build-test-e2e-gke,\


### PR DESCRIPTION
Build has been broken for 8+ hours now. Let's mark it
as non-blocking to get 1.5 queue unblocked temporarily.

https://k8s-testgrid.appspot.com/google-aws#kops-aws

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/contrib/2093)
<!-- Reviewable:end -->
