### PR TITLE
temporarily disable approvers

### DIFF
--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -7,7 +7,7 @@ data:
   config.http-cache-dir: /cache/httpcache
   config.organization: kubernetes
   config.project: contrib
-  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,needs-rebase,approval-handler
+  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,needs-rebase
   config.state: open
   config.token-file: /etc/secret-volume/token
   gitrepo.repo-dir: /gitrepos


### PR DESCRIPTION
There's a strange infinite loop that occurs we think because of old PRs that change files in directories that no longer exist (and therefore have no OWNERS files).  We have to handle that edge case, so disabling in the meantime.