### PR TITLE
[Ansible]fix etcd start twice

### DIFF
--- a/ansible/roles/etcd/tasks/main.yml
+++ b/ansible/roles/etcd/tasks/main.yml
@@ -15,5 +15,5 @@
 
 - name: Restart etcd
   include: restart.yml
-  when: etcd_modified is not defined or (etcd_modified is defined and etcd_started.changed == false)
+  when: etcd_modified is not defined or etcd_started.changed == false
   tags: restart

--- a/ansible/roles/etcd/tasks/start.yml
+++ b/ansible/roles/etcd/tasks/start.yml
@@ -1,6 +1,2 @@
 ---
-- include: etcd-start.yml
-  when: not is_coreos
-
-- include: etcd2-start.yml
-  when: is_coreos
+- include: "{% if not is_coreos %}etcd-start{% else %}etcd2-start{% endif %}.yml"


### PR DESCRIPTION
There are two register variables use the same name `etcd_started`, the first one was defined in `etcd-start.yml` and the second one was in `etcd2-start.yml`.
The later var will override the previous var even though the task was skipped, see 

http://docs.ansible.com/ansible/playbooks_variables.html#registered-variables

> Note
If a task fails or is skipped, the variable still is registered with a failure or skipped status, the only way to avoid registering a variable is using tags.

In not-coreos case, this will cause etcd restart immediately during its first start process. 
It is not harmless, it will occationally cause etcd unhealthy and could not start normally again , see https://github.com/kubernetes-incubator/kargo/issues/342