### PR TITLE
set additional ansible extra vars via env when running Vagrantfile

### DIFF
--- a/ansible/vagrant/Vagrantfile
+++ b/ansible/vagrant/Vagrantfile
@@ -240,6 +240,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         kube_apiserver_bind_address: master_ip,
       }
     end
+
+    # set additional extra vars for ansible if provided
+    if ENV.has_key?("ANSIBLE_EXTRA_VARS")
+      if provider != :virtualbox
+        ansible.extra_vars = {}
+      end
+      ENV["ANSIBLE_EXTRA_VARS"].split(" ").each do |item|
+        pair = item.split("=")
+        if pair.length != 2
+          abort("ansible var not in key=value form: #{item}")
+        end
+        ansible.extra_vars[ pair[0].to_sym ] = pair[1]
+      end
+    end
   end
 
   def run_ansible_provision(n)


### PR DESCRIPTION
When ANSIBLE_EXTRA_VARS is set in a form of "key=value key=value ..." form,
all key=value pairs are set in extra vars when ansible deployment is run.
Both key and value must be whitespace-free finite string.

E.g. export ANSIBLE_EXTRA_VARS="kube_source_type=github-release kube_master_api_port=6443 kube_version=1.4.8"

This comes handy when there is a need to change some default vars instead of modifying them manually.