### PR TITLE
Copy tokens to other masters

### DIFF
--- a/ansible/roles/kubernetes/tasks/secrets.yml
+++ b/ansible/roles/kubernetes/tasks/secrets.yml
@@ -77,3 +77,15 @@
 
 - include: gen_tokens.yml
   when: inventory_hostname == groups['masters'][0]
+
+- name: Copy tokens to other masters
+  synchronize:
+    src: /etc/kubernetes/tokens/
+    dest: /etc/kubernetes/tokens
+  delegate_to: "{{ groups['masters'][0] }}"
+  when: inventory_hostname in groups['masters'] and inventory_hostname != groups['masters'][0] 
+  notify:
+    - restart daemons
+  tags:
+   - secrets
+   - configure


### PR DESCRIPTION
Before this PR, in multi-masters case, only first master(`groups['masters'][0]`) got the tokens.
This PR will copy tokens to all masters. It's helpful for setup a HA kubernetes cluster.