### PR TITLE
Rebase 404-server on scratch & don't run as root

### DIFF
--- a/404-server/Dockerfile
+++ b/404-server/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
-MAINTAINER Prashanth B <beeps@google.com>
+FROM scratch
+
+#   nobody:nobody
+USER 65534:65534
 COPY server /
 ENTRYPOINT ["/server"]

--- a/404-server/Makefile
+++ b/404-server/Makefile
@@ -20,40 +20,21 @@
 
 all: push
 
-TAG=1.2
+TAG=1.3
 PREFIX?=gcr.io/google_containers/defaultbackend
 ARCH?=amd64
-GOLANG_VERSION=1.6
+GOLANG_VERSION=1.7
 TEMP_DIR:=$(shell mktemp -d)
 
-# Set default base image dynamically for each arch
-ifeq ($(ARCH),amd64)
-	BASEIMAGE?=busybox
-endif
-ifeq ($(ARCH),arm)
-	BASEIMAGE?=armel/busybox
-endif
-ifeq ($(ARCH),arm64)
-	BASEIMAGE?=aarch64/busybox
-endif
-ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=ppc64le/busybox
-endif
-
 server: server.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GOARM=6 go build -a -installsuffix cgo -ldflags '-w' -o server ./server.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GOARM=6 go build -a -installsuffix cgo -ldflags '-w -s' -o server ./server.go
 
 container:
-	# Copy the whole directory to a temporary dir and set the base image
-	cp -r ./* $(TEMP_DIR)
-	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
-
 	# Compile the binary inside a container for reliable builds
-	docker run --rm -it -v $(TEMP_DIR):/build golang:$(GOLANG_VERSION) /bin/bash -c "make -C /build server ARCH=$(ARCH)"
+	docker pull golang:$(GOLANG_VERSION)
+	docker run --rm -it -v $(PWD):/build golang:$(GOLANG_VERSION) /bin/bash -c "make -C /build server ARCH=$(ARCH)"
 
-	docker build --pull -t $(PREFIX)-$(ARCH):$(TAG) $(TEMP_DIR)
-
-	rm -rf $(TEMP_DIR)
+	docker build --pull -t $(PREFIX)-$(ARCH):$(TAG) .
 
 push: container
 	gcloud docker push $(PREFIX)-$(ARCH):$(TAG)


### PR DESCRIPTION
As part of the effort behind kubernetes/kubernetes#40248, I'm cutting out unnecessary dependencies from system containers by rebasing them on scratch (for containers without any external dependencies). In addition, this does not require any elevated privileges, so run as the nobody user instead of root.

For debugging scratch containers, see kubernetes/contrib#2372

/cc @ixdy