### PR TITLE
Provide multiple strategies for choosing which Node Group to increase

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -42,7 +42,9 @@ node groups and checks if any of the unschedulable pods would fit to a brand new
 While it may sound similar to what the real scheduler does it is currently quite simplified and 
 may require multiple iterations before all of the pods are eventually scheduled.
 If there are multiple node groups that, if increased, would help with getting some pods running, 
-one of them is selected at random. 
+different strategies can be selected for choosing which node group is increased. The default is
+random, but other options include selecting the group that can fit the most unschedulable pods,
+or the group that will leave the least amount of CPU or Memory available after the scale up.
 
 It may take some time before the nodes from node group appear in Kubernetes. It almost entirely 
 depends on the cloud provider and the speed of node provisioning.

--- a/cluster-autoscaler/expander/EXPANDERS.md
+++ b/cluster-autoscaler/expander/EXPANDERS.md
@@ -1,0 +1,27 @@
+# What are Expanders?
+
+When cluster-autoscaler identifies that it needs to scale up a cluster due to unscheduable pods, 
+it increases the nodes in a node group. When there is one Node Group, this strategy is trivial.
+
+When there are more than one Node Group, which group should be grown or 'expanded'?
+
+Expanders provide different strategies for selecting which Node Group to grow.
+
+Expanders can be selected by passing the name to the `--expander` flag. i.e. 
+`./cluster-autoscaler --expander=random`
+
+# What Expanders are available?
+
+Currently cluster-autoscaler has 3 expanders, but we anticipate more in the future:
+
+* `random` - this is the default expander, and should be used when you don't have a particular
+need for the node groups to scale differently
+
+* `most-pods` - this selects the node group that would be able to schedule the most pods when scaling
+up. This is useful when you are using nodeSelector to make sure certain pods land on certain nodes. 
+Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can grow multiple
+smaller nodes at once
+
+* `least-waste` - this selects the node group that will have the least idle CPU (and if tied, unused Memory) node group
+when scaling up. This is useful when you have different classes of nodes, for example, high CPU or high Memory nodes,
+and only want to expand those when pods that need those requirements are to be launched.

