### PR TITLE
Remove extra slash from SQ GitHub commit status URL

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -755,7 +755,7 @@ func (sq *SubmitQueue) SetMergeStatus(obj *github.MungeObject, reason string) {
 	status, ok := obj.GetStatus(sqContext)
 	if !ok || status == nil || *status.Description != reason {
 		state := reasonToState(reason)
-		url := fmt.Sprintf("http://submit-queue.k8s.io/#/prs/?prDisplay=%d&historyDisplay=%d", *obj.Issue.Number, *obj.Issue.Number)
+		url := fmt.Sprintf("http://submit-queue.k8s.io/#/prs?prDisplay=%d&historyDisplay=%d", *obj.Issue.Number, *obj.Issue.Number)
 		_ = obj.SetStatus(state, url, reason, sqContext)
 	}
 


### PR DESCRIPTION
The URL currently used by the SQ is subtly wrong: http://submit-queue.k8s.io/#/prs/?prDisplay=39137&historyDisplay=39137 goes to the queue tab. If we remove the slash after "prs", then http://submit-queue.k8s.io/#/prs?prDisplay=39137&historyDisplay=39137 goes to the PR details tab.

cc @saad-ali 