### PR TITLE
fluent-plugin-systemd to 0.0.8 & cleanup libc6-dev

### DIFF
--- a/fluentd/fluentd-gcp-image/Dockerfile
+++ b/fluentd/fluentd-gcp-image/Dockerfile
@@ -28,7 +28,7 @@ COPY Gemfile /Gemfile
 # 2. Install fluentd via ruby.
 # 3. Remove build dependencies.
 # 4. Cleanup leftover caches & files.
-RUN BUILD_DEPS="make gcc g++ libc-dev ruby-dev" \
+RUN BUILD_DEPS="make gcc g++ libc6-dev ruby-dev" \
     && clean-install $BUILD_DEPS \
                      ca-certificates \
                      libjemalloc1 \

--- a/fluentd/fluentd-gcp-image/Gemfile
+++ b/fluentd/fluentd-gcp-image/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'fluentd', '~>0.12.32'
 gem 'fluent-plugin-record-reformer', '~>0.8.3'
-gem 'fluent-plugin-systemd', '0.0.6'
+gem 'fluent-plugin-systemd', '~>0.0.8'
 gem 'fluent-plugin-google-cloud', '~>0.5.6'
 gem 'fluent-plugin-detect-exceptions', '~>0.0.5'
 gem 'fluent-plugin-prometheus', '~>0.2.1'

--- a/fluentd/fluentd-gcp-image/Makefile
+++ b/fluentd/fluentd-gcp-image/Makefile
@@ -26,7 +26,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google-containers
-TAG = 2.0.1
+TAG = 2.0.2
 
 build:
 	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .


### PR DESCRIPTION
Diff: https://github.com/timstclair/kubernetes/commit/e0b766b63b4ebafb3df8acd2cbc4d36abfe81b1e

Changes:

1. The fluent-plugin-systemd regression was fixed in 0.0.8 (https://github.com/reevoo/fluent-plugin-systemd/issues/32)
2. `libc-dev` is an alias for `libc6-dev`, which works on install but not purge for some reason, so a couple build dependencies were being left behind. Changing to `libc6-dev` solves this.
3. All other gem & package changes are just updates since the last image was built.

/cc @piosz 