### PR TITLE
Cluster-Autoscaler events on status configmap

### DIFF
--- a/cluster-autoscaler/clusterstate/utils/status.go
+++ b/cluster-autoscaler/clusterstate/utils/status.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	kube_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	kube_client "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+
+	"github.com/golang/glog"
+)
+
+const (
+	// StatusConfigMapNamespace is the namespace where ConfigMap with status is stored.
+	StatusConfigMapNamespace = "kube-system"
+	// StatusConfigMapName is the name of ConfigMap with status.
+	StatusConfigMapName = "cluster-autoscaler-status"
+	// ConfigMapLastUpdatedKey is the name of annotation informing about status ConfigMap last update.
+	ConfigMapLastUpdatedKey = "cluster-autoscaler.kubernetes.io/last-updated"
+)
+
+// LogEventRecorder records events on some top-level object, to give user (without access to logs) a view of most important CA actions.
+type LogEventRecorder struct {
+	recorder     record.EventRecorder
+	statusObject runtime.Object
+	active       bool
+}
+
+// Event record an event on underlying object. This does nothing if the underlying object is not set.
+func (ler *LogEventRecorder) Event(eventtype, reason, message string) {
+	if ler.active && ler.statusObject != nil {
+		ler.recorder.Event(ler.statusObject, eventtype, reason, message)
+	}
+}
+
+// Eventf record an event on underlying object. This does nothing if the underlying object is not set.
+func (ler *LogEventRecorder) Eventf(eventtype, reason, message string, args ...interface{}) {
+	if ler.active && ler.statusObject != nil {
+		ler.recorder.Eventf(ler.statusObject, eventtype, reason, message, args...)
+	}
+}
+
+// NewStatusMapRecorder creates a LogEventRecorder creating events on status configmap.
+// If the configmap doesn't exist it will be created (with 'Initializing' status).
+// If active == false the map will not be created and no events will be recorded.
+func NewStatusMapRecorder(kubeClient kube_client.Interface, recorder record.EventRecorder, active bool) (*LogEventRecorder, error) {
+	var mapObj runtime.Object
+	var err error
+	if active {
+		mapObj, err = WriteStatusConfigMap(kubeClient, "Initializing", nil)
+		if err != nil {
+			return nil, errors.New("Failed to init status ConfigMap")
+		}
+	}
+	return &LogEventRecorder{
+		recorder:     recorder,
+		statusObject: mapObj,
+		active:       active,
+	}, nil
+}
+
+// WriteStatusConfigMap writes updates status ConfigMap with a given message or creates a new
+// ConfigMap if it doesn't exist. If logRecorder is passed and configmap update is successfull
+// logRecorder's internal reference will be updated.
+func WriteStatusConfigMap(kubeClient kube_client.Interface, msg string, logRecorder *LogEventRecorder) (*apiv1.ConfigMap, error) {
+	statusUpdateTime := time.Now()
+	statusMsg := fmt.Sprintf("Cluster-autoscaler status at %v:\n%v", statusUpdateTime, msg)
+	var configMap *apiv1.ConfigMap
+	var getStatusError, writeStatusError error
+	var errMsg string
+	maps := kubeClient.CoreV1().ConfigMaps(StatusConfigMapNamespace)
+	configMap, getStatusError = maps.Get(StatusConfigMapName, metav1.GetOptions{})
+	if getStatusError == nil {
+		configMap.Data["status"] = statusMsg
+		configMap.ObjectMeta.Annotations[ConfigMapLastUpdatedKey] = fmt.Sprintf("%v", statusUpdateTime)
+		configMap, writeStatusError = maps.Update(configMap)
+	} else if kube_errors.IsNotFound(getStatusError) {
+		configMap = &apiv1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: StatusConfigMapNamespace,
+				Name:      StatusConfigMapName,
+				Annotations: map[string]string{
+					ConfigMapLastUpdatedKey: fmt.Sprintf("%v", statusUpdateTime),
+				},
+			},
+			Data: map[string]string{
+				"status": statusMsg,
+			},
+		}
+		configMap, writeStatusError = maps.Create(configMap)
+	} else {
+		errMsg = "Failed to retrieve status configmap for update"
+	}
+	if writeStatusError != nil {
+		errMsg = "Failed to write status configmap"
+	}
+	if errMsg != "" {
+		glog.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+	glog.V(8).Infof("Succesfully wrote status configmap with body \"%v\"", statusMsg)
+	// Having this as a side-effect is somewhat ugly
+	// But it makes error handling easier, as we get a free retry each loop
+	if logRecorder != nil {
+		logRecorder.statusObject = configMap
+	}
+	return configMap, nil
+}
+
+// DeleteStatusConfigMap deletes status configmap
+func DeleteStatusConfigMap(kubeClient kube_client.Interface) error {
+	maps := kubeClient.CoreV1().ConfigMaps(StatusConfigMapNamespace)
+	err := maps.Delete(StatusConfigMapName, &metav1.DeleteOptions{})
+	if err != nil {
+		glog.Error("Failed to delete status configmap")
+	}
+	return err
+}

