### PR TITLE
Leader Election: Add callback on new leader detection.

### DIFF
--- a/election/lib/election.go
+++ b/election/lib/election.go
@@ -106,6 +106,9 @@ func NewElection(electionId, id, namespace string, ttl time.Duration, callback f
 			}
 			callback(leader)
 		},
+		OnNewLeader: func(identity string) {
+			callback(identity)
+		},
 	}
 
 	config := leaderelection.LeaderElectionConfig{


### PR DESCRIPTION
The leader election web service doesn't currently update the advertised leader via:
http://localhost:4040/
if the leader has changed.

This PR adds a callback that updates the advertised leader when a change is detected.