### PR TITLE
Adds --probe to export health checks and latency metrics for dns servers

### DIFF
--- a/dnsmasq-metrics/Makefile
+++ b/dnsmasq-metrics/Makefile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 BIN := dnsmasq-metrics
-PKG := k8s.io/contrib/dnsmasq-metrics
+PKG := k8s.io/contrib/dnsmasq-metrics # TODO: change to kubedns-sidecar
 REGISTRY ?= gcr.io/google_containers
 ARCH ?= amd64
 
-VERSION := 1.0
+VERSION := 1.1
 
 ###
 ### These variables should not need tweaking.

--- a/dnsmasq-metrics/pkg/server/dnsprobe.go
+++ b/dnsmasq-metrics/pkg/server/dnsprobe.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// loopDelayer encapsulates the delay-loop timing logic. This
+// externalizes it for testing.
+type loopDelayer interface {
+	// Start the delay loop, may sleep.
+	Start(interval time.Duration)
+	// Sleep the required amount of time taking into account the
+	// `latency` of the loop body.
+	Sleep(latency time.Duration)
+}
+
+type defaultLoopDelayer struct {
+	interval time.Duration
+}
+
+func (d *defaultLoopDelayer) Start(interval time.Duration) {
+	d.interval = interval
+	// Stagger the start of the loop to avoid sending all probes at
+	// exactly the same time.
+	time.Sleep(time.Duration(rand.Int63n((int64)(d.interval))))
+}
+
+func (d *defaultLoopDelayer) Sleep(latency time.Duration) {
+	sleepInterval := d.interval - latency
+	if sleepInterval > 0 {
+		glog.V(4).Infof("Sleeping %v", sleepInterval)
+		time.Sleep(sleepInterval)
+	}
+}
+
+type dnsProbe struct {
+	DNSProbeOption
+
+	lock               sync.Mutex
+	lastResolveLatency time.Duration
+	lastError          error
+	latencyHistogram   prometheus.Histogram
+	errorCount         prometheus.Counter
+	// loopDelay to use. If set to nil, dnsProbe will use
+	// defaultLoopDelayer.
+	delayer loopDelayer
+}
+
+func (p *dnsProbe) Start(options *Options) {
+	glog.V(2).Infof("Starting dnsProbe %+v", p.DNSProbeOption)
+
+	p.lastError = fmt.Errorf("waiting for first probe")
+
+	http.HandleFunc("/healthcheck/"+p.Label, p.httpHandler)
+	p.registerMetrics(options)
+
+	if p.delayer == nil {
+		glog.V(4).Infof("Using defaultLoopDelayer")
+		p.delayer = &defaultLoopDelayer{}
+	}
+
+	go p.loop()
+}
+
+func (p *dnsProbe) registerMetrics(options *Options) {
+	const dnsProbeSubsystem = "probe"
+
+	p.latencyHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: options.PrometheusNamespace,
+		Subsystem: dnsProbeSubsystem,
+		Name:      p.Label + "_latency_ms",
+		Help:      "Latency of the DNS probe request " + p.Label,
+		Buckets:   prometheus.LinearBuckets(0, 10, 500),
+	})
+	prometheus.MustRegister(p.latencyHistogram)
+
+	p.errorCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: options.PrometheusNamespace,
+		Subsystem: dnsProbeSubsystem,
+		Name:      p.Label + "_errors",
+		Help:      "Count of errors in name resolution of " + p.Label,
+	})
+	prometheus.MustRegister(p.errorCount)
+}
+
+func (p *dnsProbe) loop() {
+	glog.V(4).Infof("Starting loop")
+	p.delayer.Start(p.Interval)
+
+	dnsClient := &dns.Client{}
+
+	for {
+		glog.V(4).Infof("Sending DNS request @%v %v", p.Server, p.Name)
+		msg, latency, err := dnsClient.Exchange(p.msg(), p.Server)
+		glog.V(4).Infof("Got response, err=%v after %v", err, latency)
+
+		if err == nil && len(msg.Answer) == 0 {
+			err = fmt.Errorf("no RRs for domain %q", p.Name)
+		}
+
+		p.update(err, latency)
+		p.delayer.Sleep(latency)
+	}
+}
+
+func (p *dnsProbe) update(err error, latency time.Duration) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if err == nil {
+		p.lastResolveLatency = latency
+		p.lastError = nil
+
+		p.latencyHistogram.Observe(latency.Seconds() * 1000)
+	} else {
+		glog.V(3).Infof("DNS resolution error for %v: %v", p.Label, err)
+		p.lastResolveLatency = 0
+		p.lastError = err
+
+		p.errorCount.Add(1)
+	}
+}
+
+func (p *dnsProbe) msg() (msg *dns.Msg) {
+	msg = new(dns.Msg)
+	msg.Id = dns.Id()
+	msg.RecursionDesired = true
+	msg.Question = make([]dns.Question, 1)
+	msg.Question[0] = dns.Question{
+		Name:   p.Name,
+		Qtype:  dns.TypeANY,
+		Qclass: dns.ClassINET,
+	}
+	return
+}
+
+func (p *dnsProbe) httpHandler(w http.ResponseWriter, r *http.Request) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	response := struct {
+		IsOk           bool
+		LatencySeconds float64
+		Err            string
+	}{}
+
+	if p.lastError == nil {
+		response.IsOk = true
+		response.LatencySeconds = p.lastResolveLatency.Seconds()
+
+		if buf, err := json.Marshal(response); err == nil {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(buf)
+		} else {
+			glog.Errorf("JSON Marshal error: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write(([]byte)(fmt.Sprintf("Error: %v", err)))
+		}
+	} else {
+		response.IsOk = false
+		response.Err = p.lastError.Error()
+
+		if buf, err := json.Marshal(response); err == nil {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write(buf)
+		} else {
+			glog.Errorf("JSON Marshal error: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write(([]byte)(fmt.Sprintf("Error: %v", err)))
+		}
+	}
+}

--- a/dnsmasq-metrics/pkg/server/dnsprobe_test.go
+++ b/dnsmasq-metrics/pkg/server/dnsprobe_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+
+	"k8s.io/contrib/dnsmasq-metrics/pkg/test"
+)
+
+type mockLoopDelayer struct {
+	sleepDone chan struct{}
+}
+
+func (d *mockLoopDelayer) Start(interval time.Duration) {
+}
+
+func (d *mockLoopDelayer) Sleep(latency time.Duration) {
+	d.sleepDone <- struct{}{}
+}
+
+func makeOptions(label string, addr string, port int) *Options {
+	return &Options{
+		PrometheusNamespace: "test",
+		Probes: []DNSProbeOption{
+			{
+				Label:    label,
+				Server:   fmt.Sprintf("%v:%v", addr, port),
+				Name:     "test.local.",
+				Interval: 1 * time.Millisecond,
+			},
+		},
+	}
+}
+
+func TestProbeOk(t *testing.T) {
+	testProbe(t, "ok", false, okResponseCallback)
+}
+
+func TestProbeNx(t *testing.T) {
+	testProbe(t, "nx", true, nxResponseCallback)
+}
+
+func TestProbeFail(t *testing.T) {
+	testProbe(t, "fail", true, nil)
+}
+
+func testProbe(t *testing.T, name string, hasError bool, callback test.ServerCallback) {
+	server := &test.Server{}
+	addr, port := server.Init(t)
+
+	if callback != nil {
+		go server.Run(callback)
+	}
+
+	// Note: sleepDone MUST be created here, otherwise there is a race
+	// creating the channel.
+	delayer := &mockLoopDelayer{sleepDone: make(chan struct{})}
+	options := makeOptions(name, addr, port)
+	probe := &dnsProbe{
+		DNSProbeOption: options.Probes[0],
+		delayer:        delayer,
+	}
+
+	probe.Start(options)
+
+	// Wait for one loop to have been completed.
+	<-delayer.sleepDone
+
+	probe.lock.Lock()
+	defer probe.lock.Unlock()
+
+	if hasError {
+		if probe.lastError == nil {
+			t.Errorf("should have error")
+		}
+	} else {
+		if probe.lastError != nil {
+			t.Errorf("should have no error: %v", probe.lastError)
+		}
+	}
+}
+
+func okResponseCallback(server *test.Server, remoteAddr net.Addr, msg *dns.Msg) {
+	bytes := makeResponsePacket(server.T, msg.Id, 1)
+	_, err := server.Conn.WriteTo(bytes, remoteAddr)
+	if err != nil {
+		server.T.Fatalf("error sending response: %v", err)
+	}
+}
+
+func nxResponseCallback(server *test.Server, remoteAddr net.Addr, msg *dns.Msg) {
+	bytes := makeResponsePacket(server.T, msg.Id, 0)
+	_, err := server.Conn.WriteTo(bytes, remoteAddr)
+	if err != nil {
+		server.T.Fatalf("error sending response: %v", err)
+	}
+}
+
+func makeResponsePacket(t *testing.T, id uint16, responses int) []byte {
+	answer, err := dns.NewRR("test.local. 100 IN A 1.2.3.4")
+	if err != nil {
+		t.Fatalf("dns.NewRR: %v", err)
+	}
+
+	msg := &dns.Msg{}
+	msg.SetQuestion("test.local.", dns.TypeA)
+	msg.Question[0].Qclass = dns.ClassANY
+
+	for i := 0; i < responses; i++ {
+		msg.Answer = append(msg.Answer, answer)
+	}
+	msg.Id = id
+
+	buf, err := msg.Pack()
+	if err != nil {
+		t.Fatalf("msg.Pack(): %v", err)
+	}
+
+	return buf
+}

