### PR TITLE
Cluster-Autoscaler FAQ entry describing events

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -393,7 +393,7 @@ func drainNode(node *apiv1.Node, pods []*apiv1.Pod, client kube_client.Interface
 	drainSuccessful := false
 	toEvict := len(pods)
 	if err := deletetaint.MarkToBeDeleted(node, client); err != nil {
-		recorder.Eventf(node, apiv1.EventTypeWarning, "ScaleDown", "failed to mark the node as toBeDeleted/unschedulable: %v", err)
+		recorder.Eventf(node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to mark the node as toBeDeleted/unschedulable: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
While writing the FAQ I noticed one event is named inconsistently with the rest, so I updated the name. It's a very minor change so I included it in this PR, but I can move it to a separate one if you think it makes more sense @mwielgus 