### PR TITLE
Cluster-autoscaler: decrease target size function in cloud provider interface

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -121,6 +121,7 @@ func (m *AwsManager) SetAsgSize(asg *Asg, size int64) error {
 		DesiredCapacity:      aws.Int64(size),
 		HonorCooldown:        aws.Bool(false),
 	}
+	glog.V(0).Infof("Setting asg %s size to %d", asg.Id(), size)
 	_, err := m.service.SetDesiredCapacity(params)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -60,6 +60,13 @@ type NodeGroup interface {
 	// should wait until node group size is updated.
 	DeleteNodes([]*apiv1.Node) error
 
+	// DecreaseTargetSize decreases the target size of the node group. This function
+	// doesn't permit to delete any existing node and can be used only to reduce the
+	// request for new nodes that have not been yet fulfilled. Delta should be negative.
+	// It is assumed that cloud provider will not delete the existing nodes if the size
+	// when there is an option to just decrease the target.
+	DecreaseTargetSize(delta int) error
+
 	// Id returns an unique identifier of the node group.
 	Id() string
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -114,6 +114,7 @@ func (m *GceManager) GetMigSize(mig *Mig) (int64, error) {
 
 // SetMigSize sets MIG size.
 func (m *GceManager) SetMigSize(mig *Mig, size int64) error {
+	glog.V(0).Infof("Setting mig size %s to %d", mig.Id(), size)
 	op, err := m.service.InstanceGroupManagers.Resize(mig.Project, mig.Zone, mig.Name, size).Do()
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -154,6 +154,17 @@ func (tng *TestNodeGroup) IncreaseSize(delta int) error {
 	return tng.cloudProvider.onIncrease(tng.id, delta)
 }
 
+// DecreaseTargetSize decreases the target size of the node group. This function
+// doesn't permit to delete any existing node and can be used only to reduce the
+// request for new nodes that have not been yet fulfilled. Delta should be negative.
+func (tng *TestNodeGroup) DecreaseTargetSize(delta int) error {
+	tng.Lock()
+	tng.targetSize += delta
+	tng.Unlock()
+
+	return tng.cloudProvider.onIncrease(tng.id, delta)
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated.

--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -103,7 +103,7 @@ var (
 	maxTotalUnreadyPercentage   = flag.Float64("max-total-unready-percentage", 33, "Maximum percentage of unready nodes after which CA halts operations")
 	okTotalUnreadyCount         = flag.Int("ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
 	maxNodeProvisionTime        = flag.Duration("max-node-provision-time", 15*time.Minute, "Maximum time CA waits for node to be provisioned")
-	unregisteredNodeRemovalTime = flag.Duration("unregistered-node-removal-time", 5*time.Minute, "Time that CA waits before removing nodes that are not registered in Kubernetes")
+	unregisteredNodeRemovalTime = flag.Duration("unregistered-node-removal-time", 15*time.Minute, "Time that CA waits before removing nodes that are not registered in Kubernetes")
 
 	// AvailableEstimators is a list of available estimators.
 	AvailableEstimators = []string{BasicEstimatorName, BinpackingEstimatorName}

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -30,14 +30,15 @@ type FakeNodeGroup struct {
 	id string
 }
 
-func (f *FakeNodeGroup) MaxSize() int                    { return 2 }
-func (f *FakeNodeGroup) MinSize() int                    { return 1 }
-func (f *FakeNodeGroup) TargetSize() (int, error)        { return 2, nil }
-func (f *FakeNodeGroup) IncreaseSize(delta int) error    { return nil }
-func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error { return nil }
-func (f *FakeNodeGroup) Id() string                      { return f.id }
-func (f *FakeNodeGroup) Debug() string                   { return f.id }
-func (f *FakeNodeGroup) Nodes() ([]string, error)        { return []string{}, nil }
+func (f *FakeNodeGroup) MaxSize() int                       { return 2 }
+func (f *FakeNodeGroup) MinSize() int                       { return 1 }
+func (f *FakeNodeGroup) TargetSize() (int, error)           { return 2, nil }
+func (f *FakeNodeGroup) IncreaseSize(delta int) error       { return nil }
+func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error { return nil }
+func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error    { return nil }
+func (f *FakeNodeGroup) Id() string                         { return f.id }
+func (f *FakeNodeGroup) Debug() string                      { return f.id }
+func (f *FakeNodeGroup) Nodes() ([]string, error)           { return []string{}, nil }
 
 func makeNodeInfo(cpu int64, memory int64, pods int64) *schedulercache.NodeInfo {
 	node := &apiv1.Node{


### PR DESCRIPTION
Sometimes the cloud provider has troubles with providing the requested amount of nodes either due to quota or to (temporary) technical limitations. In such a case CA should be able to change the previously made request without killing any of the existing nodes. 

@andrewsykim - will this PR work on AWS?

cc: @jszczepkowski @andrewsykim @fgrzadkowski 