### PR TITLE
Fix check when following merge commits.

### DIFF
--- a/mungegithub/mungers/submit-queue-batch.go
+++ b/mungegithub/mungers/submit-queue-batch.go
@@ -218,8 +218,12 @@ func (b *Batch) matchesCommits(commits []*githubapi.RepositoryCommit) (int, erro
 		if !ok {
 			return 0, errors.New("ran out of commits (missing ref " + ref + ")")
 		}
-		if len(commit.Parents) == 2 && commit.Message != nil &&
-			strings.HasPrefix(*commit.Message, "Merge") {
+		message := ""
+		if commit.Commit != nil && commit.Commit.Message != nil {
+			// The actual commit message is buried a little oddly.
+			message = *commit.Commit.Message
+		}
+		if len(commit.Parents) == 2 && strings.HasPrefix(message, "Merge") {
 			// looks like a merge commit!
 
 			// first parent is the normal branch

--- a/mungegithub/mungers/submit-queue-batch_test.go
+++ b/mungegithub/mungers/submit-queue-batch_test.go
@@ -112,7 +112,10 @@ func TestBatchMatchesCommits(t *testing.T) {
 			refs := s[:i]
 			msg := s[i+1:]
 			split := strings.Split(refs, ":")
-			commit := githubapi.RepositoryCommit{SHA: &split[0], Message: &msg}
+			commit := githubapi.RepositoryCommit{
+				SHA:    &split[0],
+				Commit: &githubapi.Commit{Message: &msg},
+			}
 			for _, parent := range strings.Split(split[1], ",") {
 				p := string(parent) // thanks, Go!
 				commit.Parents = append(commit.Parents, githubapi.Commit{SHA: &p})


### PR DESCRIPTION
The message is actually stored in commit.Commit.Message.