### PR TITLE
[Ansible] Fix for #2177

### DIFF
--- a/ansible/roles/master/tasks/cert-copy.yml
+++ b/ansible/roles/master/tasks/cert-copy.yml
@@ -1,0 +1,20 @@
+---
+- name: Read back the api-server certificates from the first master
+  slurp:
+    src: "{{ item }}"
+  register: apiserver_certs
+  run_once: true
+  delegate_to: "{{ groups['masters'][0] }}"
+  with_items:
+    - "{{ kube_cert_dir }}/server.crt"
+    - "{{ kube_cert_dir }}/server.key"
+
+- name: Write back the api-server certificates to all other masters
+  copy:
+    dest: "{{ item.item }}"
+    content: "{{ item.content | b64decode }}"
+    group: "{{ kube_cert_group }}"
+    owner: "kube"
+    mode: 0440
+  with_items: "{{ apiserver_certs.results }}"
+  when: inventory_hostname != groups['masters'][0]

--- a/ansible/roles/master/tasks/main.yml
+++ b/ansible/roles/master/tasks/main.yml
@@ -11,6 +11,9 @@
   include: apiserver-configure.yml
   tags: configure
 
+- name: Copy the certificates from the first master to the other masters
+  include: cert-copy.yml
+
 - name: Start apiserver
   include: apiserver-start.yml
 
@@ -84,4 +87,3 @@
   include: kubelet-restart.yml
   when: kubelet_modified == true and kubelet_started.changed == false
   tags: restart
-


### PR DESCRIPTION
Fix for issue #2177.

***

This slurps the certs from the first master and puts them on all other masters, so they don't fail starting because of the missing certificate (server.crt and server.key).

(This PR goes well with my other PR for the master cert gen in #2356 :wink:)