### PR TITLE
Change ansible files to respect etcd_client_port variable

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -117,6 +117,8 @@ etcd_peer_url_scheme: "https"
 # For etcd client and peer cert authentication set these to true
 etcd_client_cert_auth: true
 etcd_peer_client_cert_auth: true
+
+etcd_client_port: '2379'
 # when the scheme vars above are set to "https" you need to set these to true!
 flannel_etcd_use_certs: true
 apiserver_etcd_use_certs: true

--- a/ansible/roles/flannel/tasks/config.yml
+++ b/ansible/roles/flannel/tasks/config.yml
@@ -3,7 +3,7 @@
 
 - name: Set facts about etcdctl command
   set_fact:
-    peers: "{% for hostname in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ hostname }}:2379{% if not loop.last %},{% endif %}{% endfor %}"
+    peers: "{% for hostname in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ hostname }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}"
     conf_file: "/tmp/flannel-conf.json"
     conf_loc: "/{{ cluster_name }}/network/config"
   run_once: true

--- a/ansible/roles/flannel/templates/flanneld.j2
+++ b/ansible/roles/flannel/templates/flanneld.j2
@@ -1,8 +1,8 @@
 # Flanneld configuration options
 
 # etcd url location.  Point this to the server where etcd runs
-FLANNEL_ETCD="{% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:2379{% if not loop.last %},{% endif %}{% endfor %}"
-FLANNEL_ETCD_ENDPOINTS="{% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:2379{% if not loop.last %},{% endif %}{% endfor %}"
+FLANNEL_ETCD="{% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+FLANNEL_ETCD_ENDPOINTS="{% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 
 # etcd config key.  This is the configuration key that flannel queries
 # For address range assignment

--- a/ansible/roles/master/defaults/main.yml
+++ b/ansible/roles/master/defaults/main.yml
@@ -30,3 +30,5 @@ kube_master_binaries:
 kube_master_rpms:
   - kubernetes-client
   - kubernetes-master
+
+etcd_client_port: '2379'

--- a/ansible/roles/master/templates/apiserver.j2
+++ b/ansible/roles/master/templates/apiserver.j2
@@ -17,7 +17,7 @@ KUBE_API_PORT="--secure-port={{ kube_master_api_port }}"
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range={{ kube_service_addresses }}"
 
 # Location of the etcd cluster
-KUBE_ETCD_SERVERS="--etcd-servers={% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:2379{% if not loop.last %},{% endif %}{% endfor %}{% if etcd_url_scheme is defined and etcd_url_scheme == 'https' %} --etcd-cafile={{ apiserver_etcd_ca_file }} --etcd-certfile={{ apiserver_etcd_cert_file }} --etcd-keyfile={{ apiserver_etcd_key_file }}{% endif %}"
+KUBE_ETCD_SERVERS="--etcd-servers={% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}{% if etcd_url_scheme is defined and etcd_url_scheme == 'https' %} --etcd-cafile={{ apiserver_etcd_ca_file }} --etcd-certfile={{ apiserver_etcd_cert_file }} --etcd-keyfile={{ apiserver_etcd_key_file }}{% endif %}"
 
 # default admission control policies
 KUBE_ADMISSION_CONTROL="--admission-control={{ admission_controllers }}"


### PR DESCRIPTION
The current implementation is inconsistent, with some roles using `etcd_client_port`, and some roles hard-coding "2379" as the port.

This patch fixes those situations.  I also added `etcd_client_port` into `group_vars` so the user only needs to set it once (instead of setting it per role)