### PR TITLE
Fix StatefulSets: Zookeeper pod affinity

### DIFF
--- a/statefulsets/zookeeper/zookeeper.yaml
+++ b/statefulsets/zookeeper/zookeeper.yaml
@@ -54,7 +54,7 @@ spec:
         scheduler.alpha.kubernetes.io/affinity: >
             {
               "podAntiAffinity": {
-                "requiredDuringSchedulingRequiredDuringExecution": [{
+                "requiredDuringSchedulingIgnoredDuringExecution": [{
                   "labelSelector": {
                     "matchExpressions": [{
                       "key": "app",


### PR DESCRIPTION
According to docs, `requiredDuringSchedulingRequiredDuringExecution`
not yet implemented. Not working in 1.5.1.