--- a/cluster-autoscaler/clusterstate/utils/status_test.go
+++ b/cluster-autoscaler/clusterstate/utils/status_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	kube_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testInfo struct {
+	client       *fake.Clientset
+	configMap    *apiv1.ConfigMap
+	getError     error
+	getCalled    bool
+	updateCalled bool
+	createCalled bool
+	t            *testing.T
+}
+
+func setUpTest(t *testing.T) *testInfo {
+	result := testInfo{
+		client: &fake.Clientset{},
+		configMap: &apiv1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   StatusConfigMapNamespace,
+				Name:        StatusConfigMapName,
+				Annotations: map[string]string{},
+			},
+			Data: map[string]string{},
+		},
+		getCalled:    false,
+		updateCalled: false,
+		createCalled: false,
+		t:            t,
+	}
+	result.client.Fake.AddReactor("get", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+		get := action.(core.GetAction)
+		assert.Equal(result.t, StatusConfigMapNamespace, get.GetNamespace())
+		assert.Equal(result.t, StatusConfigMapName, get.GetName())
+		result.getCalled = true
+		if result.getError != nil {
+			return true, nil, result.getError
+		}
+		return true, result.configMap, nil
+	})
+	result.client.Fake.AddReactor("update", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+		update := action.(core.UpdateAction)
+		assert.Equal(result.t, StatusConfigMapNamespace, update.GetNamespace())
+		result.updateCalled = true
+		return true, result.configMap, nil
+	})
+	result.client.Fake.AddReactor("create", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+		create := action.(core.CreateAction)
+		assert.Equal(result.t, StatusConfigMapNamespace, create.GetNamespace())
+		configMap := create.GetObject().(*apiv1.ConfigMap)
+		assert.Equal(result.t, StatusConfigMapName, configMap.ObjectMeta.Name)
+		result.createCalled = true
+		return true, configMap, nil
+	})
+	return &result
+}
+
+func TestWriteStatusConfigMapExisting(t *testing.T) {
+	ti := setUpTest(t)
+	result, err := WriteStatusConfigMap(ti.client, "TEST_MSG", nil)
+	assert.Equal(t, ti.configMap, result)
+	assert.Contains(t, result.Data["status"], "TEST_MSG")
+	assert.Contains(t, result.ObjectMeta.Annotations, ConfigMapLastUpdatedKey)
+	assert.Nil(t, err)
+	assert.True(t, ti.getCalled)
+	assert.True(t, ti.updateCalled)
+	assert.False(t, ti.createCalled)
+}
+
+func TestWriteStatusConfigMapCreate(t *testing.T) {
+	ti := setUpTest(t)
+	ti.getError = kube_errors.NewNotFound(apiv1.Resource("configmap"), "nope, not found")
+	result, err := WriteStatusConfigMap(ti.client, "TEST_MSG", nil)
+	assert.Contains(t, result.Data["status"], "TEST_MSG")
+	assert.Contains(t, result.ObjectMeta.Annotations, ConfigMapLastUpdatedKey)
+	assert.Nil(t, err)
+	assert.True(t, ti.getCalled)
+	assert.False(t, ti.updateCalled)
+	assert.True(t, ti.createCalled)
+}
+
+func TestWriteStatusConfigMapError(t *testing.T) {
+	ti := setUpTest(t)
+	ti.getError = errors.New("stuff bad")
+	result, err := WriteStatusConfigMap(ti.client, "TEST_MSG", nil)
+	assert.NotNil(t, err)
+	assert.Nil(t, result)
+	assert.True(t, ti.getCalled)
+	assert.False(t, ti.updateCalled)
+	assert.False(t, ti.createCalled)
+}

