### PR TITLE
[ingress/controllers/nginx] Fix nginx ingress whitelist in config map

### DIFF
--- a/ingress/controllers/nginx/configuration.md
+++ b/ingress/controllers/nginx/configuration.md
@@ -306,6 +306,9 @@ The default mime type list to compress is: `application/atom+xml application/jav
 Responses with the "text/html" type are always compressed if `use-gzip` is enabled
 
 
+**whitelist-source-range:** Sets the default whitelisted IPs for each `server` block. This can be overwritten by an annotation on an Ingress
+
+
 **worker-processes:** Sets the number of [worker processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes). By default "auto" means number of available CPU cores
 
 
@@ -343,6 +346,7 @@ The next table shows the options, the default value and a description
 |use-gzip|"true"|
 |use-http2|"true"|
 |vts-status-zone-size|10m|
+|whitelist-source-range|permit all|
 |worker-processes|<number of CPUs>|
 
 

--- a/ingress/controllers/nginx/nginx/config/config.go
+++ b/ingress/controllers/nginx/nginx/config/config.go
@@ -263,7 +263,7 @@ type Configuration struct {
 
 	// WhitelistSourceRange allows limiting access to certain client addresses
 	// http://nginx.org/en/docs/http/ngx_http_access_module.html
-	WhitelistSourceRange []string `structs:"whitelist-source-range,omitempty"`
+	WhitelistSourceRange []string `structs:"whitelist-source-range,-"`
 
 	// Defines the number of worker processes. By default auto means number of available CPU cores
 	// http://nginx.org/en/docs/ngx_core_module.html#worker_processes


### PR DESCRIPTION
I was playing with the Nginx Ingress Controller and looking at using the `whitelist-source-range` annotation to restrict access to pods. The idea was that they would be "secure by default" by using the `whitelist-source-range` to the config map.

I forgot that source IPs are mangled on AWS and by default on other cloud providers so it didn't matter in the end.

This PR fixes the following error I found in the logs when trying to set the `whitelist-source-range` in the config map:
```
I0112 11:48:02.339121       1 utils.go:123] 1 error(s) decoding:

* 'whitelist-source-range': source data must be an array or slice, got string
```

Link to original feature PR #1141

I looked into the code and I could see why it was failing. I have kept the same style as the also undocumented `skip-access-log-urls`.

I've also documented `whitelist-source-range`. If this goes well, I'd be happy to update the docs for `skip-access-log-urls` and other options.

I hope I've followed the procedure correctly. This is my first contribution here.