### PR TITLE
Cluster Autoscaler: update AWS docs to include expansion options 

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/README.md
+++ b/cluster-autoscaler/cloudprovider/aws/README.md
@@ -1,5 +1,5 @@
 # Cluster Autoscaler on AWS
-The cluster autoscaler on AWS scales worker nodes within an autoscaling group. It will run as a `Deployment` in your cluster. This README will go over some of the necessary steps required to get the cluster autoscaler up and running.
+The cluster autoscaler on AWS scales worker nodes within any specified autoscaling group. It will run as a `Deployment` in your cluster. This README will go over some of the necessary steps required to get the cluster autoscaler up and running.
 
 ## Kubernetes Version
 Cluster autoscaler must run on v1.3.0 or greater.
@@ -26,13 +26,15 @@ The worker running the cluster autoscaler will need access to certain resources 
 Unfortunately AWS does not support ARNs for autoscaling groups yet so you must use "*" as the resource. More information [here](http://docs.aws.amazon.com/autoscaling/latest/userguide/IAM.html#UsingWithAutoScaling_Actions).
 
 ## Deployment Specification
-Your deployment configuration should look something like this:
+
+### 1 ASG Setup (min: 1, max: 10, ASG Name: k8s-worker-asg-1)
 ```yaml
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: cluster-autoscaler
+  namespace: kube-system
   labels:
     app: cluster-autoscaler
 spec:
@@ -46,7 +48,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-        - image: {{ YOUR IMAGE HERE }}
+        - image: gcr.io/google_containers/cluster-autoscaler:v0.4.0
           name: cluster-autoscaler
           resources:
             limits:
@@ -60,7 +62,7 @@ spec:
             - --v=4
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
-            - --nodes={{ ASG MIN e.g. 1 }}:{{ASG MAX e.g. 5}}:{{ASG NAME e.g. k8s-worker-asg}}
+            - --nodes=1:10:k8s-worker-asg-1
           env:
             - name: AWS_REGION
               value: us-east-1
@@ -74,6 +76,62 @@ spec:
           hostPath:
             path: "/etc/ssl/certs/ca-certificates.crt"
 ```
-Note:
+
+### Multiple ASG Setup
+```yaml
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      containers:
+        - image: gcr.io/google_containers/cluster-autoscaler:v0.4.0
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --expander=least-waste
+            - --nodes=1:10:k8s-worker-asg-1
+            - --nodes=1:3:k8s-worker-asg-2
+          env:
+            - name: AWS_REGION
+              value: us-east-1
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+          imagePullPolicy: "Always"
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-certificates.crt"
+```
+
+Common Notes and Gotchas:
 - The `/etc/ssl/certs/ca-certificates.crt` should exist by default on your ec2 instance.
-- The autoscaling group should span 1 availability zone for the cluster autoscaler to work. If you want to distribute workloads evenly across zones, set up multiple ASGs, with a cluster autoscaler for each ASG. At the time of writing this, cluster autoscaler is unaware of availability zones and although autoscaling groups can contain instances in multiple availability zones when configured so, the cluster autoscaler can't reliably add nodes to desired zones. That's because AWS AutoScaling determines which zone to add nodes which is out of the control of the cluster autoscaler. For more information, see https://github.com/kubernetes/contrib/pull/1552#discussion_r75533090.
+- Cluster autoscaler is not zone aware (for now), so if you wish to span multiple availability zones in your autoscaling groups beware that cluster autoscaler will not evenly distribute them. For more information, see https://github.com/kubernetes/contrib/pull/1552#discussion_r75533090.
+- By default, cluster autoscaler will not terminate nodes running pods in the kube-system namespace. You can override this default behaviour by passing in the `--skip-nodes-with-system-pods=false` flag.
+- By default, cluster autoscaler will wait 10 minutes between scale down operations, you can adjust this using the `--scale-down-delay` flag. E.g. `--scale-down-delay=5m` to decrease the scale down delay to 5 minutes.
+- If you're running multiple ASGs, the `--expander` flag supports three options: `random`, `most-pods` and `least-waste`. `random` will expand a random ASG on scale up. `most-pods` will scale up the ASG that will scheduable the most amount of pods. `least-waste` will expand the ASG that will waste the least amount of CPU/MEM resources. In the event of a tie, cluster autoscaler will fall back to `random`.


### PR DESCRIPTION
There seems to be some confusion among AWS users regarding how to setup cluster autoscaler with multiple node groups. 

/cc @mwielgus @osxi @mumoshu