### PR TITLE
Remove zoidbergwill from OWNERS

### DIFF
--- a/continuousdelivery/OWNERS
+++ b/continuousdelivery/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- emaildanwilson
-- zoidbergwill
-reviewers:
-- emaildanwilson
-- zoidbergwill


### PR DESCRIPTION
@zoidbergwill is not in the org and thus the bot cannot assign them. So remove them from OWNERS