### PR TITLE
service-loadbalancer fails to build

### DIFF
--- a/service-loadbalancer/Dockerfile
+++ b/service-loadbalancer/Dockerfile
@@ -21,7 +21,7 @@ RUN for ERROR_CODE in 400 403 404 408 500 502 503 504;do curl -sSL -o /etc/hapro
 	https://raw.githubusercontent.com/haproxy/haproxy-1.5/master/examples/errorfiles/$ERROR_CODE.http;done
 
 # https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem
-RUN curl -o /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64 && \
+RUN curl -Lo /sbin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64 && \
   chmod +x /sbin/dumb-init
 
 ENTRYPOINT ["dumb-init", "/service_loadbalancer"]


### PR DESCRIPTION
Curl doesn't follow the redirect to S3 when downloading from Github releases.