### PR TITLE
Cluster-autoscaler: precheck that the api server link is ok

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -231,6 +231,13 @@ func main() {
 		}
 
 		kubeClient := createKubeClient()
+
+		// Validate that the client is ok.
+		_, err = kubeClient.Core().Nodes().List(metav1.ListOptions{})
+		if err != nil {
+			glog.Fatalf("Failed to get nodes from apiserver: %v", err)
+		}
+
 		kube_leaderelection.RunOrDie(kube_leaderelection.LeaderElectionConfig{
 			Lock: &resourcelock.EndpointsLock{
 				EndpointsMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The logs from leader election are super vague. An explicit check is needed to let the user know that the connection could not be established.

cc: @jszczepkowski @MaciekPytel 