### PR TITLE
Bump golang in travis to 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: go
 
 matrix:
   include:
-    - go: 1.6
+    - go: 1.7
 
 install:
   - mkdir -p $HOME/gopath/src/k8s.io


### PR DESCRIPTION
Kubernetes (which is a common dependency in contrib) needs go 1.7 to compile. Some files require core golang package "context" that is not present in 1.6.  

cc: @gmarek @fgrzadkowski 