### PR TITLE
Keep looking up the tree if we found an empty set

### DIFF
--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -284,7 +284,7 @@ func peopleForPath(path string, people map[string]sets.String, leafOnly bool, en
 		s, ok := people[d]
 		if ok {
 			out = out.Union(s)
-			if leafOnly {
+			if leafOnly && out.Len() > 0 {
 				break
 			}
 		}


### PR DESCRIPTION
If we find an OWNERS file with only reviewers, but no assignee or
approvers we will insert an empty set into the assignees. If we find
that empty set later we should ignore it and look for the closest
assignable person.