### PR TITLE
Cluster-autoscaler: add stop channel to listers

### DIFF
--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -146,10 +146,11 @@ func run(_ <-chan struct{}) {
 	if err != nil {
 		glog.Fatalf("Failed to create predicate checker: %v", err)
 	}
-	unschedulablePodLister := kube_util.NewUnschedulablePodLister(kubeClient, apiv1.NamespaceAll)
-	scheduledPodLister := kube_util.NewScheduledPodLister(kubeClient)
-	readyNodeLister := kube_util.NewReadyNodeLister(kubeClient)
-	allNodeLister := kube_util.NewAllNodeLister(kubeClient)
+	stopchannel := make(chan struct{})
+	unschedulablePodLister := kube_util.NewUnschedulablePodLister(kubeClient, stopchannel)
+	scheduledPodLister := kube_util.NewScheduledPodLister(kubeClient, stopchannel)
+	readyNodeLister := kube_util.NewReadyNodeLister(kubeClient, stopchannel)
+	allNodeLister := kube_util.NewAllNodeLister(kubeClient, stopchannel)
 
 	lastScaleUpTime := time.Now()
 	lastScaleDownFailedTrial := time.Now()


### PR DESCRIPTION
So that the whole CA loop can be easily stopped and restarted with new settings. This will be handy for ConfigMap PR: https://github.com/kubernetes/contrib/pull/2226