### PR TITLE
Enabled approvers and turned of cache for contrib

### DIFF
--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -4,10 +4,10 @@ metadata:
   name: contrib-sq-config
 data:
   # basic config options.
-  config.http-cache-dir: /cache/httpcache
+  config.http-cache-dir:
   config.organization: kubernetes
   config.project: contrib
-  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,needs-rebase
+  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,needs-rebase,approval-handler
   config.state: open
   config.token-file: /etc/secret-volume/token
   gitrepo.repo-dir: /gitrepos
@@ -50,4 +50,4 @@ data:
   alias.alias-file: "/gitrepos/contrib/OWNERS_ALIASES"
 
   # Temporary gate approval process
-  approval-activated: "false"
+  approval-activated: "true"


### PR DESCRIPTION
Looks like the http cache was responsible for the duplicate comments on contrib as ListComments() was returning an empty set of Comments on Issues where the bot had commented before.  This is not a permanent/good solution as we will hit the github rate limit on kubernetes/kubernetes but for the purposes of testing on contrib, it may be okay.

*Verified that the bot is no longer double commenting on PRs