### PR TITLE
Fixup ca-cert, private key needs to be kept

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -107,6 +107,14 @@ dns_setup: true
 # How many replicas in the Replication Controller
 dns_replicas: 1
 
+# Certificate authority private key should not be kept on server
+# but you probably want to keep it to generate user certificates. Set
+# that value to "true" to keep ca.key file on {{ kube_cert_dir}}.
+# It's recommanded to remove the private key from the server. So if you set
+# kube_cert_keep_ca to true, please copy the ca.key file somewhere that
+# is secured, and remove it from server.
+kube_cert_keep_ca: false
+
 # There are other variable in roles/kubernetes/defaults/main.yml but changing
 # them comes with a much higher risk to your cluster. So proceed over there
 # with caution.

--- a/ansible/roles/kubernetes/files/make-ca-cert.sh
+++ b/ansible/roles/kubernetes/files/make-ca-cert.sh
@@ -27,6 +27,7 @@ set -o pipefail
 # MASTERS - DNS name for the masters
 # DNS_DOMAIN - which will be passed to minions in --cluster-domain
 # SERVICE_CLUSTER_IP_RANGE - where all service IPs are allocated
+# KUBE_CERT_KEEP_CA - to keep ca.key file or not, "true"|"false"
 
 # Also the following will be respected
 # CERT_DIR - where to place the finished certs
@@ -38,6 +39,7 @@ service_range="${SERVICE_CLUSTER_IP_RANGE:="10.0.0.0/16"}"
 dns_domain="${DNS_DOMAIN:="cluster.local"}"
 cert_dir="${CERT_DIR:-"/srv/kubernetes"}"
 cert_group="${CERT_GROUP:="kube-cert"}"
+keep_ca_priv_key="${KUBE_CERT_KEEP_CA:="false"}"
 
 # The following certificate pairs are created:
 #
@@ -142,6 +144,9 @@ cp -p pki/issued/kubelet.crt "${cert_dir}/kubelet.crt"
 cp -p pki/private/kubelet.key "${cert_dir}/kubelet.key"
 
 CERTS=("ca.crt" "server.key" "server.crt" "kubelet.key" "kubelet.crt" "kubecfg.key" "kubecfg.crt")
+if [[ "${keep_ca_priv_key}" == "true" ]]; then
+    CERTS+=("ca.key")
+fi
 for cert in "${CERTS[@]}"; do
   chgrp "${cert_group}" "${cert_dir}/${cert}"
   chmod 660 "${cert_dir}/${cert}"

--- a/ansible/roles/kubernetes/tasks/gen_certs.yml
+++ b/ansible/roles/kubernetes/tasks/gen_certs.yml
@@ -38,6 +38,7 @@
     HTTPS_PROXY: "{{ https_proxy|default('') }}"
     CLUSTER_HOSTNAME: "{{ master_cluster_hostname|default('') }}"
     CLUSTER_PUBLIC_HOSTNAME: "{{ master_cluster_public_hostname|default('') }}"
+    KUBE_CERT_KEEP_CA: "{{ kube_cert_keep_ca | default('false') | lower }}"
 
 - name: Verify certificate permissions
   file:
@@ -51,3 +52,11 @@
     - "{{ kube_cert_dir }}/server.key"
     - "{{ kube_cert_dir }}/kubecfg.crt"
     - "{{ kube_cert_dir }}/kubecfg.key"
+
+- name: Check CA private key permissions if kube_cert_keep_ca is set to "true"
+  file:
+    path: "{{ kube_cert_dir }}/ca.key"
+    group: "{{ kube_cert_group }}"
+    owner: kube
+    mode: 0440
+  when: kube_cert_keep_ca


### PR DESCRIPTION
To be able to create user certificates, we need to have ca.key on one server (masters).

Fixes #2394
Fixes #651