### PR TITLE
Hack for debugging FROM scratch containers

### DIFF
--- a/scratch-debugger/README.md
+++ b/scratch-debugger/README.md
@@ -1,0 +1,103 @@
+# Scratch Debugger
+
+This is a tool to make debugging containers based on scratch easier. The script
+works by bringing up a pod with a statically-linked busybox image on the same
+node as the debug target, mounting the node's root filesystem, and calling
+docker directly to copy busybox into the target container. Once the "install" is
+complete, the target can be debugged through a standard kubectl exec.
+
+## Usage
+
+```
+scratch-debugger/debug.sh POD_NAME [POD_NAMESPACE CONTAINER_NAME]
+```
+
+- `POD_NAME` - The name of the pod to debug.
+- `POD_NAMESPACE` - The namespace of the target pod (defaults to `default`).
+- `CONTAINER_NAME` - The name of the container in the pod to debug (defaults to the first container).
+
+Additionally, the following environment variables can be set:
+
+- `TMP_SUBDIR` - The subdirectory under `/tmp` to install busybox into (defaults to `debug-tools`).
+- `KUBECONTEXT` - The kubectl context to use (defaults to current context).
+- `DEBUGGER_NAME` - The name to use for the debug pod (defaults to `debugger`).
+- `ARCH` - The architecture Kubernetes is running on (defaults to `amd64`).
+
+## Example
+
+Create a simple `pause` pod, which is based off a scratch image and does nothing.
+```
+$ kubectl create -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name:   pause
+spec:
+  containers:
+    - name:    pause
+      image: gcr.io/google_containers/pause
+EOF
+
+pod "pause" created
+```
+
+Note that we cannot simply exec into the pod, since there isn't a shell or any
+other interactive tools available:
+```
+$ kubectl exec -i -t pause -- sh
+rpc error: code = 2 desc = "oci runtime error: exec failed: exec: \"sh\": executable file not found in $PATH"
+```
+
+So we use the `debug.sh` script to copy busybox (which includes many common
+tools) into the container:
+```
+$ scratch-debugger/debug.sh pause
+Debug Target Container:
+  Pod:          pause
+  Namespace:    default
+  Node:         e2e-test-stclair-minion-group-phj6
+  Container:    pause
+  Container ID: 80b134ab6550d34684cdb31e4300ff128f9f43f67fdb3d271372f9417e546737
+  Runtime:      docker
+
+Installing busybox to /tmp/debug-tools ...
+pod "debugger" created
+waiting for debugger pod to become ready...
+Installation complete.
+To debug pause, run:
+    kubectl exec -i -t pause -- /tmp/debug-tools/sh -c 'PATH=$PATH:/tmp/debug-tools sh'
+Dumping you into the pod container now.
+
+/ # ls
+dev    etc    pause  proc   sys    tmp    var
+/ # echo Hello world!
+Hello world!
+/ # exit
+pod "debugger" deleted
+```
+
+The script automatically execs into the pod and starts a shell (`ash`) with the
+`PATH` variable set to include the debug tools. After exiting, the tools are
+still present in the pod, and we can simply exec back in using the command the
+script gave us:
+
+```
+$ kubectl exec -i -t pause -- /tmp/debug-tools/sh -c 'PATH=$PATH:/tmp/debug-tools sh'
+/ # which sh
+/tmp/debug-tools/sh
+/ # exit
+```
+
+Alternatively, we can just call the `debug.sh` script again:
+```
+$ scratch-debugger/debug.sh pause
+Debug tools already installed. Dumping you into the pod container now.
+/ # exit
+```
+
+Once we've finished debugging, it's a good practice to delete the "tainted"
+pod. If that is undesirable for some reason, you can simply delete the tools
+from the container:
+```
+$ kubectl exec pause -- /tmp/debug-tools/rm -r /tmp/debug-tools
+```

