### PR TITLE
Configurable keepalived virtual router id

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -162,6 +162,7 @@ use-reviewers
 use-unicast
 user-whitelist
 verify-unschedulable-pods
+vrid
 vrrp-password
 watch-namespace
 weak-stable-jobs

--- a/keepalived-vip/keepalived.go
+++ b/keepalived-vip/keepalived.go
@@ -49,6 +49,7 @@ type keepalived struct {
 	tmpl       *template.Template
 	cmd        *exec.Cmd
 	ipt        iptables.Interface
+	vrid       int
 }
 
 // WriteCfg creates a new keepalived configuration file.
@@ -72,6 +73,7 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	conf["nodes"] = k.neighbors
 	conf["priority"] = k.priority
 	conf["useUnicast"] = k.useUnicast
+	conf["vrid"] = k.vrid
 
 	if glog.V(2) {
 		b, _ := json.Marshal(conf)
@@ -152,7 +154,7 @@ func (k *keepalived) Stop() {
 
 	err = syscall.Kill(k.cmd.Process.Pid, syscall.SIGTERM)
 	if err != nil {
-		fmt.Errorf("error stopping keepalived: %v", err)
+		glog.Errorf("error stopping keepalived: %v", err)
 	}
 }
 

--- a/keepalived-vip/keepalived.tmpl
+++ b/keepalived-vip/keepalived.tmpl
@@ -8,7 +8,7 @@ global_defs {
 vrrp_instance vips {
   state BACKUP
   interface {{ $iface }}
-  virtual_router_id 50
+  virtual_router_id {{ .vrid }}
   priority {{ .priority }}
   nopreempt
   advert_int 1
@@ -47,5 +47,5 @@ virtual_server {{ $svc.IP }} {{ $svc.Port }} {
     }
   }
 {{ end }}
-}    
+}
 {{ end }}

--- a/keepalived-vip/main.go
+++ b/keepalived-vip/main.go
@@ -43,7 +43,7 @@ var (
 
 	configMapName = flags.String("services-configmap", "",
 		`Name of the ConfigMap that contains the definition of the services to expose.
-		The key in the map indicates the external IP to use. The value is the name of the 
+		The key in the map indicates the external IP to use. The value is the name of the
 		service with the format namespace/serviceName and the port of the service could be a number or the
 		name of the port.`)
 
@@ -54,6 +54,11 @@ var (
 		// enable connection tracking for LVS connections
 		"net/ipv4/vs/conntrack": 1,
 	}
+
+	vrid = flags.Int("vrid", 50,
+		`The keepalived VRID (Virtual Router Identifier, between 0 and 255 as per
+			RFC-5798), which must be different for every Virtual Router (ie. every
+			keepalived sets) running on the same network.`)
 )
 
 func main() {
@@ -112,7 +117,7 @@ func main() {
 	if *useUnicast {
 		glog.Info("keepalived will use unicast to sync the nodes")
 	}
-	ipvsc := newIPVSController(kubeClient, namespace, *useUnicast, *configMapName)
+	ipvsc := newIPVSController(kubeClient, namespace, *useUnicast, *configMapName, *vrid)
 	go ipvsc.epController.Run(wait.NeverStop)
 	go ipvsc.svcController.Run(wait.NeverStop)
 


### PR DESCRIPTION
Hi all, this PR is an up to date version of this previous PR  #2384, it's the same but squashed and merged with the latest master revision.

It adds support for configurable keepalived virtual router id. This functionality is necessary in order to be able to run multiple keepalived "clusters" in the same subnet without having them stepping on each other's toes (having one node from one group confusing the other group into thinking it has a master).

The configuration of the virtual router id is done using the --vrid command line flag. I considered using the project's configmap but the structure of the existing configmap is not easily expandable, so I had to use a flag (I would have added support for environment variables, but it didn't seems to be in line with the way this application is thought out, so I refrained).

The flag can be specified in a k8s object with the args key, for example:
- args: ["--services-configmap=admin/vip-configmap", "--vrid=45"]

If not specified, it will default to router id 50 as it was before.

That's pretty much all there is to it, thanks in advance for your time!