### PR TITLE
[Cluster Autoscaler] Use pod's default grace period instead of setting it to maxGracefulTerminationSec

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -360,9 +360,8 @@ func deleteNode(context *AutoscalingContext, node *apiv1.Node, pods []*apiv1.Pod
 }
 
 func evictPod(podToEvict *apiv1.Pod, client kube_client.Interface, recorder kube_record.EventRecorder,
-	maxGracefulTerminationSec int, retryUntil time.Time, waitBetweenRetries time.Duration) error {
+	retryUntil time.Time, waitBetweenRetries time.Duration) error {
 	recorder.Eventf(podToEvict, apiv1.EventTypeNormal, "ScaleDown", "deleting pod for node scale down")
-	maxGraceful64 := int64(maxGracefulTerminationSec)
 	var lastError error
 	for first := true; first || time.Now().Before(retryUntil); time.Sleep(waitBetweenRetries) {
 		first = false
@@ -408,7 +407,7 @@ func drainNode(node *apiv1.Node, pods []*apiv1.Pod, client kube_client.Interface
 	confirmations := make(chan error, toEvict)
 	for _, pod := range pods {
 		go func(podToEvict *apiv1.Pod) {
-			confirmations <- evictPod(podToEvict, client, recorder, maxGracefulTerminationSec, retryUntil, waitBetweenRetries)
+			confirmations <- evictPod(podToEvict, client, recorder, retryUntil, waitBetweenRetries)
 		}(pod)
 	}
 

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -360,9 +360,9 @@ func deleteNode(context *AutoscalingContext, node *apiv1.Node, pods []*apiv1.Pod
 }
 
 func evictPod(podToEvict *apiv1.Pod, client kube_client.Interface, recorder kube_record.EventRecorder,
-	maxGratefulTerminationSec int, retryUntil time.Time, waitBetweenRetries time.Duration) error {
+	maxGracefulTerminationSec int, retryUntil time.Time, waitBetweenRetries time.Duration) error {
 	recorder.Eventf(podToEvict, apiv1.EventTypeNormal, "ScaleDown", "deleting pod for node scale down")
-	maxGraceful64 := int64(maxGratefulTerminationSec)
+	maxGraceful64 := int64(maxGracefulTerminationSec)
 	var lastError error
 	for first := true; first || time.Now().Before(retryUntil); time.Sleep(waitBetweenRetries) {
 		first = false
@@ -370,9 +370,6 @@ func evictPod(podToEvict *apiv1.Pod, client kube_client.Interface, recorder kube
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: podToEvict.Namespace,
 				Name:      podToEvict.Name,
-			},
-			DeleteOptions: &metav1.DeleteOptions{
-				GracePeriodSeconds: &maxGraceful64,
 			},
 		}
 		lastError = client.Core().Pods(podToEvict.Namespace).Evict(eviction)
@@ -388,7 +385,7 @@ func evictPod(podToEvict *apiv1.Pod, client kube_client.Interface, recorder kube
 // Performs drain logic on the node. Marks the node as unschedulable and later removes all pods, giving
 // them up to MaxGracefulTerminationTime to finish.
 func drainNode(node *apiv1.Node, pods []*apiv1.Pod, client kube_client.Interface, recorder kube_record.EventRecorder,
-	maxGratefulTerminationSec int, maxPodEvictionTime time.Duration, waitBetweenRetries time.Duration) error {
+	maxGracefulTerminationSec int, maxPodEvictionTime time.Duration, waitBetweenRetries time.Duration) error {
 
 	drainSuccessful := false
 	toEvict := len(pods)
@@ -411,7 +408,7 @@ func drainNode(node *apiv1.Node, pods []*apiv1.Pod, client kube_client.Interface
 	confirmations := make(chan error, toEvict)
 	for _, pod := range pods {
 		go func(podToEvict *apiv1.Pod) {
-			confirmations <- evictPod(podToEvict, client, recorder, maxGratefulTerminationSec, retryUntil, waitBetweenRetries)
+			confirmations <- evictPod(podToEvict, client, recorder, maxGracefulTerminationSec, retryUntil, waitBetweenRetries)
 		}(pod)
 	}
 
@@ -431,9 +428,9 @@ func drainNode(node *apiv1.Node, pods []*apiv1.Pod, client kube_client.Interface
 		return fmt.Errorf("Failed to drain node %s/%s, due to following errors: %v", node.Namespace, node.Name, evictionErrs)
 	}
 
-	// Evictions created successfully, wait maxGratefulTerminationSec to see if nodes really disappeared
+	// Evictions created successfully, wait maxGracefulTerminationSec to see if nodes really disappeared
 	allGone := true
-	for start := time.Now(); time.Now().Sub(start) < time.Duration(maxGratefulTerminationSec)*time.Second; time.Sleep(5 * time.Second) {
+	for start := time.Now(); time.Now().Sub(start) < time.Duration(maxGracefulTerminationSec)*time.Second; time.Sleep(5 * time.Second) {
 		allGone = true
 		for _, pod := range pods {
 			podreturned, err := client.Core().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -84,7 +84,7 @@ var (
 	maxNodesTotal               = flag.Int("max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
 	cloudProviderFlag           = flag.String("cloud-provider", "gce", "Cloud provider type. Allowed values: gce, aws, azure")
 	maxEmptyBulkDeleteFlag      = flag.Int("max-empty-bulk-delete", 10, "Maximum number of empty nodes that can be deleted at the same time.")
-	maxGratefulTerminationFlag  = flag.Int("max-grateful-termination-sec", 60, "Maximum number of seconds CA waints for pod termination when trying to scale down a node.")
+	maxGracefulTerminationFlag  = flag.Int("max-graceful-termination-sec", 60, "Maximum number of seconds CA waints for pod termination when trying to scale down a node.")
 	maxTotalUnreadyPercentage   = flag.Float64("max-total-unready-percentage", 33, "Maximum percentage of unready nodes after which CA halts operations")
 	okTotalUnreadyCount         = flag.Int("ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
 	maxNodeProvisionTime        = flag.Duration("max-node-provision-time", 15*time.Minute, "Maximum time CA waits for node to be provisioned")
@@ -108,7 +108,7 @@ func createAutoscalerOptions() core.AutoscalerOptions {
 		EstimatorName:                 *estimatorFlag,
 		ExpanderName:                  *expanderFlag,
 		MaxEmptyBulkDelete:            *maxEmptyBulkDeleteFlag,
-		MaxGratefulTerminationSec:     *maxGratefulTerminationFlag,
+		MaxGratefulTerminationSec:     *maxGracefulTerminationFlag,
 		MaxNodeProvisionTime:          *maxNodeProvisionTime,
 		MaxNodesTotal:                 *maxNodesTotal,
 		NodeGroups:                    nodeGroupsFlag,

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -79,7 +79,7 @@ max-empty-bulk-delete
 max-nodes-total
 max-pr-number
 max-sync-failures
-max-grateful-termination-sec
+max-graceful-termination-sec
 max-node-provision-time
 max-total-unready-percentage
 metrics-resolution


### PR DESCRIPTION
It seems like we set maxGracefulTermination in the eviction policy for each pod but we wait [maxGracefulTermination for all pods to terminate](https://github.com/kubernetes/contrib/blob/master/cluster-autoscaler/core/scale_down.go#L436). If you have pods that receive SIGTERM and then rely on kubelet to send send SIGKILL, then you're likely to reach the node eviction timeout. We should be defaulting to whatever terminationGracePeriod is set by users for each pod. `maxGracefulTermination` should be the max time it takes for all pods to be evicted (which is the current behaviour). 

Fixes https://github.com/kubernetes/contrib/issues/2491 (at least for me)

cc @mwielgus @davidopp @fgrzadkowski @MaciekPytel @ryanwalls