### PR TITLE
Cluster-autoscaler: skip pods that are being deleted in node drain

### DIFF
--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -45,6 +45,10 @@ func GetPodsForDeletionOnNodeDrain(
 		if IsMirrorPod(pod) {
 			continue
 		}
+		if pod.DeletionTimestamp != nil {
+			// pod is being deleted - no need to move it.
+			continue
+		}
 
 		daemonsetPod := false
 		replicated := false


### PR DESCRIPTION
Pods that are still running but are being deleted should not be deleted/moved in CA. 
This also fixes CA against the change in K8S after which the node controller stopped hard-deleting pods (it just sets deletionTimestamp) from unready nodes. With this PR CA will see nodes with all pods under deletion as empty.

cc: @jszczepkowski @gmarek @maciekpytel