### PR TITLE
Don't cache results across function calls for ListComments

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -1857,7 +1857,7 @@ func (obj *MungeObject) ListReviewComments() ([]*github.PullRequestComment, bool
 type WithListOpt func(*github.IssueListCommentsOptions) *github.IssueListCommentsOptions
 
 // ListComments returns all comments for the issue/PR in question
-func (obj *MungeObject) ListComments(withListOpts ...WithListOpt) ([]*github.IssueComment, bool) {
+func (obj *MungeObject) ListComments() ([]*github.IssueComment, bool) {
 	config := obj.config
 	issueNum := *obj.Issue.Number
 	allComments := []*github.IssueComment{}
@@ -1867,9 +1867,6 @@ func (obj *MungeObject) ListComments(withListOpts ...WithListOpt) ([]*github.Iss
 	}
 
 	listOpts := &github.IssueListCommentsOptions{ListOptions: github.ListOptions{PerPage: 100}}
-	for _, withListOpt := range withListOpts {
-		listOpts = withListOpt(listOpts)
-	}
 
 	page := 1
 	// Try to work around not finding comments--suspect some cache invalidation bug when the number of pages changes.


### PR DESCRIPTION
So good news, I found the problem with ListComments and it wasn't with the httpcache, with github's api, or the approval handler.

Turns out we had implemented an incorrect cache in the ListComments wrapper, and it was returning the result from call to the function with different options.

More Info:
1. The first time `ListComments` gets called in the approvers implementation (via `getCommentsAfterLastModified`) it has the since parameter set in the `IssueListCommentsOptions` 
1. The second time we call` ListComments()` with no parameters expecting ALL Comments on the PR but instead we get the results from the first call