### PR TITLE
Fix bug in scale-demo loader port specification

### DIFF
--- a/scale-demo/vegeta/loader.go
+++ b/scale-demo/vegeta/loader.go
@@ -90,7 +90,7 @@ func main() {
 
 	host := serviceIP
 	if *port != 80 {
-		host = fmt.Sprintf("%s:%d", host, port)
+		host = fmt.Sprintf("%s:%d", host, *port)
 	}
 	var targets []vegeta.Target
 	for _, path := range strings.Split(*paths, ",") {


### PR DESCRIPTION
The port argument isn't being dereferenced