--- a/scratch-debugger/debug.sh
+++ b/scratch-debugger/debug.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Customizable parameters
+TMP_SUBDIR="${TMP_SUBDIR:-debug-tools}"
+CONTEXT="${KUBECONTEXT:-}"
+ARCH="${ARCH:-amd64}"
+
+# Parse arguments & flags
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -n|--namespace)
+      NAMESPACE=$2
+      shift
+      ;;
+    -c|--container)
+      CONTAINER_NAME=$2
+      shift
+      ;;
+    *)
+      NAME=$1
+      ;;
+  esac
+  shift
+done
+
+if [[ -z ${NAME:-} ]]; then
+  echo >&2 "USAGE: $0 POD_NAME [-n POD_NAMESPACE] [-c CONTAINER_NAME]"
+  exit 1
+fi
+
+# Internal variables
+KUBECTL="kubectl"
+[ -z "${CONTEXT}" ] || KUBECTL="${KUBECTL} --context=${CONTEXT}"
+[ -z "${NAMESPACE:-}" ] || KUBECTL="${KUBECTL} --namespace=${NAMESPACE}"
+
+NAMESPACE=${NAMESPACE:-default}
+
+TARGET_CNAME=${CONTAINER_NAME:-}
+if [ -z "${CONTAINER_NAME:-}" ]; then
+  CONTAINER_NAME=$(${KUBECTL} get pod ${NAME} -o jsonpath='{.spec.containers[0].name}')
+fi
+
+INSTALL_DIR="/tmp/${TMP_SUBDIR}"
+CONTAINER_ID=$(${KUBECTL} get pod ${NAME} -o jsonpath="{.status.containerStatuses[?(@.name==\"${CONTAINER_NAME}\")].containerID}")
+RUNTIME=${CONTAINER_ID%://*}
+CONTAINER_ID=${CONTAINER_ID#*://}
+NODE=$(${KUBECTL} get pod ${NAME} -o jsonpath='{.spec.nodeName}')
+
+if [[ ${RUNTIME} != docker ]]; then
+  echo >&2 "Error: $0 only works with a docker runtime. Found: ${CONTAINER_ID}"
+  exit 1
+fi
+
+# Construct the command to debug the target container.
+DEBUG_CMD="${KUBECTL} exec -i -t ${NAME}"
+[ -z "${TARGET_CNAME}" ] || DEBUG_CMD="${DEBUG_CMD} -c ${TARGET_CNAME}"
+DEBUG_CMD="${DEBUG_CMD} -- ${INSTALL_DIR}/sh -c 'PATH=\${PATH}:${INSTALL_DIR} sh'"
+
+if ${KUBECTL} exec ${NAME} -c ${CONTAINER_NAME} -- ${INSTALL_DIR}/echo &>/dev/null; then
+  echo "Debug tools already installed. Dumping you into the pod container now."
+  eval "${DEBUG_CMD}"
+  exit 0
+fi
+
+cat <<EOF
+Debug Target Container:
+  Pod:          ${NAME}
+  Namespace:    ${NAMESPACE}
+  Node:         ${NODE}
+  Container:    ${CONTAINER_NAME}
+  Container ID: ${CONTAINER_ID}
+  Runtime:      ${RUNTIME}
+
+  "Installing busybox to ${INSTALL_DIR} ..."
+EOF
+
+case ${ARCH} in
+  "amd64")
+    IMAGE=busybox
+    ;;
+  "arm")
+    IMAGE=armhf/busybox
+    ;;
+  "arm64")
+    IMAGE=aarch64/busybox
+    ;;
+  "ppc64le")
+    IMAGE=ppc64le/busybox
+    ;;
+  "s390x")
+    IMAGE=s390x/busybox
+    ;;
+  *)
+    echo "Unsupported architecture: ${ARCH}"
+    exit 1
+esac
+
+DOCKERCMD="/mnt/rootfs/usr/bin/docker -H unix:///run/docker.sock"
+
+# Command for installing busybox image from the debugger container into the target container.
+INSTALLCMD="set -x;" # Print commands, for debugging.
+# Create the directory structure for the install.
+INSTALLCMD="${INSTALLCMD} mkdir -p ${INSTALL_DIR}"
+# Copy the directory structure into the target container.
+INSTALLCMD="${INSTALLCMD} && ${DOCKERCMD} cp /tmp ${CONTAINER_ID}:/"
+# Copy the busybox binary into the install location.
+INSTALLCMD="${INSTALLCMD} && ${DOCKERCMD} cp /bin/busybox ${CONTAINER_ID}:${INSTALL_DIR}/busybox"
+# Tell busybox to install (create symlinks for commands) into the install directory.
+INSTALLCMD="${INSTALLCMD} && ${DOCKERCMD} exec ${CONTAINER_ID} ${INSTALL_DIR}/busybox --install -s ${INSTALL_DIR}"
+
+DEBUGGER_NAME=$(${KUBECTL} create -o name -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: debugger-
+  namespace:   ${NAMESPACE}
+spec:
+  nodeName:    ${NODE}
+  restartPolicy: Never
+  containers:
+    - name:    debugger
+      image:   ${IMAGE}
+      securityContext:
+        privileged: true
+      command:
+        - sh
+        - -c
+        - "${INSTALLCMD}"
+      # Mount the node FS for direct access to docker.
+      volumeMounts:
+        - name: rootfs
+          mountPath: /mnt/rootfs
+          readOnly: true
+        - name: rootfs-run
+          mountPath: /mnt/rootfs/var/run
+          readOnly: true
+  volumes:
+    - name: rootfs
+      hostPath:
+        path: /
+    - name: rootfs-run
+      hostPath:
+        path: /var/run
+EOF
+             )
+DEBUGGER_NAME=${DEBUGGER_NAME#pod/} # Remove pod/ prefix from name
+
+# Cleanup the debugger pod.
+function cleanup() {
+  if ${KUBECTL} get pod ${DEBUGGER_NAME} &>/dev/null; then
+    ${KUBECTL} delete pod ${DEBUGGER_NAME}
+  fi
+}
+trap cleanup EXIT
+
+# Wait for the pod to terminate.
+PHASE=$(${KUBECTL} get pod -a ${DEBUGGER_NAME} -o jsonpath='{.status.phase}')
+while [[ ! ${PHASE} =~ (Succeeded|Failed) ]]; do
+  echo "waiting for debugger pod to complete (currently ${PHASE})..."
+  sleep 1
+  PHASE=$(${KUBECTL} get pod -a ${DEBUGGER_NAME} -o jsonpath='{.status.phase}')
+done
+if [[ ${PHASE} == "Failed" ]]; then
+  echo 2> "Pod failed:"
+  ${KUBECTL} logs ${DEBUGGER_NAME}
+  exit 1
+fi
+
+cleanup
+
+echo "Installation complete."
+
+echo "To debug ${NAME}, run:
+    ${DEBUG_CMD}
+Dumping you into the pod container now.
+"
+
+eval "${DEBUG_CMD}"


### PR DESCRIPTION
Hacky solution to https://github.com/kubernetes/kubernetes/issues/10834 and https://github.com/kubernetes/kubernetes/issues/27140 to unblock migration of system pods to `scratch` base images (https://github.com/kubernetes/kubernetes/issues/40248). This is not meant to be a long term solution, but rather a temporary workaround until we have native Kubernetes support.

The script works by bringing up a busybox pod on the same node as the debug target, mounting the node's root fs, and calling docker directly to copy busybox into the target container. Once the "install" is complete, the target can be debugged through a standard `kubectl exec`.

/cc @verb @thockin 