### PR TITLE
[ansible]fix var name

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -120,7 +120,7 @@ kube_cert_keep_ca: false
 # with caution.
 
 # See kube documentation for apiserver runtime config options.  Example below enables HPA, deployments features.
-#kube_apiserver_options:
+#kube_apiserver_additional_options:
 #  - --runtime-config=extensions/v1beta1/deployments=true
 
 # To enable etcd auto cert generation set the following *_scheme vars to "https"


### PR DESCRIPTION
Before #2441 , it called `apiserver_extra_args`, so after refactoring, it should called `kube_apiserver_additional_options` for consistency.

Using `kube_apiserver_options` will override the same named var defined in `roles/master/defaults/main.yml` .
cc @galexrt , I touch your PR.