### PR TITLE
ansible|contiv: Fix tasks PkgMgr CentOS with correct URL

### DIFF
--- a/ansible/roles/contiv/tasks/pkgMgrInstallers/centos-install.yml
+++ b/ansible/roles/contiv/tasks/pkgMgrInstallers/centos-install.yml
@@ -6,8 +6,8 @@
 
 - name: PkgMgr CentOS | Get openstack kilo rpm
   get_url:
-    url: https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm
-    dest: /tmp/rdo-release-kilo-1.noarch.rpm
+    url: https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm
+    dest: /tmp/rdo-release-kilo-2.noarch.rpm
     validate_certs: False
   environment:
     http_proxy: "{{ http_proxy|default('') }}"
@@ -17,7 +17,7 @@
        - ovs_install
 
 - name: PkgMgr CentOS | Install openstack kilo rpm
-  yum: name=/tmp/rdo-release-kilo-1.noarch.rpm state=present
+  yum: name=/tmp/rdo-release-kilo-2.noarch.rpm state=present
   tags:
        - ovs_install
 


### PR DESCRIPTION
As can be seen from here: https://repos.fedorapeople.org/repos/openstack/openstack-kilo/ the old url of the rpm package is not available anymore. 
Here is a PR that solves this issue.