### PR TITLE
Handle yet another release-note case.

### DIFF
--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -51,7 +51,7 @@ Please see: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull
 var (
 	releaseNoteBody       = fmt.Sprintf(releaseNoteFormat, releaseNote, releaseNoteActionRequired, releaseNoteExperimental, releaseNoteNone)
 	parentReleaseNoteBody = fmt.Sprintf(parentReleaseNoteFormat, releaseNote, releaseNoteActionRequired)
-	noteMatcherRE         = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```|```release-note)(.+?)```")
+	noteMatcherRE         = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```(?:release-note)?|```release-note)(.+?)```")
 )
 
 // ReleaseNoteLabel will add the doNotMergeLabel to a PR which has not

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -279,6 +279,11 @@ func TestGetReleaseNote(t *testing.T) {
 			expectedReleaseNoteVariable: releaseNoteNone,
 		},
 		{
+			body:                        "**Release note**:\n```release-note\nNONE\n```\n",
+			expectedReleaseNote:         "NONE",
+			expectedReleaseNoteVariable: releaseNoteNone,
+		},
+		{
 			body:                        "",
 			expectedReleaseNote:         "",
 			expectedReleaseNoteVariable: releaseNoteLabelNeeded,


### PR DESCRIPTION
It mislabeled kubernetes/kubernetes#38672