### PR TITLE
ansible: temporarily fix skydns issues

### DIFF
--- a/ansible/roles/kubernetes-addons/templates/dns/skydns-rc.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/dns/skydns-rc.yaml.j2
@@ -82,7 +82,7 @@ spec:
         # command = "/kube2sky"
         - --domain={{ dns_domain }}
       - name: skydns
-        image: gcr.io/google_containers/skydns:2015-10-13-8c72f8c
+        image: gcr.io/google_containers/skydns:1.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in


### PR DESCRIPTION
The skydns images aren't able to be pulled for newer docker
clients because they are v1 images vs v2 images as can be
shown by [1]. We should really move to kubedns as is noted
in #2124, but here is a short term workaround.

[1] https://console.cloud.google.com/kubernetes/images/tags/skydns?location=GLOBAL&project=google-containers