### PR TITLE
[Ansible] Add apiserver-count as apiserver option

### DIFF
--- a/ansible/roles/master/defaults/main.yml
+++ b/ansible/roles/master/defaults/main.yml
@@ -31,10 +31,6 @@ kube_master_rpms:
   - kubernetes-client
   - kubernetes-master
 
-kube_apiserver_options: []
-kube_controller_manager_options: []
-kube_scheduler_options: []
-
 etcd_client_port: '2379'
 
 kube_apiserver_options:
@@ -44,6 +40,7 @@ kube_apiserver_options:
   - "--token-auth-file={{ kube_token_dir }}/known_tokens.csv"
   - "--service-account-key-file={{ kube_cert_dir }}/server.crt"
   - "--bind-address={{ kube_apiserver_bind_address }}"
+  - "--apiserver-count={{ groups['masters']|length }}"
 
 kube_controller_manager_options:
   - "--kubeconfig={{ kube_config_dir }}/controller-manager.kubeconfig"

--- a/ansible/roles/master/templates/apiserver.j2
+++ b/ansible/roles/master/templates/apiserver.j2
@@ -23,4 +23,4 @@ KUBE_ETCD_SERVERS="--etcd-servers={% for node in groups['etcd'] %}{% if etcd_url
 KUBE_ADMISSION_CONTROL="--admission-control={{ admission_controllers }}"
 
 # Add your own!
-KUBE_API_ARGS="{{ kube_apiserver_additional_options|join(' ') }} {{ kube_apiserver_additional_options|join(' ') }}"
+KUBE_API_ARGS="{{ kube_apiserver_options|join(' ') }} {{ kube_apiserver_additional_options|join(' ') }}"

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -15,11 +15,6 @@ kube_node_rpms:
   - kubernetes-client
   - kubernetes-node
 
-kubelet_options: []
-#  - "--host-network-sources=*"
-#  - "--pod-infra-container-image=gcr.io/google_containers/pause:2.0"
-kube_proxy_options: []
-
 kubelet_options:
   - "--kubeconfig={{ kube_config_dir }}/kubelet.kubeconfig"
   - "--config={{ kube_manifest_dir }}"
@@ -28,4 +23,7 @@ kube_proxy_options:
   - "--kubeconfig={{ kube_config_dir }}/proxy.kubeconfig"
 
 kubelet_additional_options: []
+#  - "--host-network-sources=*"
+#  - "--pod-infra-container-image=gcr.io/google_containers/pause:2.0"
+
 kube_proxy_additional_options: []


### PR DESCRIPTION
Fix the `kube_apiserver_options` variable usage in the template
Removed duplicate variables from the master and node role defaults

/cc @xialonglee @axhoffmann For even better multi master clusters ;)