### PR TITLE
[mungegithub]: Improve Approval Process

### DIFF
--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -39,6 +39,8 @@ const (
 	ownerFilename = "OWNERS" // file which contains approvers and reviewers
 	// RepoFeatureName is how mungers should indicate this is required
 	RepoFeatureName = "gitrepos"
+	// Github's api uses "" (empty) string as basedir by convention but it's clearer to use "/"
+	baseDirConvention = ""
 )
 
 type assignmentConfig struct {
@@ -67,6 +69,16 @@ func init() {
 // Name is just going to return the name mungers use to request this feature
 func (o *RepoInfo) Name() string {
 	return RepoFeatureName
+}
+
+// by default, github's api doesn't root the project directory at "/" and instead uses the empty string for the base dir
+// of the project. And the built-in dir function returns "." for empty strings, so for consistency, we use this
+// canonicalize to get the directories of files in a consistent format with NO "/" at the root (a/b/c/ -> a/b/c)
+func canonicalize(path string) string {
+	if path == "." {
+		return baseDirConvention
+	}
+	return strings.TrimSuffix(path, "/")
 }
 
 func (o *RepoInfo) walkFunc(path string, info os.FileInfo, err error) error {
@@ -127,15 +139,12 @@ func (o *RepoInfo) walkFunc(path string, info os.FileInfo, err error) error {
 	}
 
 	path, err = filepath.Rel(o.projectDir, path)
+	path = filepath.Dir(path)
 	if err != nil {
 		glog.Errorf("Unable to find relative path between %q and %q: %v", o.projectDir, path, err)
 		return err
 	}
-	path = filepath.Dir(path)
-	// Make the root explicitly / so its easy to distinguish. Nothing else is `/` anchored
-	if path == "." {
-		path = "/"
-	}
+	path = canonicalize(path)
 	o.approvers[path] = sets.NewString(c.Approvers...)
 	o.approvers[path].Insert(c.Assignees...)
 	o.reviewers[path] = sets.NewString(c.Reviewers...)
@@ -259,24 +268,20 @@ func (o *RepoInfo) gitCommandDir(args []string, cmdDir string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-// FindOwnersForPath returns the OWNERS file further down the tree for a file
+// FindOwnersForPath returns the OWNERS file path further down the tree for a file
 func (o *RepoInfo) FindOwnersForPath(path string) string {
 	d := path
 
 	for {
-		// special case the root
-		if d == "." || d == "" {
-			d = "/"
-		}
 		_, ok := o.approvers[d]
 		if ok {
 			return d
 		}
-		if d == "/" {
+		if d == baseDirConvention {
 			break
 		}
 		d = filepath.Dir(d)
-		d = strings.TrimSuffix(d, "/")
+		d = canonicalize(d)
 	}
 	return ""
 }
@@ -289,16 +294,13 @@ func (o *RepoInfo) FindOwnersForPath(path string) string {
 func peopleForPath(path string, people map[string]sets.String, leafOnly bool, enableMdYaml bool) sets.String {
 	d := path
 	if !enableMdYaml {
-		// if path is a directory, this will remove the leaf directory
-		d = filepath.Dir(path)
+		// if path is a directory, this will remove the leaf directory, and returns "." for topmost dir
+		d = filepath.Dir(d)
+		d = canonicalize(path)
 	}
 
 	out := sets.NewString()
 	for {
-		// special case the root
-		if d == "" {
-			d = "/"
-		}
 		s, ok := people[d]
 		if ok {
 			out = out.Union(s)
@@ -306,11 +308,11 @@ func peopleForPath(path string, people map[string]sets.String, leafOnly bool, en
 				break
 			}
 		}
-		if d == "/" {
+		if d == baseDirConvention {
 			break
 		}
-		d, _ = filepath.Split(d)
-		d = strings.TrimSuffix(d, "/")
+		d = filepath.Dir(d)
+		d = canonicalize(d)
 	}
 	return out
 }

--- a/mungegithub/features/repo-updates_test.go
+++ b/mungegithub/features/repo-updates_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/golang/glog"
+	"github.com/google/go-github/github"
+)
+
+var (
+	_ = fmt.Printf
+	_ = glog.Errorf
+)
+
+const (
+	baseDir        = ""
+	leafDir        = "a/b/c"
+	nonExistentDir = "DELETED_DIR"
+)
+
+// Commit returns a filled out github.Commit which happened at time.Unix(t, 0)
+func getTestRepo() *RepoInfo {
+	testRepo := RepoInfo{BaseDir: baseDir, EnableMdYaml: false, UseReviewers: false}
+	approvers := map[string]sets.String{}
+	baseApprovers := sets.NewString("Alice", "Bob")
+	leafApprovers := sets.NewString("Carl", "Dave")
+	approvers[baseDir] = baseApprovers
+	approvers[leafDir] = leafApprovers
+	testRepo.approvers = approvers
+
+	return &testRepo
+}
+
+func TestGetApprovers(t *testing.T) {
+	testFile0 := filepath.Join(baseDir, "testFile.md")
+	testFile1 := filepath.Join(leafDir, "testFile.md")
+	testFile2 := filepath.Join(nonExistentDir, "testFile.md")
+	TestRepo := getTestRepo()
+	tests := []struct {
+		testName           string
+		testFile           *github.CommitFile
+		expectedOwnersPath string
+		expectedLeafOwners sets.String
+		expectedAllOwners  sets.String
+	}{
+		{
+			testName:           "Modified Base Dir Only",
+			testFile:           &github.CommitFile{Filename: &testFile0},
+			expectedOwnersPath: baseDir,
+			expectedLeafOwners: TestRepo.approvers[baseDir],
+			expectedAllOwners:  TestRepo.approvers[baseDir],
+		},
+		{
+			testName:           "Modified Leaf Dir Only",
+			testFile:           &github.CommitFile{Filename: &testFile1},
+			expectedOwnersPath: leafDir,
+			expectedLeafOwners: TestRepo.approvers[leafDir],
+			expectedAllOwners:  TestRepo.approvers[leafDir].Union(TestRepo.approvers[baseDir]),
+		},
+		{
+			testName:           "Modified Nonexistent Dir (Default to Base)",
+			testFile:           &github.CommitFile{Filename: &testFile2},
+			expectedOwnersPath: baseDir,
+			expectedLeafOwners: TestRepo.approvers[baseDir],
+			expectedAllOwners:  TestRepo.approvers[baseDir],
+		},
+	}
+	for testNum, test := range tests {
+		foundLeafApprovers := TestRepo.LeafApprovers(*test.testFile.Filename)
+		foundApprovers := TestRepo.Approvers(*test.testFile.Filename)
+		foundOwnersPath := TestRepo.FindOwnersForPath(*test.testFile.Filename)
+		if !foundLeafApprovers.Equal(test.expectedLeafOwners) {
+			t.Errorf("The Leaf Approvers Found Do Not Match Expected For Test %d: %s", testNum, test.testName)
+			t.Errorf("\tExpected Owners: %v\tFound Owners: %v ", test.expectedLeafOwners, foundLeafApprovers)
+		}
+		if !foundApprovers.Equal(test.expectedAllOwners) {
+			t.Errorf("The Approvers Found Do Not Match Expected For Test %d: %s", testNum, test.testName)
+			t.Errorf("\tExpected Owners: %v\tFound Owners: %v ", test.expectedAllOwners, foundApprovers)
+		}
+		if foundOwnersPath != test.expectedOwnersPath {
+			t.Errorf("The Owners Path Found Does Not Match Expected For Test %d: %s", testNum, test.testName)
+			t.Errorf("\tExpected Owners: %v\tFound Owners: %v ", test.expectedOwnersPath, foundOwnersPath)
+		}
+	}
+}
+
+func TestCanonical(t *testing.T) {
+
+	tests := []struct {
+		testName     string
+		inputPath    string
+		expectedPath string
+	}{
+		{
+			testName:     "Empty String",
+			inputPath:    "",
+			expectedPath: "",
+		},
+		{
+			testName:     "Dot (.) as Path",
+			inputPath:    ".",
+			expectedPath: "",
+		},
+		{
+			testName:     "Github Style Input (No Root)",
+			inputPath:    "a/b/c/d.txt",
+			expectedPath: "a/b/c/d.txt",
+		},
+		{
+			testName:     "Preceding Slash and Trailing Slash",
+			inputPath:    "/a/b/",
+			expectedPath: "/a/b",
+		},
+		{
+			testName:     "Trailing Slash",
+			inputPath:    "foo/bar/baz/",
+			expectedPath: "foo/bar/baz",
+		},
+	}
+	for _, test := range tests {
+		if test.expectedPath != canonicalize(test.inputPath) {
+			t.Errorf("Expected the canonical path for %v to be %v.  Found %v instead", test.inputPath, test.expectedPath, canonicalize(test.inputPath))
+		}
+	}
+}

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -305,6 +305,16 @@ func (obj *MungeObject) Number() int {
 	return *obj.Issue.Number
 }
 
+// Project is getter for obj.config.Project
+func (obj *MungeObject) Project() string {
+	return obj.config.Project
+}
+
+// Org is getter for obj.config.Org
+func (obj *MungeObject) Org() string {
+	return obj.config.Org
+}
+
 // DebugStats is a structure that tells information about how we have interacted
 // with github
 type DebugStats struct {

--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -19,10 +19,12 @@ package mungers
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
 	githubapi "github.com/google/go-github/github"
 	"github.com/spf13/cobra"
 
@@ -35,6 +37,8 @@ import (
 const (
 	approvalNotificationName = "ApprovalNotifier"
 	approveCommand           = "approve"
+	cancel                   = "cancel"
+	ownersFileName           = "OWNERS"
 )
 
 // ApprovalHandler will try to add "approved" label once
@@ -120,6 +124,7 @@ func (h *ApprovalHandler) updateNotification(obj *github.MungeObject, ownersMap 
 	if !ok {
 		return fmt.Errorf("Unable to ListComments for %d", obj.Number())
 	}
+
 	notifications := c.FilterComments(comments, notificationMatcher)
 	latestNotification := notifications.GetLast()
 	if latestNotification == nil {
@@ -134,6 +139,7 @@ func (h *ApprovalHandler) updateNotification(obj *github.MungeObject, ownersMap 
 	if latestApprove.CreatedAt.After(*latestNotification.CreatedAt) {
 		// if we can't tell when latestApprove happened, we should make a new one
 		obj.DeleteComment(latestNotification)
+		glog.Infof("Latest approve was after last time notified")
 		return h.createMessage(obj, ownersMap)
 	}
 	lastModified, ok := obj.LastModifiedTime()
@@ -142,20 +148,26 @@ func (h *ApprovalHandler) updateNotification(obj *github.MungeObject, ownersMap 
 	}
 	if latestNotification.CreatedAt.Before(*lastModified) {
 		obj.DeleteComment(latestNotification)
+		glog.Infof("PR Modified After Last Notification")
 		return h.createMessage(obj, ownersMap)
 	}
 	return nil
 }
 
-// findApproverSet Takes all the Owners Files that Are Needed for the PR and chooses a good
-// subset of Approvers that are guaranteed to be from all of them (exact cover)
+// findPeopleToApprove Takes the Owners Files that Are Needed for the PR and chooses a good
+// subset of Approvers that are guaranteed to cover all of them (exact cover)
 // This is a greedy approximation and not guaranteed to find the minimum number of OWNERS
-func (h ApprovalHandler) findApproverSet(ownersPath sets.String) sets.String {
+func (h ApprovalHandler) findPeopleToApprove(ownersPaths sets.String, prAuthor string) sets.String {
 
 	// approverCount contains a map: person -> set of relevant OWNERS file they are in
 	approverCount := make(map[string]sets.String)
-	for ownersFile := range ownersPath {
-		for approver := range h.features.Repos.LeafApprovers(ownersFile) {
+	for ownersFile := range ownersPaths {
+		// LeafApprovers removes the last part of a path for dirs and files, so we append owners to the path
+		for approver := range h.features.Repos.LeafApprovers(filepath.Join(ownersFile, ownersFileName)) {
+			if approver == prAuthor {
+				// don't add the author of the PR to the list of candidates that can approve
+				continue
+			}
 			if _, ok := approverCount[approver]; ok {
 				approverCount[approver].Insert(ownersFile)
 			} else {
@@ -165,14 +177,14 @@ func (h ApprovalHandler) findApproverSet(ownersPath sets.String) sets.String {
 	}
 
 	copyOfFiles := sets.NewString()
-	for fn := range ownersPath {
+	for fn := range ownersPaths {
 		copyOfFiles.Insert(fn)
 	}
 
 	approverGroup := sets.NewString()
+	var bestPerson string
 	for copyOfFiles.Len() > 0 {
 		maxCovered := 0
-		var bestPerson string
 		for k, v := range approverCount {
 			if v.Intersection(copyOfFiles).Len() > maxCovered {
 				maxCovered = len(v)
@@ -181,9 +193,39 @@ func (h ApprovalHandler) findApproverSet(ownersPath sets.String) sets.String {
 		}
 
 		approverGroup.Insert(bestPerson)
-		copyOfFiles.Delete(approverCount[bestPerson].List()...)
+		toDelete := sets.NewString()
+		// remove all files in the directories that our approver approved AND
+		// in the subdirectories that s/he approved.  HasPrefix finds subdirs
+		for fn := range copyOfFiles {
+			for approvedFile := range approverCount[bestPerson] {
+				if strings.HasPrefix(fn, approvedFile) {
+					toDelete.Insert(fn)
+				}
+
+			}
+		}
+		copyOfFiles.Delete(toDelete.List()...)
 	}
 	return approverGroup
+}
+
+// removeSubdirs takes a list of directories as an input and returns a set of directories with all
+// subdirectories removed.  E.g. [/a,/a/b/c,/d/e,/d/e/f] -> [/a, /d/e]
+func removeSubdirs(dirList []string) sets.String {
+	toDel := sets.String{}
+	for i := 0; i < len(dirList)-1; i++ {
+		for j := i + 1; j < len(dirList); j++ {
+			// ex /a/b has prefix /a so if remove /a/b since its already covered
+			if strings.HasPrefix(dirList[i], dirList[j]) {
+				toDel.Insert(dirList[i])
+			} else if strings.HasPrefix(dirList[j], dirList[i]) {
+				toDel.Insert(dirList[j])
+			}
+		}
+	}
+	finalSet := sets.NewString(dirList...)
+	finalSet.Delete(toDel.List()...)
+	return finalSet
 }
 
 func (h *ApprovalHandler) createMessage(obj *github.MungeObject, ownersMap map[string]sets.String) error {
@@ -201,7 +243,9 @@ func (h *ApprovalHandler) createMessage(obj *github.MungeObject, ownersMap map[s
 	for _, path := range sliceOfKeys {
 		approverSet := ownersMap[path]
 		if approverSet.Len() == 0 {
-			context.WriteString(fmt.Sprintf("- **%s**\n", path))
+			fullOwnersPath := filepath.Join(path, ownersFileName)
+			link := fmt.Sprintf("https://github.com/%s/%s/blob/master/%v", obj.Org(), obj.Project(), fullOwnersPath)
+			context.WriteString(fmt.Sprintf("- **[%s](%s)** \n", fullOwnersPath, link))
 			unapprovedOwners.Insert(path)
 		} else {
 			context.WriteString(fmt.Sprintf("- ~~%s~~ [%v]\n", path, strings.Join(approverSet.List(), ",")))
@@ -211,14 +255,14 @@ func (h *ApprovalHandler) createMessage(obj *github.MungeObject, ownersMap map[s
 	if unapprovedOwners.Len() > 0 {
 		context.WriteString("We suggest the following people:\n")
 		context.WriteString("cc ")
-		toBeAssigned := h.findApproverSet(unapprovedOwners)
+		toBeAssigned := h.findPeopleToApprove(unapprovedOwners, *obj.Issue.User.Login)
 		for person := range toBeAssigned {
 			context.WriteString("@" + person + " ")
 		}
 	}
 	context.WriteString("\n You can indicate your approval by writing `/approve` in a comment")
-	context.WriteString("\n You can cancel your approval by writing `/approve cancel`in a comment")
-	return c.Notification{approvalNotificationName, "The Following OWNERS Files Need Approval:\n", context.String()}.Post(obj)
+	context.WriteString("\n You can cancel your approval by writing `/approve cancel` in a comment")
+	return c.Notification{approvalNotificationName, "Needs approval from an approver in each of these OWNERS Files:\n", context.String()}.Post(obj)
 }
 
 // createApproverSet iterates through the list of comments on a PR
@@ -231,7 +275,7 @@ func createApproverSet(comments []*githubapi.IssueComment) sets.String {
 	approverMatcher := c.CommandName(approveCommand)
 	for _, comment := range c.FilterComments(comments, approverMatcher) {
 		cmd := c.ParseCommand(comment)
-		if cmd.Arguments == "cancel" {
+		if cmd.Arguments == cancel {
 			approverSet.Delete(*comment.User.Login)
 		} else {
 			approverSet.Insert(*comment.User.Login)
@@ -241,12 +285,27 @@ func createApproverSet(comments []*githubapi.IssueComment) sets.String {
 }
 
 // getApprovedOwners finds all the relevant OWNERS files for the PRs and identifies all the people from them
-// that have approved the PR
+// that have approved the PR.  For all files that have not been approved, it finds the minimum number of owners files
+// that cover all of them.  E.g. If /a/b/c.txt and /a/d.txt need approval, it will only indicate that an approval from
+// someone in /a/OWNERS is needed
 func (h ApprovalHandler) getApprovedOwners(files []*githubapi.CommitFile, approverSet sets.String) map[string]sets.String {
 	ownersApprovers := make(map[string]sets.String)
+	// TODO: go through the files starting at the top of the tree
+	needsApproval := sets.NewString()
 	for _, file := range files {
 		fileOwners := h.features.Repos.Approvers(*file.Filename)
-		ownersApprovers[h.features.Repos.FindOwnersForPath(*file.Filename)] = fileOwners.Intersection(approverSet)
+		ownersFile := h.features.Repos.FindOwnersForPath(*file.Filename)
+		hasApproved := fileOwners.Intersection(approverSet)
+		if len(hasApproved) != 0 {
+			ownersApprovers[ownersFile] = hasApproved
+		} else {
+			needsApproval.Insert(ownersFile)
+		}
+
+	}
+	needsApproval = removeSubdirs(needsApproval.List())
+	for fn := range needsApproval {
+		ownersApprovers[fn] = sets.NewString()
 	}
 	return ownersApprovers
 }


### PR DESCRIPTION
- Add link to OWNERS file in notification
- Show minimum set of OWNERS files needed
  for approval
- Make notification clearer
- Call LeafApprovers on full file, not just
  path, so correct owners file used
- Added tests for repo updates and removed "/"
  convention for root so files have same prefix
- Added canonical way to get filepath and
  tests for it