### PR TITLE
Allow new/changed scripts to run again

### DIFF
--- a/startup-script/manage-startup-script.sh
+++ b/startup-script/manage-startup-script.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-CHECKPOINT_PATH="${CHECKPOINT_PATH:-/tmp/startup-script.kubernetes.io}"
+CHECKPOINT_PATH="${CHECKPOINT_PATH:-/tmp/startup-script.kubernetes.io_$(md5sum <<<"${STARTUP_SCRIPT}" | cut -c-32)}"
 CHECK_INTERVAL_SECONDS="30"
 EXEC=(nsenter -t 1 -m -u -i -n -p --)
 


### PR DESCRIPTION
Small change that allows to change scripts at node runtime and have
them run "again" without the need to manually change or remove $CHECKPOINT_PATH.