### PR TITLE
handling the . case

### DIFF
--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -265,7 +265,7 @@ func (o *RepoInfo) FindOwnersForPath(path string) string {
 
 	for {
 		// special case the root
-		if d == "" {
+		if d == "." || d == "" {
 			d = "/"
 		}
 		_, ok := o.approvers[d]


### PR DESCRIPTION
The output of the call to `filepath.Dir()` for an empty string is `.` .  This results in an infinitely loop in the code.