### PR TITLE
Cluster-autoscaler: add get nodes function to cloud provider interface

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -198,6 +198,11 @@ func (asg *Asg) Debug() string {
 	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(), asg.MaxSize())
 }
 
+// Nodes returns a list of all nodes that belong to this node group.
+func (asg *Asg) Nodes() ([]string, error) {
+	return asg.awsManager.GetAsgNodes(asg)
+}
+
 func buildAsg(value string, awsManager *AwsManager) (*Asg, error) {
 	tokens := strings.SplitN(value, ":", 3)
 	if len(tokens) != 3 {

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -65,4 +65,7 @@ type NodeGroup interface {
 
 	// Debug returns a string containing all information regarding this node group.
 	Debug() string
+
+	// Nodes returns a list of all nodes that belong to this node group.
+	Nodes() ([]string, error)
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -203,6 +203,11 @@ func (mig *Mig) Debug() string {
 	return fmt.Sprintf("%s (%d:%d)", mig.Id(), mig.MinSize(), mig.MaxSize())
 }
 
+// Nodes returns a list of all nodes that belong to this node group.
+func (mig *Mig) Nodes() ([]string, error) {
+	return mig.gceManager.GetMigNodes(mig)
+}
+
 func buildMig(value string, gceManager *GceManager) (*Mig, error) {
 	tokens := strings.SplitN(value, ":", 3)
 	if len(tokens) != 3 {

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -230,3 +230,20 @@ func (m *GceManager) regenerateCache() error {
 	m.migCache = newMigCache
 	return nil
 }
+
+// GetMigNodes returns mig nodes.
+func (m *GceManager) GetMigNodes(mig *Mig) ([]string, error) {
+	instances, err := m.service.InstanceGroupManagers.ListManagedInstances(mig.Project, mig.Zone, mig.Name).Do()
+	if err != nil {
+		return []string{}, err
+	}
+	result := make([]string, 0)
+	for _, instance := range instances.ManagedInstances {
+		_, _, name, err := ParseInstanceUrl(instance.Instance)
+		if err != nil {
+			return []string{}, err
+		}
+		result = append(result, name)
+	}
+	return result, nil
+}

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -186,3 +186,17 @@ func (tng *TestNodeGroup) Debug() string {
 
 	return fmt.Sprintf("%s target:%d min:%d max:%d", tng.id, tng.targetSize, tng.minSize, tng.maxSize)
 }
+
+// Nodes returns a list of all nodes that belong to this node group.
+func (tng *TestNodeGroup) Nodes() ([]string, error) {
+	tng.Lock()
+	defer tng.Unlock()
+
+	result := make([]string, 0)
+	for node, nodegroup := range tng.cloudProvider.nodes {
+		if nodegroup == tng.id {
+			result = append(result, node)
+		}
+	}
+	return result, nil
+}

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -37,6 +37,7 @@ func (f *FakeNodeGroup) IncreaseSize(delta int) error    { return nil }
 func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error { return nil }
 func (f *FakeNodeGroup) Id() string                      { return f.id }
 func (f *FakeNodeGroup) Debug() string                   { return f.id }
+func (f *FakeNodeGroup) Nodes() ([]string, error)        { return []string{}, nil }
 
 func makeNodeInfo(cpu int64, memory int64, pods int64) *schedulercache.NodeInfo {
 	node := &apiv1.Node{


### PR DESCRIPTION
This is needed to compare the list of nodes created by the cloud provider with the list of nodes registered in Kubernetes.

Ref: #2228 #2229

cc: @jszczepkowski @andrewsykim @piosz @fgrzadkowski 