### PR TITLE
Fix docs and !GateApproval

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -945,6 +945,23 @@ func (obj *MungeObject) RemoveLabel(label string) error {
 	return nil
 }
 
+// ModifiedAfterLabeled returns true if the PR was updated after the last time the
+// label was applied.
+func (obj *MungeObject) ModifiedAfterLabeled(label string) (after bool, ok bool) {
+	labelTime := obj.LabelTime(label)
+	if labelTime == nil {
+		glog.Errorf("Unable to find label time for: %q on %d", label, obj.Number())
+		return false, false
+	}
+	lastModifiedTime := obj.LastModifiedTime()
+	if lastModifiedTime == nil {
+		glog.Errorf("Unable to find last modification time for %d", obj.Number())
+		return false, false
+	}
+	after = lastModifiedTime.After(*labelTime)
+	return after, true
+}
+
 // GetHeadAndBase returns the head SHA and the base ref, so that you can get
 // the base's sha in a second step. Purpose: if head and base SHA are the same
 // across two merge attempts, we don't need to rerun tests.

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -122,6 +122,7 @@ func NoRetestIssue() *github.Issue {
 
 func OldLGTMEvents() []*github.IssueEvent {
 	return github_test.Events([]github_test.LabelTime{
+		{"bob", approvedLabel, 20},
 		{"bob", lgtmLabel, 6},
 		{"bob", lgtmLabel, 7},
 		{"bob", lgtmLabel, 8},
@@ -130,6 +131,7 @@ func OldLGTMEvents() []*github.IssueEvent {
 
 func NewLGTMEvents() []*github.IssueEvent {
 	return github_test.Events([]github_test.LabelTime{
+		{"bob", approvedLabel, 20},
 		{"bob", lgtmLabel, 10},
 		{"bob", lgtmLabel, 11},
 		{"bob", lgtmLabel, 12},
@@ -138,9 +140,19 @@ func NewLGTMEvents() []*github.IssueEvent {
 
 func OverlappingLGTMEvents() []*github.IssueEvent {
 	return github_test.Events([]github_test.LabelTime{
+		{"bob", approvedLabel, 20},
 		{"bob", lgtmLabel, 8},
 		{"bob", lgtmLabel, 9},
 		{"bob", lgtmLabel, 10},
+	})
+}
+
+func OldApprovedEvents() []*github.IssueEvent {
+	return github_test.Events([]github_test.LabelTime{
+		{"bob", approvedLabel, 6},
+		{"bob", lgtmLabel, 10},
+		{"bob", lgtmLabel, 11},
+		{"bob", lgtmLabel, 12},
 	})
 }
 
@@ -831,6 +843,16 @@ func TestSubmitQueue(t *testing.T) {
 			retest2Pass:     true,
 			reason:          fmt.Sprintf(ciFailureFmt, notRequiredReTestContext2),
 			state:           "pending",
+		},
+		{
+			name:     "Fail because changed after approval",
+			pr:       ValidPR(),
+			issue:    LGTMApprovedIssue(),
+			events:   OldApprovedEvents(),
+			commits:  Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus: SuccessStatus(),
+			reason:   approvedEarly,
+			state:    "pending",
 		},
 
 		// // Should pass even though last 'weakStable' build failed, as it wasn't "strong" failure


### PR DESCRIPTION
The main change is the "docs" to show that approval either is or isn't
required. These are displayed on the info tab of the bot.

While in here it became clear that we were hiding such simple logic
oddly and incorrectly. Even if `GateApproved` was false, if a PR had the
approved label and had been changed since we would still reject it.

This PR attempts to make the logic a bit more clear. Although we still
do not have any tests for the GateApproved=false case.