### PR TITLE
Cluster-Autoscaler: fix delete taint value format

### DIFF
--- a/cluster-autoscaler/utils/deletetaint/delete.go
+++ b/cluster-autoscaler/utils/deletetaint/delete.go
@@ -18,6 +18,7 @@ package deletetaint
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +63,7 @@ func addToBeDeletedTaint(node *apiv1.Node) (bool, error) {
 	}
 	node.Spec.Taints = append(node.Spec.Taints, apiv1.Taint{
 		Key:    ToBeDeletedTaint,
-		Value:  time.Now().String(),
+		Value:  fmt.Sprint(time.Now().Unix()),
 		Effect: apiv1.TaintEffectNoSchedule,
 	})
 	return true, nil
@@ -82,10 +83,11 @@ func HasToBeDeletedTaint(node *apiv1.Node) bool {
 func GetToBeDeletedTime(node *apiv1.Node) (*time.Time, error) {
 	for _, taint := range node.Spec.Taints {
 		if taint.Key == ToBeDeletedTaint {
-			result, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", taint.Value)
+			resultTimestamp, err := strconv.ParseInt(taint.Value, 10, 64)
 			if err != nil {
 				return nil, err
 			}
+			result := time.Unix(resultTimestamp, 0)
 			return &result, nil
 		}
 	}


### PR DESCRIPTION
Fix a bug, where non-compliant value format prevented CA deletetaint from being created (which in turn caused CA node drain to fail).