### PR TITLE
Base kubelet-to-gcm on scratch, set user to nobody, and bump tag to 1.2.2

### DIFF
--- a/kubelet-to-gcm/Dockerfile
+++ b/kubelet-to-gcm/Dockerfile
@@ -12,15 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:14.04
-MAINTAINER Quintin Lee "qlee@google.com"
+FROM scratch
 
-# Disable prompts from apt.
-ENV DEBIAN_FRONTEND noninteractive
+COPY build/monitor /
 
-# # Install the Fluentd agent that knows how to send logs to Google Cloud Logging.
-RUN apt-get -q update && \
-    apt-get install -y curl && \
-    apt-get clean
-
-ADD build/monitor monitor
+# nobody:nobody
+USER 65534:65534
+ENTRYPOINT ["/monitor"]

--- a/kubelet-to-gcm/Makefile
+++ b/kubelet-to-gcm/Makefile
@@ -24,9 +24,8 @@
 
 OUT_DIR = build
 PACKAGE = k8s.io/contrib/kubelet-to-gcm
-#PREFIX = gcr.io/google_containers
-PREFIX = gcr.io/gke-test-us-central1-b-0
-TAG = 1.2.1
+PREFIX = gcr.io/google_containers
+TAG = 1.2.2
 
 # Rules for building the real image for deployment to gcr.io
 


### PR DESCRIPTION
This also fixes changes the prefix back to the correct default.

I haven't pushed 1.2.2 yet, but I don't expect any major changes, besides using an updated base image and being built with go1.7.5.