### PR TITLE
ansible: restore selinux to enforcing

### DIFF
--- a/ansible/roles/kubernetes-addons/templates/cluster-logging/es-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-logging/es-controller.yaml.j2
@@ -41,3 +41,6 @@ spec:
       volumes:
       - name: es-persistent-storage
         emptyDir: {}
+      securityContext:
+        seLinuxOptions:
+          type: spc_t

--- a/ansible/roles/kubernetes-addons/templates/cluster-logging/fluentd-es-ds.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-logging/fluentd-es-ds.yaml.j2
@@ -42,3 +42,6 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      securityContext:
+        seLinuxOptions:
+          type: spc_t

--- a/ansible/roles/kubernetes-addons/templates/cluster-logging/kibana-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-logging/kibana-controller.yaml.j2
@@ -35,3 +35,6 @@ spec:
         - containerPort: 5601
           name: ui
           protocol: TCP
+      securityContext:
+        seLinuxOptions:
+          type: spc_t

--- a/ansible/roles/kubernetes-addons/templates/cluster-monitoring/heapster-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-monitoring/heapster-controller.yaml.j2
@@ -106,4 +106,7 @@ spec:
             - --deployment=heapster-v1.0.2
             - --container=eventer
             - --poll-period=300000
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
 

--- a/ansible/roles/kubernetes-addons/templates/cluster-monitoring/influxdb-grafana-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/cluster-monitoring/influxdb-grafana-controller.yaml.j2
@@ -71,4 +71,6 @@ spec:
         emptyDir: {}
       - name: grafana-persistent-storage
         emptyDir: {}
-
+      securityContext:
+        seLinuxOptions:
+          type: spc_t

--- a/ansible/roles/kubernetes-addons/templates/dns/skydns-rc.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/dns/skydns-rc.yaml.j2
@@ -127,3 +127,6 @@ spec:
       - name: etcd-storage
         emptyDir: {}
       dnsPolicy: Default  # Don't use cluster DNS.
+      securityContext:
+        seLinuxOptions:
+          type: spc_t

--- a/ansible/roles/kubernetes-addons/templates/kube-dash/kube-dash-rc.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-dash/kube-dash-rc.yaml.j2
@@ -37,4 +37,7 @@
             name: "ssl-certs"
             hostPath:
               path: "/etc/ssl/certs"
+    securityContext:
+        seLinuxOptions:
+          type: spc_t
 

--- a/ansible/roles/kubernetes-addons/templates/kube-ui/dashboard-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-ui/dashboard-controller.yaml.j2
@@ -39,3 +39,6 @@ spec:
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
+    securityContext:
+        seLinuxOptions:
+          type: spc_t

--- a/ansible/roles/node/tasks/install.yml
+++ b/ansible/roles/node/tasks/install.yml
@@ -6,10 +6,6 @@
 - include: ubuntu-14.04.yml
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 15
 
-- name: Set selinux permissive because tokens and selinux don't work together
-  selinux: state=permissive policy={{ ansible_selinux.type }}
-  when: ansible_selinux is defined and ansible_selinux.status == "enabled"
-
 - name: Retrieve systemd files for github-release kube_source_type type
   include: retrieve-systemd-files.yml
   when: kube_source_type == "github-release" or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int == 16)


### PR DESCRIPTION
Rather than setting selinux to permissive on all nodes, leave selinux enforcing and specify the unconfined spc_t container type for the kube-addons containers. For more on spc_t, see: http://danwalsh.livejournal.com/74754.html. See also https://github.com/kubernetes/kubernetes/pull/37327.

I tested this with centos atomic host.