### PR TITLE
Updates the TempFile Location from NGINX Ingress Controller

### DIFF
--- a/ingress/controllers/nginx/nginx/ssl.go
+++ b/ingress/controllers/nginx/nginx/ssl.go
@@ -36,7 +36,7 @@ func (nginx *Manager) AddOrUpdateCertAndKey(name string, cert string, key string
 	temporaryPemFileName := fmt.Sprintf("%v.pem", name)
 	pemFileName := fmt.Sprintf("%v/%v.pem", config.SSLDirectory, name)
 
-	temporaryPemFile, err := ioutil.TempFile("", temporaryPemFileName)
+	temporaryPemFile, err := ioutil.TempFile(config.SSLDirectory, temporaryPemFileName)
 	if err != nil {
 		return ingress.SSLCert{}, fmt.Errorf("Couldn't create temp pem file %v: %v", temporaryPemFile.Name(), err)
 	}


### PR DESCRIPTION
This commit updates the TempFile Location from SSL Certificates. This is necessary, as the os.Rename directive doesn't work on different mount points.

As this program is being used also on bare metal machines (and not only containers), the temp file should be created on the same directory of the final SSL certificates.