### PR TITLE
Change base image for rescheduler to busybox

### DIFF
--- a/rescheduler/Dockerfile
+++ b/rescheduler/Dockerfile
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/ubuntu-slim:0.1
+FROM busybox
 
-# github handle: piosz@
-MAINTAINER Piotr Szczesniak "pszczesniak@google.com"
+COPY rescheduler /
 
-ADD rescheduler rescheduler
-
-CMD ./rescheduler
+ENTRYPOINT ["/rescheduler"]

--- a/rescheduler/Makefile
+++ b/rescheduler/Makefile
@@ -2,15 +2,15 @@ all: build
 
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-REGISTRY = gcr.io/google_containers
-TAG = v0.2.1
+REGISTRY = gcr.io/google-containers
+TAG = v0.2.2
 
 deps:
 	go get github.com/tools/godep
 
 build: clean deps
 	$(ENVVAR) godep go build ./...
-	$(ENVVAR) godep go build -o rescheduler 
+	$(ENVVAR) godep go build -o rescheduler
 
 test-unit: clean deps build
 	$(ENVVAR) godep go test --test.short -race ./... $(FLAGS)
@@ -19,7 +19,7 @@ container: build
 	docker build --pull -t ${REGISTRY}/rescheduler:$(TAG) .
 
 push: container
-	gcloud docker push ${REGISTRY}/rescheduler:$(TAG)
+	gcloud docker -- push ${REGISTRY}/rescheduler:$(TAG)
 
 clean:
 	rm -f rescheduler


### PR DESCRIPTION
Tested in my own cluster against the `[k8s.io] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available` test and it passed.

Note that because we write to `/var/log/rescheduler.log` on the master via stdout/stderr redirect, we need busybox and we need to run as root.

cc @timstclair 