### PR TITLE
Cluster-autoscaler: readable status printing

### DIFF
--- a/cluster-autoscaler/clusterstate/api/utils.go
+++ b/cluster-autoscaler/clusterstate/api/utils.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package api
 
+import (
+	"bytes"
+	"fmt"
+)
+
 // GetConditionByType gets condition by type.
 func GetConditionByType(conditionType ClusterAutoscalerConditionType,
 	conditions []ClusterAutoscalerCondition) *ClusterAutoscalerCondition {
@@ -25,4 +30,63 @@ func GetConditionByType(conditionType ClusterAutoscalerConditionType,
 		}
 	}
 	return nil
+}
+
+func getConditionsString(autoscalerConditions []ClusterAutoscalerCondition, prefix string) string {
+	health := fmt.Sprintf("%v%-12v <unknown>", prefix, ClusterAutoscalerHealth+":")
+	var scaleUp, scaleDown string
+	var buffer, other bytes.Buffer
+	for _, condition := range autoscalerConditions {
+		var line bytes.Buffer
+		line.WriteString(fmt.Sprintf("%v%-12v %v",
+			prefix,
+			condition.Type+":",
+			condition.Status))
+		if condition.Message != "" {
+			line.WriteString(" (")
+			line.WriteString(condition.Message)
+			line.WriteString(")")
+		}
+		line.WriteString("\n")
+		line.WriteString(fmt.Sprintf("%v%13sLastProbeTime:      %v\n",
+			prefix,
+			"",
+			condition.LastProbeTime))
+		line.WriteString(fmt.Sprintf("%v%13sLastTransitionTime: %v\n",
+			prefix,
+			"",
+			condition.LastTransitionTime))
+		switch condition.Type {
+		case ClusterAutoscalerHealth:
+			health = line.String()
+		case ClusterAutoscalerScaleUp:
+			scaleUp = line.String()
+		case ClusterAutoscalerScaleDown:
+			scaleDown = line.String()
+		default:
+			other.WriteString(line.String())
+		}
+	}
+	buffer.WriteString(health)
+	buffer.WriteString(scaleUp)
+	buffer.WriteString(scaleDown)
+	buffer.WriteString(other.String())
+	return buffer.String()
+}
+
+// GetReadableString produces human-redable description of status.
+func (status ClusterAutoscalerStatus) GetReadableString() string {
+	var buffer bytes.Buffer
+	buffer.WriteString("Cluster-wide:\n")
+	buffer.WriteString(getConditionsString(status.ClusterwideConditions, "  "))
+	if len(status.NodeGroupStatuses) == 0 {
+		return buffer.String()
+	}
+	buffer.WriteString("\nNodeGroups:\n")
+	for _, nodeGroupStatus := range status.NodeGroupStatuses {
+		buffer.WriteString(fmt.Sprintf("  Name:        %v\n", nodeGroupStatus.ProviderID))
+		buffer.WriteString(getConditionsString(nodeGroupStatus.Conditions, "  "))
+		buffer.WriteString("\n")
+	}
+	return buffer.String()
 }

