### PR TITLE
Cluster-Autoscaler: skip nodes currently under deletion in scale down

### DIFF
--- a/cluster-autoscaler/utils/deletetaint/delete.go
+++ b/cluster-autoscaler/utils/deletetaint/delete.go
@@ -78,6 +78,20 @@ func HasToBeDeletedTaint(node *apiv1.Node) bool {
 	return false
 }
 
+// GetToBeDeletedTime returns the date when the node was marked by CA as for delete.
+func GetToBeDeletedTime(node *apiv1.Node) (*time.Time, error) {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == ToBeDeletedTaint {
+			result, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", taint.Value)
+			if err != nil {
+				return nil, err
+			}
+			return &result, nil
+		}
+	}
+	return nil, nil
+}
+
 // CleanToBeDeleted cleans ToBeDeleted taint.
 func CleanToBeDeleted(node *apiv1.Node, client kube_client.Interface) (bool, error) {
 	newTaints := make([]apiv1.Taint, 0)

--- a/cluster-autoscaler/utils/deletetaint/delete_test.go
+++ b/cluster-autoscaler/utils/deletetaint/delete_test.go
@@ -40,6 +40,19 @@ func TestMarkNodes(t *testing.T) {
 	assert.True(t, HasToBeDeletedTaint(node))
 }
 
+func TestCheckNodes(t *testing.T) {
+	node := BuildTestNode("node", 1000, 1000)
+	fakeClient, updatedNodes := buildFakeClientAndUpdateChannel(node)
+	err := MarkToBeDeleted(node, fakeClient)
+	assert.NoError(t, err)
+	assert.Equal(t, node.Name, getStringFromChan(updatedNodes))
+	assert.True(t, HasToBeDeletedTaint(node))
+
+	val, err := GetToBeDeletedTime(node)
+	assert.NoError(t, err)
+	assert.True(t, time.Now().Sub(*val) < 10*time.Second)
+}
+
 func TestCleanNodes(t *testing.T) {
 	node := BuildTestNode("node", 1000, 1000)
 	addToBeDeletedTaint(node)


### PR DESCRIPTION
Currently we may try to delete the same node multiple times.

cc: @MaciekPytel @jszczepkowski @fgrzadkowski 