### PR TITLE
[Ansible] fix cluster_hostname var not being used in all kubeconfigs

### DIFF
--- a/ansible/roles/master/templates/controller-manager.kubeconfig.j2
+++ b/ansible/roles/master/templates/controller-manager.kubeconfig.j2
@@ -5,7 +5,11 @@ preferences: {}
 clusters:
 - cluster:
     certificate-authority: {{ kube_cert_dir }}/ca.crt
+{% if cluster_hostname | default("") != "" %}
+    server: https://{{ cluster_hostname }}:{{ cluster_port }}
+{% else %}
     server: https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}
+{% endif %}
   name: {{ cluster_name }}
 contexts:
 - context:

--- a/ansible/roles/master/templates/scheduler.kubeconfig.j2
+++ b/ansible/roles/master/templates/scheduler.kubeconfig.j2
@@ -5,7 +5,11 @@ preferences: {}
 clusters:
 - cluster:
     certificate-authority: {{ kube_cert_dir }}/ca.crt
+{% if cluster_hostname | default("") != "" %}
+    server: https://{{ cluster_hostname }}:{{ cluster_port }}
+{% else %}
     server: https://{{ groups['masters'][0] }}:{{ kube_master_api_port }}
+{% endif %}
   name: {{ cluster_name }}
 contexts:
 - context:


### PR DESCRIPTION
This should fix the issue that the var `cluster_hostname` wasn't used everywhere where it should has.

/cc @talset