### PR TITLE
[Ansible] Use slurp and copy instead of synchronize

### DIFF
--- a/ansible/roles/kubernetes/tasks/gen_tokens.yml
+++ b/ansible/roles/kubernetes/tasks/gen_tokens.yml
@@ -4,16 +4,19 @@
     src=kube-gen-token.sh
     dest={{ kube_script_dir }}
     mode=u+x
+  run_once: true
 
 - name: Generate tokens for master components
   command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item[0] }}-{{ item[1] }}"
   environment:
     TOKEN_DIR: "{{ kube_token_dir }}"
+  delegate_to: "{{ groups['masters'][0] }}"
+  run_once: true
   with_nested:
     - [ "system:controller_manager", "system:scheduler", "system:kubectl" ]
     - "{{ groups['masters'] }}"
-  register: gentoken
-  changed_when: "'Added' in gentoken.stdout"
+  register: gentoken_master
+  changed_when: "'Added' in gentoken_master.stdout"
   notify:
     - restart daemons
 
@@ -21,10 +24,12 @@
   command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item[0] }}-{{ item[1] }}"
   environment:
     TOKEN_DIR: "{{ kube_token_dir }}"
+  delegate_to: "{{ groups['masters'][0] }}"
+  run_once: true
   with_nested:
     - [ 'system:kubelet', 'system:proxy' ]
     - "{{ groups['nodes'] }}"
-  register: gentoken
-  changed_when: "'Added' in gentoken.stdout"
+  register: gentoken_node
+  changed_when: "'Added' in gentoken_node.stdout"
   notify:
     - restart daemons

--- a/ansible/roles/kubernetes/tasks/secrets.yml
+++ b/ansible/roles/kubernetes/tasks/secrets.yml
@@ -81,15 +81,41 @@
 
 - include: gen_tokens.yml
   when: inventory_hostname == groups['masters'][0]
+  tags:
+    - secrets
+    - configure
 
-- name: Copy tokens to other masters
-  synchronize:
-    src: /etc/kubernetes/tokens/
-    dest: /etc/kubernetes/tokens
+- name: Slurp known_tokens.csv from first master
+  slurp:
+    src: "{{ kube_token_dir }}/known_tokens.csv"
+  register: known_tokens
   delegate_to: "{{ groups['masters'][0] }}"
-  when: inventory_hostname in groups['masters'] and inventory_hostname != groups['masters'][0] 
+  run_once: true
+  tags:
+    - secrets
+    - configure
+
+- name: Copy known_tokens.csv to other masters
+  copy:
+    content: "{{ known_tokens.content|b64decode }}"
+    dest: "{{ kube_token_dir }}/known_tokens.csv"
+  when: inventory_hostname in groups['masters'] and inventory_hostname != groups['masters'][0]
   notify:
     - restart daemons
   tags:
-   - secrets
-   - configure
+    - secrets
+    - configure
+
+- name: Copy token files to other masters
+  copy:
+    content: "{{ item.stdout }}"
+    dest: "{{ kube_token_dir }}/{{ item.cmd[1] }}.token"
+  when: inventory_hostname in groups['masters'] and inventory_hostname != groups['masters'][0]
+  with_items:
+    - "{{ gentoken_master.results }}"
+    - "{{ gentoken_node.results }}"
+  notify:
+    - restart daemons
+  tags:
+    - secrets
+    - configure


### PR DESCRIPTION
Ansible synchronize module is a huge trouble for users with a ssh gateway or just extremely strict sshd config(s), not allowing direct server to server, and only playbook-runner to server connections.
Only the know_tokens file is copied, but for **other** masters more isn't needed.

/cc @xialonglee Do you think this is "okay" to change to only copy the `know_tokens.csv`?