### PR TITLE
Cluster-Autoscaler: reset unneededNodes list on cluster failure

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -96,6 +96,12 @@ func (sd *ScaleDown) GetCandidatesForScaleDown() []*apiv1.Node {
 	return sd.unneededNodesList
 }
 
+// CleanUpUnneededNodes clears the list of unneeded nodes.
+func (sd *ScaleDown) CleanUpUnneededNodes() {
+	sd.unneededNodesList = make([]*apiv1.Node, 0)
+	sd.unneededNodes = make(map[string]time.Time)
+}
+
 // UpdateUnneededNodes calculates which nodes are not needed, i.e. all pods can be scheduled somewhere else,
 // and updates unneededNodes map accordingly. It also computes information where pods can be rescheduled and
 // node utilization level. Timestamp is the current timestamp.

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -88,6 +88,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) {
 	}
 	if len(readyNodes) == 0 {
 		glog.Errorf("No ready nodes in the cluster")
+		scaleDown.CleanUpUnneededNodes()
 		return
 	}
 
@@ -98,6 +99,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) {
 	}
 	if len(allNodes) == 0 {
 		glog.Errorf("No nodes in the cluster")
+		scaleDown.CleanUpUnneededNodes()
 		return
 	}
 
@@ -111,6 +113,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) {
 	}()
 	if !a.ClusterStateRegistry.IsClusterHealthy() {
 		glog.Warningf("Cluster is not ready for autoscaling: %v", err)
+		scaleDown.CleanUpUnneededNodes()
 		return
 	}
 


### PR DESCRIPTION
If the nodes is marked as unneeded and cluster goes to an unhealthy state shortly after the node will likely be deleted immediately on cluster recovery. This is because there is already an entry for it in unnededNodes datastructure and the cluster downtime is counted towards node being unneeded time.

It's not 100% obvious to me what should happen in this case, but I think it's better to play it safe and just wait the full 10 minutes after cluster recovery before we start to delete nodes. After a quick glance at the code I haven't spotted any other stuff that needs to be cleaned up in case of cluster failure, but maybe you have some other ideas @mwielgus?