### PR TITLE
Cluster-autoscaler: bump version to 0.5.0-alpha1 in preparation for the next release

### DIFF
--- a/cluster-autoscaler/version.go
+++ b/cluster-autoscaler/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package main
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "0.4.0"
+const ClusterAutoscalerVersion = "0.5.0-alpha1"


### PR DESCRIPTION
cc: @fgrzadkowski @jszczepkowski @MaciekPytel 