### PR TITLE
SSL documentation improvements

### DIFF
--- a/ingress/controllers/nginx/README.md
+++ b/ingress/controllers/nginx/README.md
@@ -31,8 +31,8 @@ This is an nginx Ingress controller that uses [ConfigMap](https://github.com/kub
 ## Conventions
 
 Anytime we reference a tls secret, we mean (x509, pem encoded, RSA 2048, etc). You can generate such a certificate with: 
-`openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $(KEY) -out $(CERT) -subj "/CN=$(HOST)/O=$(HOST)"`
-and create the secret via `kubectl create secret tls --key file --cert file`
+`openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ${KEY_FILE} -out ${CERT_FILE} -subj "/CN=${HOST}/O=${HOST}"`
+and create the secret via `kubectl create secret tls ${CERT_NAME} --key ${KEY_FILE} --cert ${CERT_FILE}`
 
 
 
@@ -118,9 +118,9 @@ data:
   tls.key: base64 encoded key
 kind: Secret
 metadata:
-  name: testsecret
+  name: foo-secret
   namespace: default
-type: Opaque
+type: kubernetes.io/tls
 ```
 
 Referencing this secret in an Ingress will tell the Ingress controller to secure the channel from the client to the loadbalancer using TLS:
@@ -132,7 +132,7 @@ metadata:
   name: no-rules-map
 spec:
   tls:
-    secretName: testsecret
+    secretName: foo-secret
   backend:
     serviceName: s1
     servicePort: 80

--- a/ingress/controllers/nginx/examples/tls/README.md
+++ b/ingress/controllers/nginx/examples/tls/README.md
@@ -17,15 +17,7 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /t
 *Now store the SSL certificate in a secret:*
 
 ```
-echo "
-apiVersion: v1
-kind: Secret
-metadata:
-  name: foo-secret
-data:
-  tls.crt: `base64 /tmp/tls.crt`
-  tls.key: `base64 /tmp/tls.key`
-" | kubectl create -f -
+kubectl create secret tls foo-secret --key /tmp/tls.key --cert /tmp/tls.crt`
 ```
 
 *Finally create a tls Ingress rule:*


### PR DESCRIPTION
Minor documentation touch-up to add missing ```kubectl create``` option and synchronise secret objects spread-around in the documentation.