--- a/cluster-autoscaler/clusterstate/api/utils_test.go
+++ b/cluster-autoscaler/clusterstate/api/utils_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func prepareConditions() (health, scaleUp ClusterAutoscalerCondition) {
+	healthCondition := ClusterAutoscalerCondition{
+		Type:    ClusterAutoscalerHealth,
+		Status:  ClusterAutoscalerHealthy,
+		Message: "HEALTH_MESSAGE"}
+	scaleUpCondition := ClusterAutoscalerCondition{
+		Type:    ClusterAutoscalerScaleUp,
+		Status:  ClusterAutoscalerNotNeeded,
+		Message: "SCALE_UP_MESSAGE"}
+	return healthCondition, scaleUpCondition
+}
+
+func TestGetStringForEmptyStatus(t *testing.T) {
+	var empty ClusterAutoscalerStatus
+	assert.Regexp(t, regexp.MustCompile("\\s*Health:\\s*<unknown>"), empty.GetReadableString())
+}
+
+func TestGetStringNothingGoingOn(t *testing.T) {
+	var status ClusterAutoscalerStatus
+	healthCondition, scaleUpCondition := prepareConditions()
+	status.ClusterwideConditions = append(status.ClusterwideConditions, healthCondition)
+	status.ClusterwideConditions = append(status.ClusterwideConditions, scaleUpCondition)
+
+	// Make sure everything is printed
+	result := status.GetReadableString()
+	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("%v:\\s*%v", ClusterAutoscalerHealth, ClusterAutoscalerHealthy)), result)
+	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("%v.*HEALTH_MESSAGE", ClusterAutoscalerHealth)), result)
+	assert.NotRegexp(t, regexp.MustCompile(fmt.Sprintf("%v.*SCALE_UP_MESSAGE", ClusterAutoscalerHealth)), result)
+	assert.NotRegexp(t, regexp.MustCompile("NodeGroups"), result)
+	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("%v:\\s*%v", ClusterAutoscalerScaleUp, ClusterAutoscalerNotNeeded)), result)
+
+	// Check if reordering fields doesn't change output
+	var reorderedStatus ClusterAutoscalerStatus
+	reorderedStatus.ClusterwideConditions = append(status.ClusterwideConditions, scaleUpCondition)
+	reorderedStatus.ClusterwideConditions = append(status.ClusterwideConditions, healthCondition)
+	reorderedResult := reorderedStatus.GetReadableString()
+	assert.Equal(t, result, reorderedResult)
+}
+
+func TestGetStringScalingUp(t *testing.T) {
+	var status ClusterAutoscalerStatus
+	healthCondition, scaleUpCondition := prepareConditions()
+	scaleUpCondition.Status = ClusterAutoscalerInProgress
+	status.ClusterwideConditions = append(status.ClusterwideConditions, healthCondition)
+	status.ClusterwideConditions = append(status.ClusterwideConditions, scaleUpCondition)
+	result := status.GetReadableString()
+	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("%v:\\s*%v.*SCALE_UP_MESSAGE", ClusterAutoscalerScaleUp, ClusterAutoscalerInProgress)), result)
+}
+
+func TestGetStringNodeGroups(t *testing.T) {
+	var status ClusterAutoscalerStatus
+	healthCondition, scaleUpCondition := prepareConditions()
+	status.ClusterwideConditions = append(status.ClusterwideConditions, healthCondition)
+	status.ClusterwideConditions = append(status.ClusterwideConditions, scaleUpCondition)
+	var ng1, ng2 NodeGroupStatus
+	ng1.ProviderID = "ng1"
+	ng1.Conditions = status.ClusterwideConditions
+	ng2.ProviderID = "ng2"
+	ng2.Conditions = status.ClusterwideConditions
+	status.NodeGroupStatuses = append(status.NodeGroupStatuses, ng1)
+	status.NodeGroupStatuses = append(status.NodeGroupStatuses, ng2)
+	result := status.GetReadableString()
+	assert.Regexp(t, regexp.MustCompile("(?ms)NodeGroups:.*Name:\\s*ng1"), result)
+	assert.Regexp(t, regexp.MustCompile("(?ms)NodeGroups:.*Name:\\s*ng2"), result)
+}


### PR DESCRIPTION
Example output (github seems to slightly mess up tabs):
```
Health:      Healthy (ready=0 unready=1 notStarted=0 longNotStarted=0 registered=1)
             LastProbeTime:      0001-01-01 00:00:00 +0000 UTC                     
             LastTransitionTime: 0001-01-01 00:00:00 +0000 UTC                     
ScaleUp:     NoActivity (ready=0 registered=1)                                     
             LastProbeTime:      0001-01-01 00:00:00 +0000 UTC                     
             LastTransitionTime: 0001-01-01 00:00:00 +0000 UTC                     
ScaleDown:   NoCandidates (candidates=0)                                           
             LastProbeTime:      0001-01-01 00:00:00 +0000 UTC                     
             LastTransitionTime: 0001-01-01 00:00:00 +0000 UTC                     
                                                                                   
NodeGroups:                                                                        
  Name:        ng1                                                                 
  Health:      Unhealthy (ready=0 unready=1 notStarted=0 longNotStarted=0 registered=1 cloudProviderTarget=5 (min=5, max=5))
               LastProbeTime:      0001-01-01 00:00:00 +0000 UTC                   
               LastTransitionTime: 0001-01-01 00:00:00 +0000 UTC                   
  ScaleUp:     NoActivity (ready=0 cloudProviderTarget=5)                          
               LastProbeTime:      0001-01-01 00:00:00 +0000 UTC                   
               LastTransitionTime: 0001-01-01 00:00:00 +0000 UTC                   
  ScaleDown:   NoCandidates (candidates=0)                                         
               LastProbeTime:      0001-01-01 00:00:00 +0000 UTC                   
               LastTransitionTime: 0001-01-01 00:00:00 +0000 UTC
```