### PR TITLE
Cluster-autoscaler: support unready nodes in scale down

### DIFF
--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -87,7 +87,9 @@ var (
 	scaleDownDelay   = flag.Duration("scale-down-delay", 10*time.Minute,
 		"Duration from the last scale up to the time when CA starts to check scale down options")
 	scaleDownUnneededTime = flag.Duration("scale-down-unneeded-time", 10*time.Minute,
-		"How long the node should be unneeded before it is eligible for scale down")
+		"How long a node should be unneeded before it is eligible for scale down")
+	scaleDownUnreadyTime = flag.Duration("scale-down-unready-time", 20*time.Minute,
+		"How long an unready node should be unneeded before it is eligible for scale down")
 	scaleDownUtilizationThreshold = flag.Float64("scale-down-utilization-threshold", 0.5,
 		"Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down")
 	scaleDownTrialInterval = flag.Duration("scale-down-trial-interval", 1*time.Minute,
@@ -214,6 +216,7 @@ func run(_ <-chan struct{}) {
 		MaxEmptyBulkDelete:            *maxEmptyBulkDeleteFlag,
 		ScaleDownUtilizationThreshold: *scaleDownUtilizationThreshold,
 		ScaleDownUnneededTime:         *scaleDownUnneededTime,
+		ScaleDownUnreadyTime:          *scaleDownUnreadyTime,
 		MaxNodesTotal:                 *maxNodesTotal,
 		EstimatorName:                 *estimatorFlag,
 		ExpanderStrategy:              expanderStrategy,

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -288,7 +288,7 @@ func (csr *ClusterStateRegistry) calculateReadinessStats(currentTime time.Time) 
 
 	for _, node := range csr.nodes {
 		nodeGroup, errNg := csr.cloudProvider.NodeGroupForNode(node)
-		ready, _, errReady := getReadinessState(node)
+		ready, _, errReady := GetReadinessState(node)
 
 		// Node is most likely not autoscaled, however check the errors.
 		if reflect.ValueOf(nodeGroup).IsNil() {
@@ -306,11 +306,10 @@ func (csr *ClusterStateRegistry) calculateReadinessStats(currentTime time.Time) 
 	return perNodeGroup, total
 }
 
-// getReadinessState gets readiness state for the node
-func getReadinessState(node *apiv1.Node) (isNodeReady bool, lastTransitionTime time.Time, err error) {
+// GetReadinessState gets readiness state for the node
+func GetReadinessState(node *apiv1.Node) (isNodeReady bool, lastTransitionTime time.Time, err error) {
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == apiv1.NodeReady {
-
 			if condition.Status == apiv1.ConditionTrue {
 				return true, condition.LastTransitionTime.Time, nil
 			}

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -32,9 +32,9 @@ func TestOKWithScaleUp(t *testing.T) {
 	now := time.Now()
 
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
-	setReadyState(ng1_1, true, now.Add(-time.Minute))
+	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
-	setReadyState(ng2_1, true, now.Add(-time.Minute))
+	SetNodeReadyState(ng2_1, true, now.Add(-time.Minute))
 
 	provider := testprovider.NewTestCloudProvider(nil, nil)
 	provider.AddNodeGroup("ng1", 1, 10, 5)
@@ -63,9 +63,9 @@ func TestOKOneUnreadyNode(t *testing.T) {
 	now := time.Now()
 
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
-	setReadyState(ng1_1, true, now.Add(-time.Minute))
+	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
-	setReadyState(ng2_1, false, now.Add(-time.Minute))
+	SetNodeReadyState(ng2_1, false, now.Add(-time.Minute))
 
 	provider := testprovider.NewTestCloudProvider(nil, nil)
 	provider.AddNodeGroup("ng1", 1, 10, 1)
@@ -88,9 +88,9 @@ func TestMissingNodes(t *testing.T) {
 	now := time.Now()
 
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
-	setReadyState(ng1_1, true, now.Add(-time.Minute))
+	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
-	setReadyState(ng2_1, true, now.Add(-time.Minute))
+	SetNodeReadyState(ng2_1, true, now.Add(-time.Minute))
 
 	provider := testprovider.NewTestCloudProvider(nil, nil)
 	provider.AddNodeGroup("ng1", 1, 10, 5)
@@ -113,9 +113,9 @@ func TestToManyUnready(t *testing.T) {
 	now := time.Now()
 
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
-	setReadyState(ng1_1, false, now.Add(-time.Minute))
+	SetNodeReadyState(ng1_1, false, now.Add(-time.Minute))
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
-	setReadyState(ng2_1, false, now.Add(-time.Minute))
+	SetNodeReadyState(ng2_1, false, now.Add(-time.Minute))
 
 	provider := testprovider.NewTestCloudProvider(nil, nil)
 	provider.AddNodeGroup("ng1", 1, 10, 1)
@@ -138,7 +138,7 @@ func TestExpiredScaleUp(t *testing.T) {
 	now := time.Now()
 
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
-	setReadyState(ng1_1, true, now.Add(-time.Minute))
+	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
 
 	provider := testprovider.NewTestCloudProvider(nil, nil)
 	provider.AddNodeGroup("ng1", 1, 10, 5)
@@ -159,24 +159,6 @@ func TestExpiredScaleUp(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy(now))
 	assert.False(t, clusterstate.IsNodeGroupHealthy("ng1"))
-}
-
-func setReadyState(node *apiv1.Node, ready bool, lastTransition time.Time) {
-	if ready {
-		node.Status.Conditions = append(node.Status.Conditions,
-			apiv1.NodeCondition{
-				Type:               apiv1.NodeReady,
-				Status:             apiv1.ConditionTrue,
-				LastTransitionTime: metav1.Time{Time: lastTransition},
-			})
-	} else {
-		node.Status.Conditions = append(node.Status.Conditions,
-			apiv1.NodeCondition{
-				Type:               apiv1.NodeReady,
-				Status:             apiv1.ConditionFalse,
-				LastTransitionTime: metav1.Time{Time: lastTransition},
-			})
-	}
 }
 
 func TestRegisterScaleDown(t *testing.T) {
@@ -210,28 +192,28 @@ func TestUpcomingNodes(t *testing.T) {
 
 	// 6 nodes are expected to come.
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
-	setReadyState(ng1_1, true, now.Add(-time.Minute))
+	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
 	provider.AddNodeGroup("ng1", 1, 10, 7)
 	provider.AddNode("ng1", ng1_1)
 
 	// One node is expected to come. One node is unready for the long time
 	// but this should not make any differnece.
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
-	setReadyState(ng2_1, false, now.Add(-time.Minute))
+	SetNodeReadyState(ng2_1, false, now.Add(-time.Minute))
 	provider.AddNodeGroup("ng2", 1, 10, 2)
 	provider.AddNode("ng2", ng2_1)
 
 	// Two nodes are expected to come. One is just being started for the first time,
 	// the other one is not there yet.
 	ng3_1 := BuildTestNode("ng3-1", 1000, 1000)
-	setReadyState(ng3_1, false, now.Add(-time.Minute))
+	SetNodeReadyState(ng3_1, false, now.Add(-time.Minute))
 	ng3_1.CreationTimestamp = metav1.Time{Time: now.Add(-time.Minute)}
 	provider.AddNodeGroup("ng3", 1, 10, 2)
 	provider.AddNode("ng3", ng3_1)
 
 	// Nothing should be added here.
 	ng4_1 := BuildTestNode("ng4-1", 1000, 1000)
-	setReadyState(ng4_1, false, now.Add(-time.Minute))
+	SetNodeReadyState(ng4_1, false, now.Add(-time.Minute))
 	provider.AddNodeGroup("ng4", 1, 10, 1)
 	provider.AddNode("ng4", ng4_1)
 

--- a/cluster-autoscaler/utils.go
+++ b/cluster-autoscaler/utils.go
@@ -53,6 +53,9 @@ type AutoscalingContext struct {
 	// ScaleDownUnneededTime sets the duriation CA exepects a node to be unneded/eligible for removal
 	// before scaling down the node.
 	ScaleDownUnneededTime time.Duration
+	// ScaleDownUnreadyTime sets the duriation CA exepects an unready node to be unneded/eligible for removal
+	// before scaling down the node.
+	ScaleDownUnreadyTime time.Duration
 	// MaxNodesTotal sets the maximum number of nodes in the whole cluster
 	MaxNodesTotal int
 	// EstimatorName is the estimator used to estimate the number of needed nodes in scale up.

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -115,6 +115,7 @@ scale-down-delay
 scale-down-enabled
 scale-down-trial-interval
 scale-down-unneeded-time
+scale-down-unready-time
 scale-down-utilization-threshold
 scan-interval
 services-configmap


### PR DESCRIPTION
Use a different unneeded time threshold for unready nodes (to either allow debugging or make node/cluster healing faster).

Ref: #2228 #2229 

cc: @jszczepkowski @fgrzadkowski @piosz 