### PR TITLE
[Ansible] Forgotten copy of ca.key

### DIFF
--- a/ansible/roles/kubernetes/files/make-ca-cert.sh
+++ b/ansible/roles/kubernetes/files/make-ca-cert.sh
@@ -145,6 +145,7 @@ cp -p pki/private/kubelet.key "${cert_dir}/kubelet.key"
 
 CERTS=("ca.crt" "server.key" "server.crt" "kubelet.key" "kubelet.crt" "kubecfg.key" "kubecfg.crt")
 if [[ "${keep_ca_priv_key}" == "true" ]]; then
+    cp -p pki/private/ca.key "${cert_dir}/ca.key"
     CERTS+=("ca.key")
 fi
 for cert in "${CERTS[@]}"; do


### PR DESCRIPTION
When kube_cert_keep_ca is true, we must copy the certificate private key. That was forgotten in earlier PR acceptance.