### PR TITLE
ingress/controller/nginx: ensure redirect to HTTPS

### DIFF
--- a/ingress/controllers/nginx/nginx/rewrite/main_test.go
+++ b/ingress/controllers/nginx/nginx/rewrite/main_test.go
@@ -96,9 +96,13 @@ func TestAnnotations(t *testing.T) {
 
 func TestWithoutAnnotations(t *testing.T) {
 	ing := buildIngress()
-	_, err := ParseAnnotations(config.NewDefault(), ing)
+	redirect, err := ParseAnnotations(config.NewDefault(), ing)
 	if err == nil {
 		t.Error("Expected error with ingress without annotations")
+	}
+
+	if !redirect.SSLRedirect {
+		t.Errorf("Expected true but returned false")
 	}
 }
 


### PR DESCRIPTION
Currently, the Nginx ingress controller will not redirect requests to
HTTPS even if TLS is enabled for that ingress if the ingress has no
annotations. This commit corrects this behavior to ensure that reqests
are redirected to HTTPS as stated in the Nginx ingress controller
README.