### PR TITLE
Move fluentd-gcp image to contrib repo

### DIFF
--- a/fluentd/OWNERS
+++ b/fluentd/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- piosz
+- crassirostris
+- igorpeshansky
+reviewers:
+- piosz
+- crassirostris
+- igorpeshansky

--- a/fluentd/fluentd-gcp-image/Dockerfile
+++ b/fluentd/fluentd-gcp-image/Dockerfile
@@ -1,0 +1,58 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile will build an image that is configured
+# to use Fluentd to collect all Docker container log files
+# and then cause them to be ingested using the Google Cloud
+# Logging API. This configuration assumes that the host performning
+# the collection is a VM that has been created with a logging.write
+# scope and that the Logging API has been enabled for the project
+# in the Google Developer Console.
+
+FROM gcr.io/google-containers/debian-base-amd64:0.1
+
+COPY Gemfile /Gemfile
+
+# 1. Install & configure dependencies.
+# 2. Install fluentd via ruby.
+# 3. Remove build dependencies.
+# 4. Cleanup leftover caches & files.
+RUN BUILD_DEPS="make gcc g++ libc-dev ruby-dev" \
+    && clean-install $BUILD_DEPS \
+                     ca-certificates \
+                     libjemalloc1 \
+                     liblz4-1 \
+                     ruby \
+    && echo 'gem: --no-document' >> /etc/gemrc \
+    && gem install --file Gemfile \
+    && apt-get purge -y --auto-remove \
+                     -o APT::AutoRemove::RecommendsImportant=false \
+                     $BUILD_DEPS \
+    && rm -rf /tmp/* \
+              /var/lib/apt/lists/* \
+              /usr/lib/ruby/gems/*/cache/*.gem \
+              /var/log/* \
+              /var/tmp/*
+
+# Copy the Fluentd configuration file for logging Docker container logs.
+COPY fluent.conf /etc/fluent/fluent.conf
+COPY run.sh /run.sh
+
+# Expose prometheus metrics.
+EXPOSE 80
+
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
+
+# Start Fluentd to pick up our config that watches Docker container logs.
+CMD /run.sh $FLUENTD_ARGS

--- a/fluentd/fluentd-gcp-image/Gemfile
+++ b/fluentd/fluentd-gcp-image/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'fluentd', '~>0.12.32'
+gem 'fluent-plugin-record-reformer', '~>0.8.3'
+gem 'fluent-plugin-systemd', '~>0.0.7'
+gem 'fluent-plugin-google-cloud', '~>0.5.6'
+gem 'fluent-plugin-detect-exceptions', '~>0.0.5'
+gem 'fluent-plugin-prometheus', '~>0.2.1'
+gem 'oj', '~>2.18.1'

--- a/fluentd/fluentd-gcp-image/Makefile
+++ b/fluentd/fluentd-gcp-image/Makefile
@@ -1,0 +1,36 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The build rule builds a Docker image that logs all Docker contains logs to
+# Google Compute Platform using the Cloud Logging API.
+
+# Procedure for change:
+# 1. Bump the tag number.
+# 2. Push to the private repo and test using newer version
+# 3. Issue PR.
+# 4. Assuming permissions to do so, when PR is approved
+#    make the gcr.io version of the image: make build push
+# 5. Issue PR with config files changes
+
+.PHONY:	build push
+
+PREFIX=gcr.io/google-containers
+TAG = 2.0
+
+build:
+	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .
+
+
+push:
+	gcloud docker -- push $(PREFIX)/fluentd-gcp:$(TAG)

--- a/fluentd/fluentd-gcp-image/README.md
+++ b/fluentd/fluentd-gcp-image/README.md
@@ -1,0 +1,25 @@
+# Collecting Docker Log Files with Fluentd and sending to GCP.
+This directory contains the source files needed to make a Docker image
+that collects Docker container log files using [Fluentd](http://www.fluentd.org/)
+and sends them to GCP.
+This image is designed to be used as part of the [Kubernetes](https://github.com/kubernetes/kubernetes)
+cluster bring up process. The image resides at DockerHub under the name
+[kubernetes/fluentd-gcp](https://registry.hub.docker.com/u/kubernetes/fluentd-gcp/).
+
+# Usage
+
+The image is built with its own set of plugins which you can later use
+in the configuration. The set of plugin is enumerated in a Gemfile in the
+image's directory. You can find details about fluentd configuration on the
+[official site](http://docs.fluentd.org/articles/config-file).
+
+In order to configure fluentd image, you should mount a directory with `.conf`
+files to `/etc/fluent/config.d` or add files to that directory by building
+a new image on top. All `.conf` files in the `/etc/fluent/config.d` directory
+will be included to the final fluentd configuration.
+
+Command line arguments to the fluentd executable are passed
+via environment variable `FLUENTD_ARGS`.
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/fluentd-gcp/fluentd-gcp-image/README.md?pixel)]()

--- a/fluentd/fluentd-gcp-image/fluent.conf
+++ b/fluentd/fluentd-gcp-image/fluent.conf
@@ -1,0 +1,8 @@
+# This is the root config file, which only includes components of the actual configuration
+
+# Do not collect fluentd's own logs to avoid infinite loops.
+<match fluent.**>
+  type null
+</match>
+
+@include /etc/fluent/config.d/*.conf

--- a/fluentd/fluentd-gcp-image/run.sh
+++ b/fluentd/fluentd-gcp-image/run.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These steps must be executed once the host /var and /lib volumes have
+# been mounted, and therefore cannot be done in the docker build stage.
+
+# For systems without journald
+mkdir -p /var/log/journal
+
+# Copy host libsystemd into image to avoid compatibility issues.
+if [ ! -z "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
+  rm /lib/x86_64-linux-gnu/libsystemd*
+  cp -a /host/lib/libsystemd* /lib/x86_64-linux-gnu/
+fi
+
+/usr/local/bin/fluentd $@


### PR DESCRIPTION
Replacement for https://github.com/kubernetes/contrib/pull/2410, complimentary for https://github.com/kubernetes/kubernetes/pull/42127

Moving to contrib, because it's going to be maintained by Stackdriver team

CC @igorpeshansky, @qingling128 and @dhrupadb