### PR TITLE
Add Least-Cost Node Group Expander

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -139,12 +139,6 @@ func (asg *Asg) NodeCost() (float64, error) {
 		glog.V(4).Infof("Returning user-defined cost on NodeGroup %s: %+v", asg.Id(), asg.nodeCost)
 		return *asg.nodeCost, nil
 	}
-
-	if asg.launchConfig == nil {
-		if err := asg.awsManager.regenerateCache(); err != nil {
-			return 0, fmt.Errorf("Error while looking for LaunchConfiguration of ASG %s, error: %v", asg.Name, err)
-		}
-	}
 	cost, err := asg.awsManager.GetAsgSpotInstanceCost(asg)
 	if err != nil {
 		return 0, fmt.Errorf("Error calculating nodeCost: %v", err)

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -147,7 +147,7 @@ func TestNodeGroupForNode(t *testing.T) {
 		},
 	}
 	provider := testProvider(t, testAwsManager)
-	err := provider.addNodeGroup("1:5:test-asg")
+	err := provider.addNodeGroup("1:5:test-asg:0")
 	assert.NoError(t, err)
 	group, err := provider.NodeGroupForNode(node)
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -327,4 +327,11 @@ func TestBuildAsg(t *testing.T) {
 	assert.Equal(t, 111, asg.MinSize())
 	assert.Equal(t, 222, asg.MaxSize())
 	assert.Equal(t, "test-name", asg.Name)
+
+	asg, err = buildAsg("111:222:test-name:0.5", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 111, asg.MinSize())
+	assert.Equal(t, 222, asg.MaxSize())
+	assert.Equal(t, "test-name", asg.Name)
+	assert.Equal(t, 0.5, *asg.nodeCost)
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -229,7 +229,6 @@ func (m *AwsManager) GetAsgSpotInstanceCost(asgConfig *Asg) (float64, error) {
 				},
 			},
 		}
-		glog.Infof("describeSpotPriceParams: %v", describeSpotPriceParams)
 
 		ph, err := m.client.DescribeSpotPriceHistory(describeSpotPriceParams)
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -314,19 +314,19 @@ func (m *AwsManager) getAutoscalingGroup(name string) (*autoscaling.Group, error
 	return groups.AutoScalingGroups[0], nil
 }
 
