### PR TITLE
SQ: Add kops-aws back to blocking

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -19,7 +19,8 @@ data:
     \"Jenkins GCE Node e2e\",\
     \"Jenkins Kubemark GCE e2e\",\
     \"Jenkins GCE etcd3 e2e\",\
-    \"Jenkins Bazel Build\""
+    \"Jenkins Bazel Build\",\
+    \"Jenkins kops AWS e2e\""
 
   submit-queue.protected-branches: "master"
   submit-queue.protected-branches-extra-contexts: "cla/linuxfoundation"
@@ -154,19 +155,19 @@ data:
     ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-gci-kubectl-skew,\
     ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster,\
     ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gce-1.4-1.5-upgrade-master,\
-    ci-kubernetes-e2e-kops-aws"
+    ci-kubernetes-e2e-gce-1.4-1.5-upgrade-master"
   submit-queue.jenkins-jobs: "\
     ci-kubernetes-build,\
     ci-kubernetes-e2e-gce-etcd3,\
     ci-kubernetes-e2e-gci-gce,\
     ci-kubernetes-e2e-gci-gce-slow,\
+    ci-kubernetes-e2e-gci-gce-ingress,\
     ci-kubernetes-e2e-gci-gke,\
     ci-kubernetes-e2e-gci-gke-slow,\
+    ci-kubernetes-e2e-kops-aws,\
     ci-kubernetes-kubemark-500-gce,\
     ci-kubernetes-node-kubelet,\
     ci-kubernetes-test-go,\
-    ci-kubernetes-e2e-gci-gce-ingress,\
     ci-kubernetes-verify-master"
   submit-queue.presubmit-jobs: "\
     kubernetes-pull-build-test-e2e-gce,\

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -12,7 +12,14 @@ data:
   config.token-file: /etc/secret-volume/token
 
   # test-options feature options.
-  test-options.required-retest-contexts: "\"Jenkins GCE e2e\",\"Jenkins unit/integration\",\"Jenkins verification\",\"Jenkins GCE Node e2e\",\"Jenkins Kubemark GCE e2e\",\"Jenkins GCE etcd3 e2e\",\"Jenkins Bazel Build\""
+  test-options.required-retest-contexts: "\
+    \"Jenkins GCE e2e\",\
+    \"Jenkins unit/integration\",\
+    \"Jenkins verification\",\
+    \"Jenkins GCE Node e2e\",\
+    \"Jenkins Kubemark GCE e2e\",\
+    \"Jenkins GCE etcd3 e2e\",\
+    \"Jenkins Bazel Build\""
 
   submit-queue.protected-branches: "master"
   submit-queue.protected-branches-extra-contexts: "cla/linuxfoundation"


### PR DESCRIPTION
Since I attempted this last, we have..
- logging on Up failures as well
- An AWS resource janitor to make sure we don't explode completely

This is a follow-on to kubernetes/test-infra#1471, which reenables reporting of the PR builder. ~~I'm waiting for the latest failure to finish clearing before merging that one, and I'll wait for the PR builder to go (more) green before merging this. (The `kops-aws-updown` job has cleared already, the `kops-aws` job should be green in the next half hour.)~~

I'd like to get this into blocking today, since basically after every weekend I end up fighting the next breakage in `kops-aws`.

Along the way: Reformat `required-retest-contexts` as well (separate commit).