### PR TITLE
Cluster-Autoscaler: fix delete taint failing

### DIFF
--- a/cluster-autoscaler/utils/deletetaint/delete.go
+++ b/cluster-autoscaler/utils/deletetaint/delete.go
@@ -96,8 +96,12 @@ func GetToBeDeletedTime(node *apiv1.Node) (*time.Time, error) {
 
 // CleanToBeDeleted cleans ToBeDeleted taint.
 func CleanToBeDeleted(node *apiv1.Node, client kube_client.Interface) (bool, error) {
+	freshNode, err := client.Core().Nodes().Get(node.Name, metav1.GetOptions{})
+	if err != nil || freshNode == nil {
+		return false, fmt.Errorf("failed to get node %v: %v", node.Name, err)
+	}
 	newTaints := make([]apiv1.Taint, 0)
-	for _, taint := range node.Spec.Taints {
+	for _, taint := range freshNode.Spec.Taints {
 		if taint.Key == ToBeDeletedTaint {
 			glog.V(1).Infof("Releasing taint %+v on node %v", taint, node.Name)
 		} else {
@@ -105,9 +109,9 @@ func CleanToBeDeleted(node *apiv1.Node, client kube_client.Interface) (bool, err
 		}
 	}
 
-	if len(newTaints) != len(node.Spec.Taints) {
-		node.Spec.Taints = newTaints
-		_, err := client.Core().Nodes().Update(node)
+	if len(newTaints) != len(freshNode.Spec.Taints) {
+		freshNode.Spec.Taints = newTaints
+		_, err := client.Core().Nodes().Update(freshNode)
 		if err != nil {
 			glog.Warningf("Error while releasing taints on node %v: %v", node.Name, err)
 			return false, err


### PR DESCRIPTION
It was using old node version (which in general is always going to be outdated, as we've likely modified it by adding delete taint).

@mwielgus 