### PR TITLE
[Ansible]keep consistent with secret files mode

### DIFF
--- a/ansible/roles/kubernetes/tasks/secrets.yml
+++ b/ansible/roles/kubernetes/tasks/secrets.yml
@@ -47,7 +47,12 @@
     kube_ca_cert: "{{ ca_cert.content|b64decode }}"
 
 - name: Place CA certificate and kube_cfg credentials everywhere
-  copy: content="{{ kube_ca_cert }}" dest="{{ kube_cert_dir }}/ca.crt"
+  copy:
+    content: "{{ kube_ca_cert }}"
+    dest: "{{ kube_cert_dir }}/ca.crt"
+    group: "{{ kube_cert_group }}"
+    owner: "kube"
+    mode: 0440
 
 - name: Read back the kubecfg key
   slurp:
@@ -61,7 +66,12 @@
     kube_api_key: "{{ api_key.content|b64decode }}"
 
 - name: Place CA certificate and kube_cfg credentials everywhere
-  copy: content="{{ kube_api_key }}" dest="{{ kube_cert_dir }}/kubecfg.key"
+  copy:
+    content: "{{ kube_api_key }}"
+    dest: "{{ kube_cert_dir }}/kubecfg.key"
+    group: "{{ kube_cert_group }}"
+    owner: "kube"
+    mode: 0440
 
 - name: Read back the kubecfg cert
   slurp:
@@ -75,7 +85,12 @@
     kube_api_crt: "{{ api_crt.content|b64decode }}"
 
 - name: Place CA certificate and kube_cfg credentials everywhere
-  copy: content="{{ kube_api_crt }}" dest="{{ kube_cert_dir }}/kubecfg.crt"
+  copy:
+    content: "{{ kube_api_crt }}"
+    dest: "{{ kube_cert_dir }}/kubecfg.crt"
+    group: "{{ kube_cert_group }}"
+    owner: "kube"
+    mode: 0440
   notify:
     - restart daemons
 


### PR DESCRIPTION
All certificate files should keep the same permission mode, as the task `Verify certificate permissions` done.