### PR TITLE
Return correct ProviderID format from GetAsgNodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -224,7 +224,8 @@ func (m *AwsManager) GetAsgNodes(asg *Asg) ([]string, error) {
 		return []string{}, err
 	}
 	for _, instance := range group.Instances {
-		result = append(result, *instance.InstanceId)
+		result = append(result,
+			fmt.Sprintf("aws:///%s/%s", *instance.AvailabilityZone, *instance.InstanceId))
 	}
 	return result, nil
 }


### PR DESCRIPTION
This matches the way that the [gce does it][1] and fixes issues with the
[cluster state][2].

[1]: https://github.com/kubernetes/contrib/blob/master/cluster-autoscaler/cloudprovider/gce/gce_manager.go#L247
[2]: https://github.com/kubernetes/contrib/issues/2228#issuecomment-274896211