--- a/dnsmasq-metrics/pkg/server/metrics.go
+++ b/dnsmasq-metrics/pkg/server/metrics.go
@@ -32,39 +32,41 @@ var (
 	errorsCounter prometheus.Counter
 )
 
-func defineMetrics(options *Options) {
+func defineDnsmasqMetrics(options *Options) {
+	const dnsmasqSubsystem = "dnsmasq"
+
 	gauges[dnsmasq.CacheHits] = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: options.PrometheusNamespace,
-			Subsystem: options.PrometheusSubsystem,
+			Subsystem: dnsmasqSubsystem,
 			Name:      "hits",
 			Help:      "Number of DNS cache hits (from start of process)",
 		})
 	gauges[dnsmasq.CacheMisses] = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: options.PrometheusNamespace,
-			Subsystem: options.PrometheusSubsystem,
+			Subsystem: dnsmasqSubsystem,
 			Name:      "misses",
 			Help:      "Number of DNS cache misses (from start of process)",
 		})
 	gauges[dnsmasq.CacheEvictions] = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: options.PrometheusNamespace,
-			Subsystem: options.PrometheusSubsystem,
+			Subsystem: dnsmasqSubsystem,
 			Name:      "evictions",
 			Help:      "Counter of DNS cache evictions (from start of process)",
 		})
 	gauges[dnsmasq.CacheInsertions] = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: options.PrometheusNamespace,
