### PR TITLE
Make release-note-label work with newlines and ```release-note format.

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -63,6 +63,7 @@ var (
 	priorityLabelRE    = regexp.MustCompile(`priority/[pP]([\d]+)`)
 	fixesIssueRE       = regexp.MustCompile(`(?i)(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)[\s]+#([\d]+)`)
 	reviewableFooterRE = regexp.MustCompile(`(?s)<!-- Reviewable:start -->.*<!-- Reviewable:end -->`)
+	htmlCommentRE      = regexp.MustCompile(`(?s)<!--[^<>]*?-->\n?`)
 	maxTime            = time.Unix(1<<63-62135596801, 999999999) // http://stackoverflow.com/questions/25065055/what-is-the-maximum-time-time-in-go
 
 	// How long we locally cache the combined status of an object. We will not
@@ -1635,6 +1636,7 @@ func (obj *MungeObject) MergeCommit() *string {
 // including Reviewable footers and extra whitespace.
 func cleanIssueBody(issueBody string) string {
 	issueBody = reviewableFooterRE.ReplaceAllString(issueBody, "")
+	issueBody = htmlCommentRE.ReplaceAllString(issueBody, "")
 	return strings.TrimSpace(issueBody)
 }
 

--- a/mungegithub/github/github_test.go
+++ b/mungegithub/github/github_test.go
@@ -549,6 +549,46 @@ gratuitous href
 <!-- Reviewable:end -->`,
 			"Some message",
 		},
+		{
+			`Merge pull request #1234 from user/master
+
+Automatic merge from submit-queue (batch tested with PRs 1, 2, 1234, 57)
+
+[Part 2] Adding s390x cross-compilation support for gcr.io images in this repo
+
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
+2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
+3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
+-->
+
+**What this PR does / why we need it**: This PR enables s390x support.
+
+**Which issue this PR fixes #34328
+
+**Special notes for your reviewer**:  I am enabling cross compilation for s390x.
+
+**Release note**:
+<!--  Steps to write your release note:
+1. Use the release-note-* labels to set the release note state (if you have access)
+2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write` +
+				" `NONE`.\n-->\n```\nAllows cross compilation of Kubernetes on x86 host for s390x also enables s390x support to kube-dns , pause, addon-manager, etcd, hyperkube, kube-discovery etc\n```\n",
+			`Merge pull request #1234 from user/master
+
+Automatic merge from submit-queue (batch tested with PRs 1, 2, 1234, 57)
+
+[Part 2] Adding s390x cross-compilation support for gcr.io images in this repo
+
+
+**What this PR does / why we need it**: This PR enables s390x support.
+
+**Which issue this PR fixes #34328
+
+**Special notes for your reviewer**:  I am enabling cross compilation for s390x.
+
+**Release note**:
+` + "```\nAllows cross compilation of Kubernetes on x86 host for s390x also enables s390x support to kube-dns , pause, addon-manager, etcd, hyperkube, kube-discovery etc\n```",
+		},
 	}
 	for testNum, test := range tests {
 		body := cleanIssueBody(test.body)

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -51,6 +51,7 @@ Please see: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull
 var (
 	releaseNoteBody       = fmt.Sprintf(releaseNoteFormat, releaseNote, releaseNoteActionRequired, releaseNoteExperimental, releaseNoteNone)
 	parentReleaseNoteBody = fmt.Sprintf(parentReleaseNoteFormat, releaseNote, releaseNoteActionRequired)
+	noteMatcherRE         = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*` + "```|```release-note)(.+?)```")
 )
 
 // ReleaseNoteLabel will add the doNotMergeLabel to a PR which has not
@@ -170,16 +171,15 @@ func determineReleaseNoteLabel(obj *github.MungeObject) string {
 // getReleaseNote returns the release note from a PR body
 // assumes that the PR body followed the PR template
 func getReleaseNote(body string) string {
-	noteMatcher := regexp.MustCompile(`Release note\*\*:\s*` + "```" + `(.+?)` + "```")
-	potentialMatch := noteMatcher.FindStringSubmatch(body)
+	potentialMatch := noteMatcherRE.FindStringSubmatch(body)
 	if potentialMatch == nil {
 		return ""
 	}
-	return potentialMatch[1]
+	return strings.TrimSpace(potentialMatch[1])
 }
 
 func chooseLabel(composedReleaseNote string) string {
-	composedReleaseNote = strings.ToLower(strings.Trim(composedReleaseNote, " "))
+	composedReleaseNote = strings.ToLower(strings.TrimSpace(composedReleaseNote))
 
 	if composedReleaseNote == "" {
 		return releaseNoteLabelNeeded

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -249,7 +249,7 @@ func TestGetReleaseNote(t *testing.T) {
 			expectedReleaseNoteVariable: releaseNoteNone,
 		},
 		{
-			body:                        "**Release note**:\n\n ```NONE```",
+			body:                        "**Release note**:\n\n ```\nNONE\n```",
 			expectedReleaseNote:         "NONE",
 			expectedReleaseNoteVariable: releaseNoteNone,
 		},
@@ -262,6 +262,16 @@ func TestGetReleaseNote(t *testing.T) {
 			body:                        "**Release note**: ```This is my feature. There is some action required for my feature.```",
 			expectedReleaseNote:         "This is my feature. There is some action required for my feature.",
 			expectedReleaseNoteVariable: releaseNoteActionRequired,
+		},
+		{
+			body:                        "```release-note\nsomething great.\n```",
+			expectedReleaseNote:         "something great.",
+			expectedReleaseNoteVariable: releaseNote,
+		},
+		{
+			body:                        "```release-note\nNONE\n```",
+			expectedReleaseNote:         "NONE",
+			expectedReleaseNoteVariable: releaseNoteNone,
 		},
 		{
 			body:                        "",


### PR DESCRIPTION
There's an even split (109 "Release note**", 113 "```release-note") between the two styles of release note marking, so we might as well support both.

It didn't work with newlines at all before, so it was messing up in almost every case.