### PR TITLE
Cluster-Autoscaler: consider node with unknown readiness unready

### DIFF
--- a/cluster-autoscaler/utils/kubernetes/ready.go
+++ b/cluster-autoscaler/utils/kubernetes/ready.go
@@ -45,7 +45,7 @@ func GetReadinessState(node *apiv1.Node) (isNodeReady bool, lastTransitionTime t
 		switch cond.Type {
 		case apiv1.NodeReady:
 			readyFound = true
-			if cond.Status == apiv1.ConditionFalse {
+			if cond.Status == apiv1.ConditionFalse || cond.Status == apiv1.ConditionUnknown {
 				canNodeBeReady = false
 			}
 			if lastTransitionTime.Before(cond.LastTransitionTime.Time) {


### PR DESCRIPTION
Node with non-responsive kubelet seems to be marked as NodeReady: Unknown, which is currently considered as ready by CA.