--- a/cluster-autoscaler/expander/expander.go
+++ b/cluster-autoscaler/expander/expander.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package expander
+
+import (
+	"k8s.io/contrib/cluster-autoscaler/cloudprovider"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+// Option describes an option to expand the cluster.
+type Option struct {
+	NodeGroup cloudprovider.NodeGroup
+	NodeCount int
+	Debug     string
+	Pods      []*apiv1.Pod
+}
+
+// Strategy describes an interface for selecting the best option when scaling up
+type Strategy interface {
+	BestOption(options []Option, nodeInfo map[string]*schedulercache.NodeInfo) *Option
+}

--- a/cluster-autoscaler/expander/mostpods/mostpods.go
+++ b/cluster-autoscaler/expander/mostpods/mostpods.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mostpods
+
+import (
+	"k8s.io/contrib/cluster-autoscaler/expander"
+	"k8s.io/contrib/cluster-autoscaler/expander/random"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+type mostpods struct {
+	fallbackStrategy expander.Strategy
+}
+
+// NewStrategy returns a scale up strategy (expander) that picks the node group that can schedule the most pods
+func NewStrategy() expander.Strategy {
+	return &mostpods{random.NewStrategy()}
+}
+
+// BestOption Selects the expansion option that schedules the most pods
+func (m *mostpods) BestOption(expansionOptions []expander.Option, nodeInfo map[string]*schedulercache.NodeInfo) *expander.Option {
+	var maxPods int
+	var maxOptions []expander.Option
+
+	for _, option := range expansionOptions {
+		if len(option.Pods) == maxPods {
+			maxOptions = append(maxOptions, option)
+		}
+
+		if len(option.Pods) > maxPods {
+			maxPods = len(option.Pods)
+			maxOptions = []expander.Option{option}
+		}
+	}
+
+	if len(maxOptions) == 0 {
+		return nil
+	}
+
+	return m.fallbackStrategy.BestOption(maxOptions, nodeInfo)
+}

--- a/cluster-autoscaler/expander/mostpods/mostpods_test.go
+++ b/cluster-autoscaler/expander/mostpods/mostpods_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mostpods
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/contrib/cluster-autoscaler/expander"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+)
+
+func TestMostPods(t *testing.T) {
+	eo0 := expander.Option{Debug: "EO0"}
+	e := NewStrategy()
+
+	ret := e.BestOption([]expander.Option{eo0}, nil)
+	assert.Equal(t, *ret, eo0)
+
+	eo1 := expander.Option{Debug: "EO1", Pods: []*apiv1.Pod{nil}}
+
+	ret = e.BestOption([]expander.Option{eo0, eo1}, nil)
+	assert.Equal(t, *ret, eo1)
+
+	eo1b := expander.Option{Debug: "EO1b", Pods: []*apiv1.Pod{nil}}
+
+	ret = e.BestOption([]expander.Option{eo0, eo1, eo1b}, nil)
+	assert.NotEqual(t, *ret, eo0)
+
+	assert.True(t, assert.ObjectsAreEqual(*ret, eo1) || assert.ObjectsAreEqual(*ret, eo1b))
+}

--- a/cluster-autoscaler/expander/random/random.go
+++ b/cluster-autoscaler/expander/random/random.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package random
+
+import (
+	"math/rand"
+
+	"k8s.io/contrib/cluster-autoscaler/expander"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+type random struct {
+}
+
+// NewStrategy returns an expansion strategy that randomly picks between node groups
+func NewStrategy() expander.Strategy {
+	return &random{}
+}
+
+// RandomExpansion Selects from the expansion options at random
+func (r *random) BestOption(expansionOptions []expander.Option, nodeInfo map[string]*schedulercache.NodeInfo) *expander.Option {
+	pos := rand.Int31n(int32(len(expansionOptions)))
+	return &expansionOptions[pos]
+}

--- a/cluster-autoscaler/expander/random/random_test.go
+++ b/cluster-autoscaler/expander/random/random_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package random
+
+import (
+	"testing"
+
+	"k8s.io/contrib/cluster-autoscaler/expander"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomExpander(t *testing.T) {
+	eo1a := expander.Option{Debug: "EO1a"}
+	e := NewStrategy()
+
+	ret := e.BestOption([]expander.Option{eo1a}, nil)
+	assert.Equal(t, *ret, eo1a)
+
+	eo1b := expander.Option{Debug: "EO1b"}
+
+	ret = e.BestOption([]expander.Option{eo1a, eo1b}, nil)
+
+	assert.True(t, assert.ObjectsAreEqual(*ret, eo1a) || assert.ObjectsAreEqual(*ret, eo1b))
+}

--- a/cluster-autoscaler/expander/waste/waste.go
+++ b/cluster-autoscaler/expander/waste/waste.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package waste
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/contrib/cluster-autoscaler/expander"
+	"k8s.io/contrib/cluster-autoscaler/expander/random"
+	"k8s.io/kubernetes/pkg/api/resource"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+type leastwaste struct {
+	fallbackStrategy expander.Strategy
+}
+
+// NewStrategy returns a strategy that selects the best scale up option based on which node group returns the least waste
+func NewStrategy() expander.Strategy {
+	return &leastwaste{random.NewStrategy()}
+}
+
+// BestOption Finds the option that wastes the least fraction of CPU and Memory
+func (l *leastwaste) BestOption(expansionOptions []expander.Option, nodeInfo map[string]*schedulercache.NodeInfo) *expander.Option {
+	var leastWastedScore float64
+	var leastWastedOptions []expander.Option
+
+	for _, option := range expansionOptions {
+		requestedCPU, requestedMemory := resourcesForPods(option.Pods)
+		node, found := nodeInfo[option.NodeGroup.Id()]
+		if !found {
+			glog.Errorf("No node info for: %s", option.NodeGroup.Id())
+			continue
+		}
+
+		nodeCPU, nodeMemory := resourcesForNode(node.Node())
+		availCPU := nodeCPU.MilliValue() * int64(option.NodeCount)
+		availMemory := nodeMemory.Value() * int64(option.NodeCount)
+		wastedCPU := float64(availCPU-requestedCPU.MilliValue()) / float64(availCPU)
+		wastedMemory := float64(availMemory-requestedMemory.Value()) / float64(availMemory)
+		wastedScore := wastedCPU + wastedMemory
+
+		glog.V(1).Infof("Expanding Node Group %s would waste %0.2f%% CPU, %0.2f%% Memory, %0.2f%% Blended\n", option.NodeGroup.Id(), wastedCPU*100.0, wastedMemory*100.0, wastedScore*50.0)
+
+		if wastedScore == leastWastedScore {
+			leastWastedOptions = append(leastWastedOptions, option)
+		}
+
+		if leastWastedOptions == nil || wastedScore < leastWastedScore {
+			leastWastedScore = wastedScore
+			leastWastedOptions = []expander.Option{option}
+		}
+	}
+
+	if len(leastWastedOptions) == 0 {
+		return nil
+	}
+
+	return l.fallbackStrategy.BestOption(leastWastedOptions, nodeInfo)
+}
+
+func resourcesForPods(pods []*apiv1.Pod) (cpu resource.Quantity, memory resource.Quantity) {
+	for _, pod := range pods {
+		for _, container := range pod.Spec.Containers {
+			if request, ok := container.Resources.Requests[apiv1.ResourceCPU]; ok {
+				cpu.Add(request)
+			}
+			if request, ok := container.Resources.Requests[apiv1.ResourceMemory]; ok {
+				memory.Add(request)
+			}
+		}
+	}
+
+	return cpu, memory
+}
+
+func resourcesForNode(node *apiv1.Node) (cpu resource.Quantity, memory resource.Quantity) {
+	cpu = node.Status.Capacity[apiv1.ResourceCPU]
+	memory = node.Status.Capacity[apiv1.ResourceMemory]
+
+	return cpu, memory
+}

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package waste
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/contrib/cluster-autoscaler/expander"
+	"k8s.io/kubernetes/pkg/api/resource"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+type FakeNodeGroup struct {
+	id string
+}
+
+func (f *FakeNodeGroup) MaxSize() int                    { return 2 }
+func (f *FakeNodeGroup) MinSize() int                    { return 1 }
+func (f *FakeNodeGroup) TargetSize() (int, error)        { return 2, nil }
+func (f *FakeNodeGroup) IncreaseSize(delta int) error    { return nil }
+func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error { return nil }
+func (f *FakeNodeGroup) Id() string                      { return f.id }
+func (f *FakeNodeGroup) Debug() string                   { return f.id }
+
+func makeNodeInfo(cpu int64, memory int64, pods int64) *schedulercache.NodeInfo {
+	node := &apiv1.Node{
+		Status: apiv1.NodeStatus{
+			Capacity: apiv1.ResourceList{
+				apiv1.ResourceCPU:    *resource.NewMilliQuantity(cpu, resource.DecimalSI),
+				apiv1.ResourceMemory: *resource.NewQuantity(memory, resource.DecimalSI),
+				apiv1.ResourcePods:   *resource.NewQuantity(pods, resource.DecimalSI),
+			},
+		},
+	}
+	node.Status.Allocatable = node.Status.Capacity
+
+	nodeInfo := schedulercache.NewNodeInfo()
+	nodeInfo.SetNode(node)
+
+	return nodeInfo
+}
+
+func TestLeastWaste(t *testing.T) {
+	cpuPerPod := int64(500)
+	memoryPerPod := int64(1000 * 1024 * 1024)
+	e := NewStrategy()
+	balancedNodeInfo := makeNodeInfo(16*cpuPerPod, 16*memoryPerPod, 100)
+	nodeMap := map[string]*schedulercache.NodeInfo{"balanced": balancedNodeInfo}
+	balancedOption := expander.Option{NodeGroup: &FakeNodeGroup{"balanced"}, NodeCount: 1}
+
+	// Test without any pods, one node info
+	ret := e.BestOption([]expander.Option{balancedOption}, nodeMap)
+	assert.Equal(t, *ret, balancedOption)
+
+	pod := &apiv1.Pod{
+		Spec: apiv1.PodSpec{
+			Containers: []apiv1.Container{
+				{
+					Resources: apiv1.ResourceRequirements{
+						Requests: apiv1.ResourceList{
+							apiv1.ResourceCPU:    *resource.NewMilliQuantity(cpuPerPod, resource.DecimalSI),
+							apiv1.ResourceMemory: *resource.NewQuantity(memoryPerPod, resource.DecimalSI),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test with one pod, one node info
+	balancedOption.Pods = []*apiv1.Pod{pod}
+	ret = e.BestOption([]expander.Option{balancedOption}, nodeMap)
+	assert.Equal(t, *ret, balancedOption)
+
+	// Test with one pod, two node infos, one that has lots of RAM one that has less
+	highmemNodeInfo := makeNodeInfo(16*cpuPerPod, 32*memoryPerPod, 100)
+	nodeMap["highmem"] = highmemNodeInfo
+	highmemOption := expander.Option{NodeGroup: &FakeNodeGroup{"highmem"}, NodeCount: 1, Pods: []*apiv1.Pod{pod}}
+	ret = e.BestOption([]expander.Option{balancedOption, highmemOption}, nodeMap)
+	assert.Equal(t, *ret, balancedOption)
+
+	// Test with one pod, three node infos, one that has lots of RAM one that has less, and one that has less CPU
+	lowcpuNodeInfo := makeNodeInfo(8*cpuPerPod, 16*memoryPerPod, 100)
+	nodeMap["lowcpu"] = lowcpuNodeInfo
+	lowcpuOption := expander.Option{NodeGroup: &FakeNodeGroup{"lowcpu"}, NodeCount: 1, Pods: []*apiv1.Pod{pod}}
+	ret = e.BestOption([]expander.Option{balancedOption, highmemOption, lowcpuOption}, nodeMap)
+	assert.Equal(t, *ret, lowcpuOption)
+}

--- a/cluster-autoscaler/utils.go
+++ b/cluster-autoscaler/utils.go
@@ -18,11 +18,11 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 	"time"
 
 	"k8s.io/contrib/cluster-autoscaler/cloudprovider"
+	"k8s.io/contrib/cluster-autoscaler/expander"
 	"k8s.io/contrib/cluster-autoscaler/simulator"
 
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
@@ -57,6 +57,8 @@ type AutoscalingContext struct {
 	MaxNodesTotal int
 	// EstimatorName is the estimator used to estimate the number of needed nodes in scale up.
 	EstimatorName string
+	// ExpanderStrategy is the strategy used to choose which node group to expand when scaling up
+	ExpanderStrategy expander.Strategy
 	// MaxGratefulTerminationSec is maximum number of seconds scale down waits for pods to terminante before
 	// removing the node from cloud provider.
 	MaxGratefulTerminationSec int
@@ -208,13 +210,4 @@ func GetNodeInfosForGroups(nodes []*apiv1.Node, cloudProvider cloudprovider.Clou
 		}
 	}
 	return result, nil
-}
-
-// BestExpansionOption picks the best cluster expansion option.
-func BestExpansionOption(expansionOptions []ExpansionOption) *ExpansionOption {
-	if len(expansionOptions) > 0 {
-		pos := rand.Int31n(int32(len(expansionOptions)))
-		return &expansionOptions[pos]
-	}
-	return nil
 }


### PR DESCRIPTION
As per #1921, the current cluster-autoscaler chooses a node group to increase at random among the groups that can fit at least one pod. This expands this to two additional strategies:

- Most Pods - choose the node group that can schedule the most pods, usually due to predicate rules
- Least Waste - choose the node group that has the least remaining CPU resources after a scale up, and if that is tied, the least remaining Memory

In the event of a tie, both of these strategies fall back to the current Random method.

This probably needs test coverage, to move to its own package, and there could be some weirdness in the algorithms as it needs manual testing.

Looking mostly to see if I'm on the right track and will proceed after.

