### PR TITLE
Fix issue when "ingress.kubernetes.io/limit-rps" enabled in annotations

### DIFF
--- a/ingress/controllers/nginx/nginx/ratelimit/main.go
+++ b/ingress/controllers/nginx/nginx/ratelimit/main.go
@@ -119,7 +119,7 @@ func ParseAnnotations(ing *extensions.Ingress) (*RateLimit, error) {
 		RPS: Zone{
 			Name:       fmt.Sprintf("%v_rps", zoneName),
 			Limit:      rps,
-			Burst:      conn * defBurst,
+			Burst:      rps * defBurst,
 			SharedSize: defSharedSize,
 		},
 	}, nil

--- a/ingress/controllers/nginx/nginx/template/template.go
+++ b/ingress/controllers/nginx/nginx/template/template.go
@@ -293,10 +293,10 @@ func buildRateLimitZones(input interface{}) []string {
 			}
 
 			if loc.RateLimit.RPS.Limit > 0 {
-				zone := fmt.Sprintf("limit_conn_zone $binary_remote_addr zone=%v:%vm rate=%vr/s;",
-					loc.RateLimit.Connections.Name,
-					loc.RateLimit.Connections.SharedSize,
-					loc.RateLimit.Connections.Limit)
+				zone := fmt.Sprintf("limit_req_zone $binary_remote_addr zone=%v:%vm rate=%vr/s;",
+					loc.RateLimit.RPS.Name,
+					loc.RateLimit.RPS.SharedSize,
+					loc.RateLimit.RPS.Limit)
 				zones = append(zones, zone)
 			}
 		}
@@ -323,7 +323,7 @@ func buildRateLimit(input interface{}) []string {
 
 	if loc.RateLimit.RPS.Limit > 0 {
 		limit := fmt.Sprintf("limit_req zone=%v burst=%v nodelay;",
-			loc.RateLimit.Connections.Name, loc.RateLimit.Connections.Burst)
+			loc.RateLimit.RPS.Name, loc.RateLimit.RPS.Burst)
 		limits = append(limits, limit)
 	}
 


### PR DESCRIPTION
For RPS it should use limit_req_zone.

Signed-off-by: Tang Le <at28997146@163.com>