### PR TITLE
Fix nil pointer exception when nodegroupfornode is nil

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -430,6 +430,10 @@ func (csr *ClusterStateRegistry) UpdateScaleDownCandidates(nodes []*apiv1.Node) 
 			glog.Warningf("Failed to get node group for %s: %v", node.Name, err)
 			continue
 		}
+		if reflect.ValueOf(group).IsNil() {
+			glog.Warningf("Got nil node group from cloudProvider for node %s", node.Name)
+			continue
+		}
 		result[group.Id()] = append(result[group.Id()], node.Name)
 	}
 	csr.candidatesForScaleDown = result


### PR DESCRIPTION
This fix should prevent a segmentation fault when a NodeGroup comes back as nil from the cloudprovider. I've not been able to track down the root cause, but I figured this might be useful for others.

In case the following is relevant or helpful:

K8s version: 1.5.2
Cluster tool: kops 1.5.1
Cloud: AWS
cluster-autoscaler version: master