-func (m *AwsManager) getLaunchConfiguration(name string) (*autoscaling.LaunchConfiguration, error) {
+func (m *AwsManager) getLaunchConfiguration(name *string) (*autoscaling.LaunchConfiguration, error) {
 	params := &autoscaling.DescribeLaunchConfigurationsInput{
 		LaunchConfigurationNames: []*string{name},
 	}
 	lcs, err := m.service.DescribeLaunchConfigurations(params)
 	if err != nil {
 		glog.V(4).Infof("Failed LC info request for %s: %v", name, err)
-		return err
+		return nil, err
 	}
 	if len(lcs.LaunchConfigurations) < 1 {
-		return fmt.Errorf("Unable to get first lc.LaunchConfiguration for %s", name)
+		return nil, fmt.Errorf("Unable to get first lc.LaunchConfiguration for %s", name)
 	}
-	return *lcs.LaunchConfigurations[0], nil
+	return lcs.LaunchConfigurations[0], nil
 }
 
 // GetAsgNodes returns Asg nodes.

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -44,6 +44,9 @@ type NodeGroup interface {
 	// MinSize returns minimum size of the node group.
 	MinSize() int
 
+	// NodeCost returns cost of each node within the node group.
+	NodeCost() (float64, error)
+
 	// TargetSize returns the current target size of the node group. It is possible that the
 	// number of nodes in Kubernetes is different at the moment but should be equal
 	// to Size() once everything stabilizes (new nodes finish startup and registration or

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -125,6 +125,14 @@ func (mig *Mig) MinSize() int {
 	return mig.minSize
 }
 
+// NodeCost returns cost per node within the node group.
+func (mig *Mig) NodeCost() (float64, error) {
+	if mig.nodeCost == nil {
+		return 0, nil
+	}
+	return *mig.nodeCost, nil
+}
+
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kuberentes.
 func (mig *Mig) TargetSize() (int, error) {

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -38,4 +38,12 @@ func TestBuildMig(t *testing.T) {
 	assert.Equal(t, 222, mig.MaxSize())
 	assert.Equal(t, "test-zone", mig.Zone)
 	assert.Equal(t, "test-name", mig.Name)
+
+	mig, err = buildMig("111:222:https://content.googleapis.com/compute/v1/projects/test-project/zones/test-zone/instanceGroups/test-name:1.5", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 111, mig.MinSize())
+	assert.Equal(t, 222, mig.MaxSize())
+	assert.Equal(t, "test-zone", mig.Zone)
+	assert.Equal(t, "test-name", mig.Name)
+	assert.Equal(t, 1.5, mig.NodeCost())
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -45,5 +45,7 @@ func TestBuildMig(t *testing.T) {
 	assert.Equal(t, 222, mig.MaxSize())
 	assert.Equal(t, "test-zone", mig.Zone)
 	assert.Equal(t, "test-name", mig.Name)
-	assert.Equal(t, 1.5, mig.NodeCost())
+	cost, err := mig.NodeCost()
+	assert.NoError(t, err)
+	assert.Equal(t, 1.5, cost)
 }

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -96,6 +96,7 @@ func (tcp *TestCloudProvider) AddNodeGroup(id string, min int, max int, size int
 		minSize:       min,
 		maxSize:       max,
 		targetSize:    size,
+		nodeCost:      0,
 	}
 }
 
@@ -114,6 +115,7 @@ type TestNodeGroup struct {
 	maxSize       int
 	minSize       int
 	targetSize    int
+	nodeCost      float64
 }
 
 // MaxSize returns maximum size of the node group.
@@ -130,6 +132,14 @@ func (tng *TestNodeGroup) MinSize() int {
 	defer tng.Unlock()
 
 	return tng.minSize
+}
+
+// NodeCost returns the price per node of the node group.
+func (tng *TestNodeGroup) NodeCost() (float64, error) {
+	tng.Lock()
+	defer tng.Unlock()
+
+	return tng.nodeCost, nil
 }
 
 // TargetSize returns the current target size of the node group. It is possible that the

--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -75,6 +75,8 @@ const (
 	MostPodsExpanderName = "most-pods"
 	// LeastWasteExpanderName selects a node group that leaves the least fraction of CPU and Memory
 	LeastWasteExpanderName = "least-waste"
+	// LeastCostExpanderName selects the node group with the lowest cost per node
+	LeastCostExpanderName = "least-cost"
 )
 
 var (
@@ -112,7 +114,7 @@ var (
 		"Type of resource estimator to be used in scale up. Available values: ["+strings.Join(AvailableEstimators, ",")+"]")
 
 	// AvailableExpanders is a list of avaialble expander options
-	AvailableExpanders = []string{RandomExpanderName, MostPodsExpanderName, LeastWasteExpanderName}
+	AvailableExpanders = []string{RandomExpanderName, MostPodsExpanderName, LeastWasteExpanderName, LeastCostExpanderName}
 	expanderFlag       = flag.String("expander", RandomExpanderName,
 		"Type of node group expander to be used in scale up. Available values: ["+strings.Join(AvailableExpanders, ",")+"]")
 )

--- a/cluster-autoscaler/cluster_autoscaler.go
+++ b/cluster-autoscaler/cluster_autoscaler.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/contrib/cluster-autoscaler/clusterstate"
 	"k8s.io/contrib/cluster-autoscaler/config"
 	"k8s.io/contrib/cluster-autoscaler/expander"
+	"k8s.io/contrib/cluster-autoscaler/expander/leastcost"
 	"k8s.io/contrib/cluster-autoscaler/expander/mostpods"
 	"k8s.io/contrib/cluster-autoscaler/expander/random"
 	"k8s.io/contrib/cluster-autoscaler/expander/waste"
@@ -215,6 +216,8 @@ func run(_ <-chan struct{}) {
 			expanderStrategy = mostpods.NewStrategy()
 		case LeastWasteExpanderName:
 			expanderStrategy = waste.NewStrategy()
+		case LeastCostExpanderName:
+			expanderStrategy = leastcost.NewStrategy()
 		}
 	}
 

--- a/cluster-autoscaler/expander/leastcost/leastcost.go
+++ b/cluster-autoscaler/expander/leastcost/leastcost.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leastcost
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/contrib/cluster-autoscaler/expander"
+	"k8s.io/contrib/cluster-autoscaler/expander/random"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+type leastcost struct {
+	next expander.Strategy
+}
+
+// NewStrategy returns a scale up strategy (expander) that picks the node group that will cost the least to scale up
+func NewStrategy() expander.Strategy {
+	return &leastcost{random.NewStrategy()}
+}
+
+// BestOption Finds the option with the least cost per node, selecting a random node group if costs are equal.
+func (l *leastcost) BestOption(expansionOptions []expander.Option, nodeInfo map[string]*schedulercache.NodeInfo) *expander.Option {
+	var leastCost float64
+	var leastCostOptions []expander.Option
+
+	for _, option := range expansionOptions {
+		if option.NodeCount == option.NodeGroup.MaxSize() {
+			glog.V(1).Infof("Skipping full Node Group: %s", option.NodeGroup.Id())
+			continue
+		}
+
+		nodeCost, err := option.NodeGroup.NodeCost()
+
+		if err != nil {
+			glog.Errorf("Error calculating NodeCost: %v", err)
+			return nil
+		}
+
+		glog.V(1).Infof("Expanding Node Group %s would cost $%f per node", option.NodeGroup.Id(), nodeCost)
+
+		if nodeCost == leastCost {
+			leastCostOptions = append(leastCostOptions, option)
+		}
+
+		if leastCostOptions == nil || nodeCost < leastCost {
+			leastCost = nodeCost
+			leastCostOptions = []expander.Option{option}
+		}
+	}
+
+	if len(leastCostOptions) == 0 {
+		glog.V(1).Info("Unable to determine NodeGroup with lowest cost per node")
+		return nil
+	}
+
+	return l.next.BestOption(leastCostOptions, nodeInfo)
+}

--- a/cluster-autoscaler/expander/leastcost/leastcost_test.go
+++ b/cluster-autoscaler/expander/leastcost/leastcost_test.go
@@ -44,12 +44,13 @@ func (f *FakeNodeGroup) NodeCost() (float64, error) {
 		return 0, nil
 	}
 }
-func (f *FakeNodeGroup) TargetSize() (int, error)        { return 2, nil }
-func (f *FakeNodeGroup) IncreaseSize(delta int) error    { return nil }
-func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error { return nil }
-func (f *FakeNodeGroup) Id() string                      { return f.id }
-func (f *FakeNodeGroup) Debug() string                   { return f.id }
-func (f *FakeNodeGroup) Nodes() ([]string, error)        { return []string{}, nil }
+func (f *FakeNodeGroup) TargetSize() (int, error)           { return 2, nil }
+func (f *FakeNodeGroup) IncreaseSize(delta int) error       { return nil }
+func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error { return nil }
+func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error    { return nil }
+func (f *FakeNodeGroup) Id() string                         { return f.id }
+func (f *FakeNodeGroup) Debug() string                      { return f.id }
+func (f *FakeNodeGroup) Nodes() ([]string, error)           { return []string{}, nil }
 
 func TestLeastCost(t *testing.T) {
 	od1 := expander.Option{NodeGroup: &FakeNodeGroup{"OnDemand"}}

--- a/cluster-autoscaler/expander/leastcost/leastcost_test.go
+++ b/cluster-autoscaler/expander/leastcost/leastcost_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/contrib/cluster-autoscaler/expander"
-	kube_api "k8s.io/kubernetes/pkg/api"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
 type FakeNodeGroup struct {
@@ -44,11 +44,12 @@ func (f *FakeNodeGroup) NodeCost() (float64, error) {
 		return 0, nil
 	}
 }
-func (f *FakeNodeGroup) TargetSize() (int, error)           { return 2, nil }
-func (f *FakeNodeGroup) IncreaseSize(delta int) error       { return nil }
-func (f *FakeNodeGroup) DeleteNodes([]*kube_api.Node) error { return nil }
-func (f *FakeNodeGroup) Id() string                         { return f.id }
-func (f *FakeNodeGroup) Debug() string                      { return f.id }
+func (f *FakeNodeGroup) TargetSize() (int, error)        { return 2, nil }
+func (f *FakeNodeGroup) IncreaseSize(delta int) error    { return nil }
+func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error { return nil }
+func (f *FakeNodeGroup) Id() string                      { return f.id }
+func (f *FakeNodeGroup) Debug() string                   { return f.id }
+func (f *FakeNodeGroup) Nodes() ([]string, error)        { return []string{}, nil }
 
 func TestLeastCost(t *testing.T) {
 	od1 := expander.Option{NodeGroup: &FakeNodeGroup{"OnDemand"}}

--- a/cluster-autoscaler/expander/leastcost/leastcost_test.go
+++ b/cluster-autoscaler/expander/leastcost/leastcost_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leastcost
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/contrib/cluster-autoscaler/expander"
+	kube_api "k8s.io/kubernetes/pkg/api"
+)
+
+type FakeNodeGroup struct {
+	id string
+}
+
+func (f *FakeNodeGroup) MaxSize() int { return 2 }
+func (f *FakeNodeGroup) MinSize() int { return 1 }
+func (f *FakeNodeGroup) NodeCost() (float64, error) {
+	switch f.Id() {
+	case "AnotherOnDemand":
+		fallthrough
+	case "OnDemand":
+		return 1.675, nil
+	case "CheapSpot":
+		return 0.5, nil
+	case "ExpensiveSpot":
+		return 16.75, nil
+	default:
+		return 0, nil
+	}
+}
+func (f *FakeNodeGroup) TargetSize() (int, error)           { return 2, nil }
+func (f *FakeNodeGroup) IncreaseSize(delta int) error       { return nil }
+func (f *FakeNodeGroup) DeleteNodes([]*kube_api.Node) error { return nil }
+func (f *FakeNodeGroup) Id() string                         { return f.id }
+func (f *FakeNodeGroup) Debug() string                      { return f.id }
+
+func TestLeastCost(t *testing.T) {
+	od1 := expander.Option{NodeGroup: &FakeNodeGroup{"OnDemand"}}
+	od2 := expander.Option{NodeGroup: &FakeNodeGroup{"AnotherOnDemand"}}
+	cs := expander.Option{NodeGroup: &FakeNodeGroup{"CheapSpot"}}
+	es := expander.Option{NodeGroup: &FakeNodeGroup{"ExpensiveSpot"}}
+	e := NewStrategy()
+
+	// Select the cheapest Spot node group over the more expensive groups
+	ret := e.BestOption([]expander.Option{od1, cs, es}, nil)
+	assert.Equal(t, cs, *ret)
+
+	// Select the On-Demand node group over both spot groups once the cheapest Spot node group is full
+	cs.NodeCount = 2
+	ret = e.BestOption([]expander.Option{od1, cs, es}, nil)
+	assert.Equal(t, od1, *ret)
+
+	// Select the OnDemand node group over the expensive Spot
+	ret = e.BestOption([]expander.Option{od1, es}, nil)
+	assert.Equal(t, od1, *ret)
+
+	// Select an OnDemand node group at random
+	ret = e.BestOption([]expander.Option{od1, od2}, nil)
+	assert.True(t, assert.ObjectsAreEqual(*ret, od1) || assert.ObjectsAreEqual(*ret, od2))
+}

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -35,6 +35,7 @@ type FakeNodeGroup struct {
 
 func (f *FakeNodeGroup) MaxSize() int                       { return 2 }
 func (f *FakeNodeGroup) MinSize() int                       { return 1 }
+func (f *FakeNodeGroup) NodeCost() (float64, error)         { return 0, nil }
 func (f *FakeNodeGroup) TargetSize() (int, error)           { return 2, nil }
 func (f *FakeNodeGroup) IncreaseSize(delta int) error       { return nil }
 func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error { return nil }


### PR DESCRIPTION
#2118 added support for node group expansion strategies, allowing the cluster autoscaler to determine the best node group to expand instead of just selecting a node group at random. This adds a new expansion strategy that selects the node group with the lowest price per node as the group to be expanded, falling back to random selection if the price per node is equal across all configured node groups.

The main purpose of this PR is to improve support for AWS spot instance nodes; as GCE does not provide a bidding . Consider the following snippet from a cluster-autoscaler deployment manifest:
```
        - ./cluster-autoscaler
        - --v=4
        - --cloud-provider=aws
        - --expander=least-cost
        - --nodes=1:10:spot-node-1
        - --nodes=1:10:spot-node-2
        - --nodes=1:10:spot-node-3
        - --nodes=1:10:spot-node-4
        - --nodes=1:10:on-demand-node:0.10
```
Each of the spot worker groups spans a single Availability Zone on AWS. As instances are added to the spot worker groups, the current market price for spot instances in a given AZ is likely to change. Using the least-cost expander allows the cluster autoscaler to take the market price of spot instances into account when scaling, causing it to select the node group with the cheapest spot price at the time the scale-up was requested.

Note the additional on-demand node group; since there is no simple API for getting the current on-demand price of an AWS instance type, the node cost is manually specified as part of the node group. This way, if the spot price in all AZs is higher than the max bid price configured for the spot node groups, the cluster autoscaler can fall back to the on-demand node group.

Since GCE doesn't use a variable pricing model for their discounted Preemptible VMs, configuring the cluster autoscaler to add support for them should be trivial:
```
        - ./cluster-autoscaler
        - --v=4
        - --cloud-provider=gce
        - --expander=least-cost
        - --nodes=1:10:preemptible-node-1:0.20
        - --nodes=1:10:preemptible-node-2:0.20
        - --nodes=1:10:preemptible-node-3:0.20
        - --nodes=1:10:preemptible-node-4:0.20
        - --nodes=1:10:regular-node:1.00
```