### PR TITLE
Add ci-kubernetes-e2e-kops-aws back to blocking jobs

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -14,11 +14,15 @@ data:
   # test-options feature options.
   test-options.required-retest-contexts: "\"Jenkins GCE e2e\",\"Jenkins unit/integration\",\"Jenkins verification\",\"Jenkins GCE Node e2e\",\"Jenkins Kubemark GCE e2e\",\"Jenkins GCE etcd3 e2e\""
 
-  # submit-queue options.
+  # submit-queue options. Keep job lists sorted!
   submit-queue.required-contexts: "Jenkins GCE Node e2e"
   submit-queue.nonblocking-jenkins-jobs: "\
     ci-kubernetes-cross-build,\
     ci-kubernetes-e2e-aws,\
+    ci-kubernetes-e2e-garbage-gci,\
+    ci-kubernetes-e2e-gce-enormous-cluster,\
+    ci-kubernetes-e2e-gce-enormous-deploy,\
+    ci-kubernetes-e2e-gce-enormous-teardown,\
     ci-kubernetes-e2e-gce-examples,\
     ci-kubernetes-e2e-gce-federation,\
     ci-kubernetes-e2e-gce-multizone,\
@@ -80,22 +84,18 @@ data:
     ci-kubernetes-soak-gke-deploy,\
     ci-kubernetes-soak-gke-gci-deploy,\
     ci-kubernetes-soak-gke-gci-test,\
-    ci-kubernetes-soak-gke-test,\
-    ci-kubernetes-e2e-gce-enormous-cluster,\
-    ci-kubernetes-e2e-gce-enormous-deploy,\
-    ci-kubernetes-e2e-gce-enormous-teardown,\
-    ci-kubernetes-e2e-garbage-gci"
+    ci-kubernetes-soak-gke-test"
   submit-queue.jenkins-jobs: "\
-    ci-kubernetes-build,\
-    ci-kubernetes-e2e-gce-etcd3,\
-    ci-kubernetes-e2e-gci-gce,\
-    ci-kubernetes-e2e-gci-gce-slow,\
-    ci-kubernetes-e2e-gci-gke,\
-    ci-kubernetes-e2e-gci-gke-slow,\
-    ci-kubernetes-e2e-kops-aws,\
-    ci-kubernetes-kubemark-500-gce,\
-    ci-kubernetes-node-kubelet,\
-    ci-kubernetes-test-go,\
+    ci-kubernetes-build,
+    ci-kubernetes-e2e-gce-etcd3,
+    ci-kubernetes-e2e-gci-gce,
+    ci-kubernetes-e2e-gci-gce-slow,
+    ci-kubernetes-e2e-gci-gke,
+    ci-kubernetes-e2e-gci-gke-slow,
+    ci-kubernetes-e2e-kops-aws,
+    ci-kubernetes-kubemark-500-gce,
+    ci-kubernetes-node-kubelet,
+    ci-kubernetes-test-go,
     ci-kubernetes-verify-master"
   submit-queue.presubmit-jobs: "\
     kubernetes-pull-build-test-e2e-gce,\

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -70,6 +70,7 @@ data:
     ci-kubernetes-e2e-gke-staging,\
     ci-kubernetes-e2e-gke-staging-parallel,\
     ci-kubernetes-e2e-gke-test,\
+    ci-kubernetes-e2e-kops-aws-updown,\
     ci-kubernetes-kubemark-5-gce,\
     ci-kubernetes-node-kubelet-serial,\
     ci-kubernetes-soak-gce-deploy,\
@@ -83,9 +84,7 @@ data:
     ci-kubernetes-e2e-gce-enormous-cluster,\
     ci-kubernetes-e2e-gce-enormous-deploy,\
     ci-kubernetes-e2e-gce-enormous-teardown,\
-    ci-kubernetes-e2e-garbage-gci,\
-    ci-kubernetes-e2e-kops-aws,\
-    ci-kubernetes-e2e-kops-aws-updown"
+    ci-kubernetes-e2e-garbage-gci"
   submit-queue.jenkins-jobs: "\
     ci-kubernetes-build,\
     ci-kubernetes-e2e-gce-etcd3,\
@@ -93,6 +92,7 @@ data:
     ci-kubernetes-e2e-gci-gce-slow,\
     ci-kubernetes-e2e-gci-gke,\
     ci-kubernetes-e2e-gci-gke-slow,\
+    ci-kubernetes-e2e-kops-aws,\
     ci-kubernetes-kubemark-500-gce,\
     ci-kubernetes-node-kubelet,\
     ci-kubernetes-test-go,\


### PR DESCRIPTION
The job is stable again after kubernetes/kops#1011 & kubernetes/test-infra#1213, and per request, I also fixed logging in kubernetes/kubernetes#37646 before proposing this.

Along the way: Sort the submit queue job list (separate commit)

TBD: It'd be nice if `cmd.Flags().StringSliceVar` were lenient about a trailing comma, but it doesn't look like it is.