-			Subsystem: options.PrometheusSubsystem,
+			Subsystem: dnsmasqSubsystem,
 			Name:      "insertions",
 			Help:      "Counter of DNS cache insertions (from start of process)",
 		})
 	gauges[dnsmasq.CacheSize] = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: options.PrometheusNamespace,
-			Subsystem: options.PrometheusSubsystem,
+			Subsystem: dnsmasqSubsystem,
 			Name:      "max_size",
 			Help:      "Maximum size of the DNS cache",
 		})
@@ -76,7 +78,7 @@ func defineMetrics(options *Options) {
 	errorsCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: options.PrometheusNamespace,
-			Subsystem: options.PrometheusSubsystem,
+			Subsystem: dnsmasqSubsystem,
 			Name:      "errors",
 			Help:      "Number of errors that have occurred getting metrics",
 		})
@@ -85,7 +87,7 @@ func defineMetrics(options *Options) {
 
 // InitializeMetrics and export metrics.
 func InitializeMetrics(options *Options) {
-	defineMetrics(options)
+	defineDnsmasqMetrics(options)
 
 	http.Handle(options.PrometheusPath, prometheus.Handler())
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) {

--- a/dnsmasq-metrics/pkg/server/options.go
+++ b/dnsmasq-metrics/pkg/server/options.go
@@ -16,17 +16,32 @@ limitations under the License.
 
 package server
 
+import "time"
+
+// DNSProbeOption for periodic DNS health check and latency probes.
+type DNSProbeOption struct {
+	// Label to use for healthcheck URL
+	Label string
+	// Endpoint to send DNS requests to.
+	Server string
+	// Name to resolve to test endpoint.
+	Name string
+	// Interval to use for probing
+	Interval time.Duration
+}
+
 // Options for the daemon
 type Options struct {
 	DnsMasqPort           int
 	DnsMasqAddr           string
 	DnsMasqPollIntervalMs int
 
+	Probes []DNSProbeOption
+
 	PrometheusAddr      string
 	PrometheusPort      int
 	PrometheusPath      string
 	PrometheusNamespace string
-	PrometheusSubsystem string
 }
 
 // NewOptions creates a new options struct with default values.
@@ -35,10 +50,10 @@ func NewOptions() *Options {
 		DnsMasqAddr:           "127.0.0.1",
 		DnsMasqPort:           53,
 		DnsMasqPollIntervalMs: 5000,
-		PrometheusAddr:        "0.0.0.0",
-		PrometheusPort:        10054,
-		PrometheusPath:        "/metrics",
-		PrometheusNamespace:   "dnsmasq",
-		PrometheusSubsystem:   "cache",
+
+		PrometheusAddr:      "0.0.0.0",
+		PrometheusPort:      10054,
+		PrometheusPath:      "/metrics",
+		PrometheusNamespace: "kubedns",
 	}
 }

--- a/dnsmasq-metrics/pkg/server/server.go
+++ b/dnsmasq-metrics/pkg/server/server.go
@@ -31,6 +31,7 @@ type Server interface {
 type server struct {
 	options       *Options
 	metricsClient dnsmasq.MetricsClient
+	probes        []*dnsProbe
 }
 
 // NewServer creates a new server instance
@@ -43,6 +44,16 @@ func (s *server) Run(options *Options) {
 	s.options = options
 	glog.Infof("Starting server (options %+v)", *s.options)
 
+	for _, probeOption := range options.Probes {
+		probe := &dnsProbe{DNSProbeOption: probeOption}
+		s.probes = append(s.probes, probe)
+		probe.Start(options)
+	}
+
+	s.runMetrics(options)
+}
+
+func (s *server) runMetrics(options *Options) {
 	InitializeMetrics(options)
 
 	client := dnsmasq.NewMetricsClient(options.DnsMasqAddr, options.DnsMasqPort)

--- a/dnsmasq-metrics/pkg/test/test.go
+++ b/dnsmasq-metrics/pkg/test/test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// Server for mock DNS responses.
+type Server struct {
+	T         *testing.T
+	Conn      *net.UDPConn
+	StartChan chan struct{}
+}
+
+// ServerCallback to respond to DNS messages.
+type ServerCallback func(server *Server, remoteAddr net.Addr, msg *dns.Msg)
+
+// Init the DNS server.
+func (s *Server) Init(t *testing.T) (addr string, port int) {
+	s.T = t
+	s.StartChan = make(chan struct{})
+
+	var err error
+	s.Conn, err = net.ListenUDP(
+		"udp",
+		&net.UDPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 0, // allocate a free emphemeral port
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	localAddr, err := net.ResolveUDPAddr("udp", s.Conn.LocalAddr().String())
+	if err != nil {
+		panic(err)
+	}
+
+	addr = localAddr.IP.String()
+	port = localAddr.Port
+
+	return
+}
+
+// Run the server with the given response callback.
+func (s *Server) Run(cb ServerCallback) {
+	close(s.StartChan)
+
+	for {
+		buf := make([]byte, 4096)
+		len, remoteAddr, err := s.Conn.ReadFrom(buf)
+		if err != nil {
+			s.T.Fatalf("error reading packet: %v", err)
+		}
+		buf = buf[:len]
+
+		msg := &dns.Msg{}
+		err = msg.Unpack(buf)
+		if err != nil {
+			s.T.Fatalf("unable to Unpack %v: %v", buf, err)
+		}
+
+		cb(s, remoteAddr, msg)
+	}
+}

--- a/dnsmasq-metrics/test/e2e/docker-run-e2e.sh
+++ b/dnsmasq-metrics/test/e2e/docker-run-e2e.sh
@@ -36,12 +36,23 @@ dig="/usr/bin/dig"
 sleep_interval=10
 
 run ${dnsmasq} \
-  -q -k -a 127.0.0.1 -p ${dnsmasq_port} -c 1337 -8 - 2> ${dnsmasq_out} &
+  -q -k \
+  -a 127.0.0.1 \
+  -p ${dnsmasq_port} \
+  -c 1337 \
+  -8 - \
+  -A "/ok.local/1.2.3.4" \
+  -A "/nxdomain.local/" \
+  2> ${dnsmasq_out} &
 dnsmasq_pid=$!
 echo "dnsmasq_pid=${dnsmasq_pid}"
 
 run ${dnsmasq_metrics} \
-  --dnsmasq-port ${dnsmasq_port} -v 4 2> ${dnsmasq_metrics_out} &
+  --dnsmasq-port ${dnsmasq_port} -v 4 \
+  --probe "ok,127.0.0.1:${dnsmasq_port},ok.local,1" \
+  --probe "nxdomain,127.0.0.1:${dnsmasq_port},nx.local,1" \
+  --probe "notpresent,127.0.0.1:$((dnsmasq_port + 1)),notpresent.local,1" \
+  2> ${dnsmasq_metrics_out} &
 dnsmasq_metrics_pid=$!
 echo "dnsmasq_metrics_pid=${dnsmasq_metrics_pid}"
 

--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -1,10 +1,9 @@
+dnsmasq-metrics/test/e2e/docker-run-e2e.sh:  --probe "notpresent,127.0.0.1:$((dnsmasq_port + 1)),notpresent.local,1" \
 ingress/controllers/nginx/configuration.md:**custom-http-errors:** Enables which HTTP codes should be passed for processing with the [error_page directive](http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page)
 ingress/controllers/nginx/configuration.md:Setting at least one code this also enables [proxy_intercept_errors](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors) (required to process error_page)
 ingress/controllers/nginx/nginx.tmpl:        require("error_page")
 ingress/controllers/nginx/nginx.tmpl:    error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
 ingress/controllers/nginx/nginx/config/config.go:	// enables which HTTP codes should be passed for processing with the error_page directive
-kubelet-to-gcm/monitor/kubelet/translate.go:				"container_name": containerName,
-kubelet-to-gcm/monitor/kubelet/translate.go:		"container_name": "",
 mungegithub/mungers/submit-queue.go:		sq.e2e = &fake_e2e.FakeE2ETester{
 mungegithub/mungers/submit-queue.go:	fake_e2e "k8s.io/contrib/mungegithub/mungers/e2e/fake"
 mungegithub/mungers/submit-queue_test.go:	e2e := sq.e2e.(*fake_e2e.FakeE2ETester)


### PR DESCRIPTION
`--probe <label>,<server>,<dns name>,<interval>` will query the given
DNS server for `<dns name>` every `<interval>` seconds. The results will
be posted to a health check URL and DNS latencies and errors reported
via the /metrics URL.

Multple `--probe`s may be specified.

This replaces the functionality of the exec-healthz for the DNS pod.