--- a/cluster-autoscaler/core/autoscaling_context.go
+++ b/cluster-autoscaler/core/autoscaling_context.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/contrib/cluster-autoscaler/cloudprovider"
 	"k8s.io/contrib/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/contrib/cluster-autoscaler/clusterstate"
+	"k8s.io/contrib/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/contrib/cluster-autoscaler/expander"
 	"k8s.io/contrib/cluster-autoscaler/expander/factory"
 	"k8s.io/contrib/cluster-autoscaler/simulator"
@@ -48,6 +49,8 @@ type AutoscalingContext struct {
 	PredicateChecker *simulator.PredicateChecker
 	// ExpanderStrategy is the strategy used to choose which node group to expand when scaling up
 	ExpanderStrategy expander.Strategy
+	// LogRecorder can be used to collect log messages to expose via Events on some central object.
+	LogRecorder *utils.LogEventRecorder
 }
 
 // AutoscalingOptions contain various options to customize how autoscaling works
@@ -99,7 +102,8 @@ type AutoscalingOptions struct {
 }
 
 // NewAutoscalingContext returns an autoscaling context from all the necessary parameters passed via arguments
-func NewAutoscalingContext(options AutoscalingOptions, predicateChecker *simulator.PredicateChecker, kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder) *AutoscalingContext {
+func NewAutoscalingContext(options AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
+	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder, logEventRecorder *utils.LogEventRecorder) *AutoscalingContext {
 	cloudProviderBuilder := builder.NewCloudProviderBuilder(options.CloudProviderName, options.CloudConfig)
 	cloudProvider := cloudProviderBuilder.Build(options.NodeGroups)
 	expanderStrategy := factory.ExpanderStrategyFromString(options.ExpanderName)
@@ -118,6 +122,7 @@ func NewAutoscalingContext(options AutoscalingOptions, predicateChecker *simulat
 		Recorder:             kubeEventRecorder,
 		PredicateChecker:     predicateChecker,
 		ExpanderStrategy:     expanderStrategy,
+		LogRecorder:          logEventRecorder,
 	}
 
 	return &autoscalingContext

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -219,6 +219,7 @@ func (sd *ScaleDown) TryToScaleDown(nodes []*apiv1.Node, pods []*apiv1.Pod) (Sca
 		confirmation := make(chan error, len(emptyNodes))
 		for _, node := range emptyNodes {
 			glog.V(0).Infof("Scale-down: removing empty node %s", node.Name)
+			sd.context.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaleDownEmpty", "Scale-down: removing empty node %s", node.Name)
 			simulator.RemoveNodeFromTracker(sd.usageTracker, node.Name, sd.unneededNodes)
 			go func(nodeToDelete *apiv1.Node) {
 				confirmation <- deleteNodeFromCloudProvider(nodeToDelete, sd.context.CloudProvider,
@@ -271,6 +272,8 @@ func (sd *ScaleDown) TryToScaleDown(nodes []*apiv1.Node, pods []*apiv1.Pod) (Sca
 	}
 	glog.V(0).Infof("Scale-down: removing node %s, utilization: %v, pods to reschedule: %s", toRemove.Node.Name, utilization,
 		strings.Join(podNames, ","))
+	sd.context.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaleDown", "Scale-down: removing node %s, utilization: %v, pods to reschedule: %s",
+		toRemove.Node.Name, utilization, strings.Join(podNames, ","))
 
 	// Nothing super-bad should happen if the node is removed from tracker prematurely.
 	simulator.RemoveNodeFromTracker(sd.usageTracker, toRemove.Node.Name, sd.unneededNodes)

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -27,6 +27,7 @@ import (
 	core "k8s.io/client-go/testing"
 	"k8s.io/contrib/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/contrib/cluster-autoscaler/clusterstate"
+	"k8s.io/contrib/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/contrib/cluster-autoscaler/simulator"
 	kube_util "k8s.io/contrib/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/contrib/cluster-autoscaler/utils/test"
@@ -69,11 +70,15 @@ func TestFindUnneededNodes(t *testing.T) {
 	SetNodeReadyState(n3, true, time.Time{})
 	SetNodeReadyState(n4, true, time.Time{})
 
+	fakeClient := &fake.Clientset{}
+	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
 	context := AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.35,
 		},
 		PredicateChecker: simulator.NewTestPredicateChecker(),
+		LogRecorder:      fakeLogRecorder,
 	}
 	sd := NewScaleDown(&context)
 	sd.UpdateUnneededNodes([]*apiv1.Node{n1, n2, n3, n4}, []*apiv1.Pod{p1, p2, p3, p4}, time.Now())
@@ -194,6 +199,8 @@ func TestScaleDown(t *testing.T) {
 	provider.AddNode("ng1", n2)
 	assert.NotNil(t, provider)
 
+	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.5,
@@ -203,8 +210,9 @@ func TestScaleDown(t *testing.T) {
 		PredicateChecker:     simulator.NewTestPredicateChecker(),
 		CloudProvider:        provider,
 		ClientSet:            fakeClient,
-		Recorder:             kube_util.CreateEventRecorder(fakeClient),
+		Recorder:             fakeRecorder,
 		ClusterStateRegistry: clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}),
+		LogRecorder:          fakeLogRecorder,
 	}
 	scaleDown := NewScaleDown(context)
 	scaleDown.UpdateUnneededNodes([]*apiv1.Node{n1, n2}, []*apiv1.Pod{p1, p2}, time.Now().Add(-5*time.Minute))
@@ -249,6 +257,8 @@ func TestNoScaleDownUnready(t *testing.T) {
 	provider.AddNode("ng1", n1)
 	provider.AddNode("ng1", n2)
 
+	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.5,
@@ -259,8 +269,9 @@ func TestNoScaleDownUnready(t *testing.T) {
 		PredicateChecker:     simulator.NewTestPredicateChecker(),
 		CloudProvider:        provider,
 		ClientSet:            fakeClient,
-		Recorder:             kube_util.CreateEventRecorder(fakeClient),
+		Recorder:             fakeRecorder,
 		ClusterStateRegistry: clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}),
+		LogRecorder:          fakeLogRecorder,
 	}
 
 	// N1 is unready so it requires a bigger unneeded time.
@@ -350,6 +361,8 @@ func TestScaleDownNoMove(t *testing.T) {
 	provider.AddNode("ng1", n2)
 	assert.NotNil(t, provider)
 
+	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			ScaleDownUtilizationThreshold: 0.5,
@@ -360,8 +373,9 @@ func TestScaleDownNoMove(t *testing.T) {
 		PredicateChecker:     simulator.NewTestPredicateChecker(),
 		CloudProvider:        provider,
 		ClientSet:            fakeClient,
-		Recorder:             kube_util.CreateEventRecorder(fakeClient),
+		Recorder:             fakeRecorder,
 		ClusterStateRegistry: clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}),
+		LogRecorder:          fakeLogRecorder,
 	}
 	scaleDown := NewScaleDown(context)
 	scaleDown.UpdateUnneededNodes([]*apiv1.Node{n1, n2}, []*apiv1.Pod{p1, p2}, time.Now().Add(5*time.Minute))

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -153,7 +153,6 @@ func ScaleUp(context *AutoscalingContext, unschedulablePods []*apiv1.Pod, nodes 
 		}
 
 		glog.V(0).Infof("Scale-up: setting group %s size to %d", bestOption.NodeGroup.Id(), newSize)
-
 		increase := newSize - currentSize
 		if err := bestOption.NodeGroup.IncreaseSize(increase); err != nil {
 			return false, fmt.Errorf("failed to increase node group size: %v", err)
@@ -165,6 +164,8 @@ func ScaleUp(context *AutoscalingContext, unschedulablePods []*apiv1.Pod, nodes 
 				Time:            time.Now(),
 				ExpectedAddTime: time.Now().Add(context.MaxNodeProvisionTime),
 			})
+		context.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
+			"Scale-up: group %s size set to %d", bestOption.NodeGroup.Id(), newSize)
 
 		for _, pod := range bestOption.Pods {
 			context.Recorder.Eventf(pod, apiv1.EventTypeNormal, "TriggeredScaleUp",

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -27,6 +27,7 @@ import (
 	core "k8s.io/client-go/testing"
 	"k8s.io/contrib/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/contrib/cluster-autoscaler/clusterstate"
+	"k8s.io/contrib/cluster-autoscaler/clusterstate/utils"
 	"k8s.io/contrib/cluster-autoscaler/estimator"
 	"k8s.io/contrib/cluster-autoscaler/expander/random"
 	"k8s.io/contrib/cluster-autoscaler/simulator"
@@ -74,6 +75,8 @@ func TestScaleUpOK(t *testing.T) {
 
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{})
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
+	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -81,9 +84,10 @@ func TestScaleUpOK(t *testing.T) {
 		PredicateChecker:     simulator.NewTestPredicateChecker(),
 		CloudProvider:        provider,
 		ClientSet:            fakeClient,
-		Recorder:             kube_util.CreateEventRecorder(fakeClient),
+		Recorder:             fakeRecorder,
 		ExpanderStrategy:     random.NewStrategy(),
 		ClusterStateRegistry: clusterState,
+		LogRecorder:          fakeLogRecorder,
 	}
 	p3 := BuildTestPod("p-new", 500, 0)
 
@@ -135,6 +139,8 @@ func TestScaleUpNodeComingNoScale(t *testing.T) {
 	})
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
+	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -142,9 +148,10 @@ func TestScaleUpNodeComingNoScale(t *testing.T) {
 		PredicateChecker:     simulator.NewTestPredicateChecker(),
 		CloudProvider:        provider,
 		ClientSet:            fakeClient,
-		Recorder:             kube_util.CreateEventRecorder(fakeClient),
+		Recorder:             fakeRecorder,
 		ExpanderStrategy:     random.NewStrategy(),
 		ClusterStateRegistry: clusterState,
+		LogRecorder:          fakeLogRecorder,
 	}
 	p3 := BuildTestPod("p-new", 550, 0)
 
@@ -197,6 +204,8 @@ func TestScaleUpNodeComingHasScale(t *testing.T) {
 	})
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
 
+	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -204,9 +213,10 @@ func TestScaleUpNodeComingHasScale(t *testing.T) {
 		PredicateChecker:     simulator.NewTestPredicateChecker(),
 		CloudProvider:        provider,
 		ClientSet:            fakeClient,
-		Recorder:             kube_util.CreateEventRecorder(fakeClient),
+		Recorder:             fakeRecorder,
 		ExpanderStrategy:     random.NewStrategy(),
 		ClusterStateRegistry: clusterState,
+		LogRecorder:          fakeLogRecorder,
 	}
 	p3 := BuildTestPod("p-new", 550, 0)
 
@@ -252,6 +262,8 @@ func TestScaleUpUnhealthy(t *testing.T) {
 
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{})
 	clusterState.UpdateNodes([]*apiv1.Node{n1, n2}, time.Now())
+	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -259,9 +271,10 @@ func TestScaleUpUnhealthy(t *testing.T) {
 		PredicateChecker:     simulator.NewTestPredicateChecker(),
 		CloudProvider:        provider,
 		ClientSet:            fakeClient,
-		Recorder:             kube_util.CreateEventRecorder(fakeClient),
+		Recorder:             fakeRecorder,
 		ExpanderStrategy:     random.NewStrategy(),
 		ClusterStateRegistry: clusterState,
+		LogRecorder:          fakeLogRecorder,
 	}
 	p3 := BuildTestPod("p-new", 550, 0)
 
@@ -298,6 +311,8 @@ func TestScaleUpNoHelp(t *testing.T) {
 
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{})
 	clusterState.UpdateNodes([]*apiv1.Node{n1}, time.Now())
+	fakeRecorder := kube_util.CreateEventRecorder(fakeClient)
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, fakeRecorder, false)
 	context := &AutoscalingContext{
 		AutoscalingOptions: AutoscalingOptions{
 			EstimatorName: estimator.BinpackingEstimatorName,
@@ -305,9 +320,10 @@ func TestScaleUpNoHelp(t *testing.T) {
 		PredicateChecker:     simulator.NewTestPredicateChecker(),
 		CloudProvider:        provider,
 		ClientSet:            fakeClient,
-		Recorder:             kube_util.CreateEventRecorder(fakeClient),
+		Recorder:             fakeRecorder,
 		ExpanderStrategy:     random.NewStrategy(),
 		ClusterStateRegistry: clusterState,
+		LogRecorder:          fakeLogRecorder,
 	}
 	p3 := BuildTestPod("p-new", 500, 0)
 


### PR DESCRIPTION
Write events on status configmap on scale up / scale down. Moved writing to status configmap to a separate file (clusterstate/utils/status.go) to clean up and also allow reasonably isolated unittests.