### PR TITLE
Fix wrong task tags name

### DIFF
--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -13,5 +13,5 @@
 
 - include: secrets.yml
   tags:
-    secrets
-  tags: configure
+    - secrets
+    - configure


### PR DESCRIPTION
The later tags name overrides the former, fixed this.