### PR TITLE
Relax OWNERSHIP rules if none found

### DIFF
--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -304,7 +304,7 @@ func (o *RepoInfo) LeafAssignees(path string) sets.String {
 	return peopleForPath(path, o.assignees, true, o.EnableMdYaml)
 }
 
-// Assignees returns a set of users who are the closest assignees to the
+// Assignees returns a set of all users who are assignees to the
 // requested file. If pkg/OWNERS has user1 and pkg/util/OWNERS has user2 this
 // will return both user1 and user2 for the path pkg/util/sets/file.go
 func (o *RepoInfo) Assignees(path string) sets.String {

--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -22,8 +22,10 @@ import (
 
 	"k8s.io/contrib/mungegithub/features"
 	"k8s.io/contrib/mungegithub/github"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/golang/glog"
+	githubapi "github.com/google/go-github/github"
 	"github.com/spf13/cobra"
 )
 
@@ -84,6 +86,46 @@ func printChance(owners weightMap, total int64) {
 	}
 }
 
+func (b *BlunderbussMunger) potentialOwners(issue *githubapi.Issue, files []*githubapi.CommitFile, leafOnly bool) (weightMap, int64) {
+	potentialOwners := weightMap{}
+	weightSum := int64(0)
+	for _, file := range files {
+		if file == nil {
+			continue
+		}
+		fileWeight := int64(1)
+		if file.Changes != nil && *file.Changes != 0 {
+			fileWeight = int64(*file.Changes)
+		}
+		// Judge file size on a log scale-- effectively this
+		// makes three buckets, we shouldn't have many 10k+
+		// line changes.
+		fileWeight = int64(math.Log10(float64(fileWeight))) + 1
+		fileOwners := sets.String{}
+		if leafOnly {
+			fileOwners = b.features.Repos.LeafAssignees(*file.Filename)
+		} else {
+			fileOwners = b.features.Repos.Assignees(*file.Filename)
+		}
+		if fileOwners.Len() == 0 {
+			glog.Warningf("Couldn't find an owner for: %s", *file.Filename)
+		}
+
+		if b.features.Aliases != nil && b.features.Aliases.IsEnabled {
+			fileOwners = b.features.Aliases.Expand(fileOwners)
+		}
+
+		for _, owner := range fileOwners.List() {
+			if owner == *issue.User.Login {
+				continue
+			}
+			potentialOwners[owner] = potentialOwners[owner] + fileWeight
+			weightSum += fileWeight
+		}
+	}
+	return potentialOwners, weightSum
+}
+
 // Munge is the workhorse the will actually make updates to the PR
 func (b *BlunderbussMunger) Munge(obj *github.MungeObject) {
 	if !obj.IsPR() {
@@ -101,37 +143,13 @@ func (b *BlunderbussMunger) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	potentialOwners := weightMap{}
-	weightSum := int64(0)
-	for _, file := range files {
-		fileWeight := int64(1)
-		if file.Changes != nil && *file.Changes != 0 {
-			fileWeight = int64(*file.Changes)
-		}
-		// Judge file size on a log scale-- effectively this
-		// makes three buckets, we shouldn't have many 10k+
-		// line changes.
-		fileWeight = int64(math.Log10(float64(fileWeight))) + 1
-		fileOwners := b.features.Repos.LeafAssignees(*file.Filename)
-		if fileOwners.Len() == 0 {
-			glog.Warningf("Couldn't find an owner for: %s", *file.Filename)
-		}
-
-		if b.features.Aliases != nil && b.features.Aliases.IsEnabled {
-			fileOwners = b.features.Aliases.Expand(fileOwners)
-		}
-
-		for _, owner := range fileOwners.List() {
-			if owner == *issue.User.Login {
-				continue
-			}
-			potentialOwners[owner] = potentialOwners[owner] + fileWeight
-			weightSum += fileWeight
-		}
-	}
+	potentialOwners, weightSum := b.potentialOwners(issue, files, true)
 	if len(potentialOwners) == 0 {
-		glog.Errorf("No owners found for PR %d", *issue.Number)
-		return
+		potentialOwners, weightSum = b.potentialOwners(issue, files, false)
+		if len(potentialOwners) == 0 {
+			glog.Errorf("No OWNERS found for PR %d", *issue.Number)
+			return
+		}
 	}
 	printChance(potentialOwners, weightSum)
 	if issue.Assignee != nil {


### PR DESCRIPTION
It was possible that a PR changing files whose only "leaf" owner was the
PR author would result in 1 OWNER. The PR author. That OWNER would be
eliminated. Thus the PR would get no owner.

The fix is to look for ALL owners of files if we can't find any.