### PR TITLE
Cluster-Autoscaler: add node drain logic

### DIFF
--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -205,6 +205,12 @@ func run(_ <-chan struct{}) {
 					continue
 				}
 
+				// CA can die at any time. Removing taints that might have been left from the previous run.
+				if err := cleanToBeDeleted(nodes, kubeClient, recorder); err != nil {
+					glog.Warningf("Failed to clean ToBeDeleted information: %v", err)
+					continue
+				}
+
 				allUnschedulablePods, err := unschedulablePodLister.List()
 				if err != nil {
 					glog.Errorf("Failed to list unscheduled pods: %v", err)

--- a/cluster-autoscaler/scale_down_test.go
+++ b/cluster-autoscaler/scale_down_test.go
@@ -23,7 +23,11 @@ import (
 	"k8s.io/contrib/cluster-autoscaler/simulator"
 	. "k8s.io/contrib/cluster-autoscaler/utils/test"
 
+	"k8s.io/kubernetes/pkg/api/errors"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5/fake"
+	"k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/runtime"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -75,4 +79,78 @@ func TestFindUnneededNodes(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, addTime, addTime2)
 	assert.Equal(t, 4, len(utilization))
+}
+
+func TestDrainNode(t *testing.T) {
+	deletedPods := make(chan string, 10)
+	updatedNodes := make(chan string, 10)
+	fakeClient := &fake.Clientset{}
+
+	p1 := BuildTestPod("p1", 100, 0)
+	p2 := BuildTestPod("p2", 300, 0)
+	n1 := BuildTestNode("n1", 1000, 1000)
+
+	fakeClient.Fake.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &apiv1.PodList{Items: []apiv1.Pod{*p1, *p2}}, nil
+	})
+	fakeClient.Fake.AddReactor("get", "pods", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewNotFound(apiv1.Resource("pod"), "whatever")
+	})
+	fakeClient.Fake.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+		return true, n1, nil
+	})
+	fakeClient.Fake.AddReactor("delete", "pods", func(action core.Action) (bool, runtime.Object, error) {
+		deleteAction := action.(core.DeleteAction)
+		deletedPods <- deleteAction.GetName()
+		return true, nil, nil
+	})
+	fakeClient.Fake.AddReactor("update", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+		update := action.(core.UpdateAction)
+		obj := update.GetObject().(*apiv1.Node)
+		updatedNodes <- obj.Name
+		return true, obj, nil
+	})
+	err := drainNode(n1, []*apiv1.Pod{p1, p2}, fakeClient, createEventRecorder(fakeClient))
+	assert.NoError(t, err)
+	assert.Equal(t, p1.Name, getStringFromChan(deletedPods))
+	assert.Equal(t, p2.Name, getStringFromChan(deletedPods))
+	assert.Equal(t, n1.Name, getStringFromChan(updatedNodes))
+}
+
+func TestCleanNodes(t *testing.T) {
+	updatedNodes := make(chan string, 10)
+	fakeClient := &fake.Clientset{}
+
+	n1 := BuildTestNode("n1", 1000, 1000)
+	addToBeDeletedTaint(n1)
+	n2 := BuildTestNode("n2", 1000, 1000)
+
+	fakeClient.Fake.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+		get := action.(core.GetAction)
+		if get.GetName() == n1.Name {
+			return true, n1, nil
+		}
+		if get.GetName() == n2.Name {
+			return true, n2, nil
+		}
+		return true, nil, errors.NewNotFound(apiv1.Resource("node"), get.GetName())
+	})
+	fakeClient.Fake.AddReactor("update", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+		update := action.(core.UpdateAction)
+		obj := update.GetObject().(*apiv1.Node)
+		updatedNodes <- obj.Name
+		return true, obj, nil
+	})
+	err := cleanToBeDeleted([]*apiv1.Node{n1, n2}, fakeClient, createEventRecorder(fakeClient))
+	assert.NoError(t, err)
+	assert.Equal(t, n1.Name, getStringFromChan(updatedNodes))
+}
+
+func getStringFromChan(c chan string) string {
+	select {
+	case val := <-c:
+		return val
+	case <-time.After(time.Second * 10):
+		return "Nothing returned"
+	}
 }


### PR DESCRIPTION
Currently a node is removed without any notice and pods  that live on the node killed without graceful termination. This PR adds drain logic to scale down.

cc: @fgrzadkowski @piosz @jszczepkowski 