### PR TITLE
Cluster Autoscaler: Support other scale down poilcies

### DIFF
--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -73,6 +73,8 @@ var (
 	scaleDownEnabled = flag.Bool("scale-down-enabled", true, "Should CA scale down the cluster")
 	scaleDownDelay   = flag.Duration("scale-down-delay", 10*time.Minute,
 		"Duration from the last scale up to the time when CA starts to check scale down options")
+	scaleDownPolicy = flag.String("scale-down-policy", "",
+		"Scaling policy determing which node to terminate. Options: oldest and least-utilized. If not specified, terminates first valid candidate.")
 	scaleDownUnneededTime = flag.Duration("scale-down-unneeded-time", 10*time.Minute,
 		"How long the node should be unneeded before it is eligible for scale down")
 	scaleDownUtilizationThreshold = flag.Float64("scale-down-utilization-threshold", 0.5,

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -53,7 +53,7 @@ type NodeToBeRemoved struct {
 // FindNodesToRemove finds nodes that can be removed. Returns also an information about good
 // rescheduling location for each of the pods.
 func FindNodesToRemove(candidates []*kube_api.Node, allNodes []*kube_api.Node, pods []*kube_api.Pod,
-	client *kube_client.Client, predicateChecker *PredicateChecker, maxCount int,
+	client *kube_client.Client, predicateChecker *PredicateChecker,
 	fastCheck bool, oldHints map[string]string, usageTracker *UsageTracker,
 	timestamp time.Time) (nodesToRemove []NodeToBeRemoved, podReschedulingHints map[string]string, finalError error) {
 
@@ -101,9 +101,6 @@ candidateloop:
 				PodsToReschedule: podsToRemove,
 			})
 			glog.V(2).Infof("%s: node %s may be removed", evaluationType, node.Name)
-			if len(result) >= maxCount {
-				break candidateloop
-			}
 		} else {
 			glog.V(2).Infof("%s: node %s is not suitable for removal %v", evaluationType, node.Name, err)
 		}

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -87,6 +87,7 @@ required-contexts
 right-build-number
 running-in-cluster
 scale-down-delay
+scale-down-policy
 scale-down-enabled
 scale-down-trial-interval
 scale-down-unneeded-time


### PR DESCRIPTION
Seems like cluster autoscaler terminates the first valid candidate which works for most cases. There are situations where we might want to terminate the oldest nodes (like gradually upgrading cluster to new kubernetes version) or the least utilized node (to reduce rescheduling overhead). 

I wrote some preliminary code to get some initial feedback. After approval I will attempt to add some unit/integration/e2e tests for the different scaling policies (possibly in another PR).