### PR TITLE
Use default etcd port (2379) in systemd service

### DIFF
--- a/init/systemd/README.md
+++ b/init/systemd/README.md
@@ -4,7 +4,7 @@ What these give you
 These 'config' files default to launch a single master/node on the same system talking to each
 other via 127.0.0.1.
 
-They require that etcd be available at 127.0.0.1:4001.
+They require that etcd be available at 127.0.0.1:2379.
 
 Daemons may have multiple config files.  An example is that the scheduler will pull in 'config', 'apiserver', and 'scheduler'.  In that order.  Each file may overwrite the values of the previous file.  The 'config' file is sourced by all daemons.  The kube-apiserver config file is sourced by those daemons which must know how to reach the kube-apiserver.  Each daemon has its own config file for configuration specific to that daemon.
 

--- a/init/systemd/environ/apiserver
+++ b/init/systemd/environ/apiserver
@@ -14,7 +14,7 @@ KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1"
 # KUBELET_PORT="--kubelet-port=10250"
 
 # Comma separated list of nodes in the etcd cluster
-KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:4001"
+KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:2379,http://127.0.0.1:4001"
 
 # Address range to use for services
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"


### PR DESCRIPTION
etcd changed its default port to 2379. Update apiserver configuration
for systemd to add a etcd node listening in that port, and not removing
the previous one for a smooth transition.