### PR TITLE
[ansible] add cluster_public_hostname

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -16,6 +16,9 @@ cluster_name: cluster.local
 # kubenetes master
 #master_cluster_hostname: kubernetes-cluster.example.com
 
+# External fqdn used for the cluster (certificat only)
+#master_cluster_public_hostname: public-kubernetes
+
 # Port number for the load balanced master hostname.
 #master_cluster_port: 443
 

--- a/ansible/roles/kubernetes/files/make-ca-cert.sh
+++ b/ansible/roles/kubernetes/files/make-ca-cert.sh
@@ -110,6 +110,10 @@ if [[ -n "${CLUSTER_HOSTNAME}" ]]; then
     san_array+=(DNS:${CLUSTER_HOSTNAME})
 fi
 
+if [[ -n "${CLUSTER_PUBLIC_HOSTNAME}" ]]; then
+    san_array+=(DNS:${CLUSTER_PUBLIC_HOSTNAME})
+fi
+
 sans="$(IFS=, ; echo "${san_array[*]}")"
 
 curl -sSL -O https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz

--- a/ansible/roles/kubernetes/tasks/gen_certs.yml
+++ b/ansible/roles/kubernetes/tasks/gen_certs.yml
@@ -36,7 +36,8 @@
     CERT_GROUP: "{{ kube_cert_group }}"
     HTTP_PROXY: "{{ http_proxy|default('') }}"
     HTTPS_PROXY: "{{ https_proxy|default('') }}"
-    CLUSTER_HOSTNAME: "{{ master_cluster_hostname |default('') }}"
+    CLUSTER_HOSTNAME: "{{ master_cluster_hostname|default('') }}"
+    CLUSTER_PUBLIC_HOSTNAME: "{{ master_cluster_public_hostname|default('') }}"
 
 - name: Verify certificate permissions
   file:


### PR DESCRIPTION
The cluster_hostname is already present (to be able to reach the
private/internal vip kube api).
The goal of cluster_public_hostname is to have the same thing but for
public access to the api.

If the public vip domain is not part of the certificat, when you will
try to access to the api via kubectl you will have something like that :

Unable to connect to the server: x509: certificate is valid for
cluster_hostname, master0, master1 ..., not cluster_public_hostname