### PR TITLE
cluster-autoscaler: Re: AWS Autoscaler autodiscover ASG names and sizes

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -21,20 +21,74 @@ import (
 	"regexp"
 	"strings"
 
+	"errors"
 	"k8s.io/contrib/cluster-autoscaler/cloudprovider"
 	"k8s.io/contrib/cluster-autoscaler/config/dynamic"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
-// AwsCloudProvider implements CloudProvider interface.
-type AwsCloudProvider struct {
+// awsCloudProvider implements CloudProvider interface.
+type awsCloudProvider struct {
 	awsManager *AwsManager
 	asgs       []*Asg
 }
 
+// autoDiscoveringProvider implements CloudProvider interface.
+type autoDiscoveringProvider struct {
+	*awsCloudProvider
+}
+
 // BuildAwsCloudProvider builds CloudProvider implementation for AWS.
-func BuildAwsCloudProvider(awsManager *AwsManager, specs []string) (*AwsCloudProvider, error) {
-	aws := &AwsCloudProvider{
+func BuildAwsCloudProvider(awsManager *AwsManager, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (cloudprovider.CloudProvider, error) {
+	if len(discoveryOpts.NodeGroupSpecs) > 0 {
+		return buildStaticallyDiscoveringProvider(awsManager, discoveryOpts.NodeGroupSpecs)
+	}
+	if discoveryOpts.NodeGroupAutoDiscoverySpec != "" {
+		return buildAutoDiscoveringProvider(awsManager, discoveryOpts.NodeGroupAutoDiscoverySpec)
+	}
+	return nil, errors.New("Failed to build an aws cloud provider: Either node group specs or node group auto discovery spec must be specified")
+}
+
+func buildAutoDiscoveringProvider(awsManager *AwsManager, spec string) (*autoDiscoveringProvider, error) {
+	tokens := strings.Split(spec, ":")
+	if len(tokens) != 2 {
+		return nil, fmt.Errorf("Invalid node group auto discovery spec specified: %s", spec)
+	}
+	discoverer := tokens[0]
+	if discoverer != "asg" {
+		return nil, fmt.Errorf("Unsupported discoverer specified: %s", discoverer)
+	}
+	param := tokens[1]
+	paramTokens := strings.Split(param, "=")
+	parameterKey := paramTokens[0]
+	if parameterKey != "tag" {
+		return nil, fmt.Errorf("Unsupported parameter key specified for discoverer \"%s\": %s", discoverer, parameterKey)
+	}
+	tag := paramTokens[1]
+	if tag == "" {
+		return nil, errors.New("Invalid ASG tag for auto discovery specified: ASG tag must not be empty")
+	}
+	underlying := &awsCloudProvider{
+		awsManager: awsManager,
+		asgs:       make([]*Asg, 0),
+	}
+	asgs, err := awsManager.getAutoscalingGroupsByTag(tag)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get ASGs: %v", err)
+	}
+
+	aws := &autoDiscoveringProvider{
+		awsCloudProvider: underlying,
+	}
+	for _, asg := range asgs {
+		aws.addAsg(buildAsg(aws.awsManager, int(*asg.MinSize), int(*asg.MaxSize), *asg.AutoScalingGroupName))
+	}
+
+	return aws, nil
+}
+
+func buildStaticallyDiscoveringProvider(awsManager *AwsManager, specs []string) (*awsCloudProvider, error) {
+	aws := &awsCloudProvider{
 		awsManager: awsManager,
 		asgs:       make([]*Asg, 0),
 	}
@@ -48,23 +102,28 @@ func BuildAwsCloudProvider(awsManager *AwsManager, specs []string) (*AwsCloudPro
 
 // addNodeGroup adds node group defined in string spec. Format:
 // minNodes:maxNodes:asgName
-func (aws *AwsCloudProvider) addNodeGroup(spec string) error {
-	asg, err := buildAsg(spec, aws.awsManager)
+func (aws *awsCloudProvider) addNodeGroup(spec string) error {
+	asg, err := buildAsgFromSpec(spec, aws.awsManager)
 	if err != nil {
 		return err
 	}
-	aws.asgs = append(aws.asgs, asg)
-	aws.awsManager.RegisterAsg(asg)
+	aws.addAsg(asg)
 	return nil
 }
 
+// addAsg adds and registers an asg to this cloud provider
+func (aws *awsCloudProvider) addAsg(asg *Asg) {
+	aws.asgs = append(aws.asgs, asg)
+	aws.awsManager.RegisterAsg(asg)
+}
+
 // Name returns name of the cloud provider.
-func (aws *AwsCloudProvider) Name() string {
+func (aws *awsCloudProvider) Name() string {
 	return "aws"
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (aws *AwsCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (aws *awsCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	result := make([]cloudprovider.NodeGroup, 0, len(aws.asgs))
 	for _, asg := range aws.asgs {
 		result = append(result, asg)
@@ -73,7 +132,7 @@ func (aws *AwsCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (aws *AwsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	ref, err := AwsRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
 		return nil, err
@@ -227,21 +286,25 @@ func (asg *Asg) Nodes() ([]string, error) {
 	return asg.awsManager.GetAsgNodes(asg)
 }
 
-func buildAsg(value string, awsManager *AwsManager) (*Asg, error) {
+func buildAsgFromSpec(value string, awsManager *AwsManager) (*Asg, error) {
 	spec, err := dynamic.SpecFromString(value)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse node group spec: %v", err)
 	}
 
-	asg := Asg{
+	asg := buildAsg(awsManager, spec.MinSize, spec.MaxSize, spec.Name)
+
+	return asg, nil
+}
+
+func buildAsg(awsManager *AwsManager, minSize int, maxSize int, name string) *Asg {
+	return &Asg{
 		awsManager: awsManager,
-		minSize:    spec.MinSize,
-		maxSize:    spec.MaxSize,
+		minSize:    minSize,
+		maxSize:    maxSize,
 		AwsRef: AwsRef{
-			Name: spec.Name,
+			Name: name,
 		},
 	}
-
-	return &asg, nil
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -24,6 +24,7 @@ import (
 
 	"gopkg.in/gcfg.v1"
 
+	"errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -35,6 +36,7 @@ import (
 const (
 	operationWaitTimeout  = 5 * time.Second
 	operationPollInterval = 100 * time.Millisecond
+	maxRecords            = 100
 )
 
 type asgInformation struct {
@@ -44,6 +46,7 @@ type asgInformation struct {
 
 type autoScaling interface {
 	DescribeAutoScalingGroups(input *autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
+	DescribeTags(input *autoscaling.DescribeTagsInput) (*autoscaling.DescribeTagsOutput, error)
 	SetDesiredCapacity(input *autoscaling.SetDesiredCapacityInput) (*autoscaling.SetDesiredCapacityOutput, error)
 	TerminateInstanceInAutoScalingGroup(input *autoscaling.TerminateInstanceInAutoScalingGroupInput) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error)
 }
@@ -214,6 +217,87 @@ func (m *AwsManager) getAutoscalingGroup(name string) (*autoscaling.Group, error
 		return nil, fmt.Errorf("Unable to get first autoscaling.Group for %s", name)
 	}
 	return groups.AutoScalingGroups[0], nil
+}
+
+func (m *AwsManager) getAutoscalingGroupsByNames(names []string) ([]*autoscaling.Group, error) {
+	nameRefs := []*string{}
+	for _, n := range names {
+		nameRefs = append(nameRefs, &n)
+	}
+	params := &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: nameRefs,
+		MaxRecords:            aws.Int64(maxRecords),
+	}
+	description, err := m.service.DescribeAutoScalingGroups(params)
+	if err != nil {
+		glog.V(4).Infof("Failed to describe ASGs : %v", err)
+		return nil, err
+	}
+	if len(description.AutoScalingGroups) < 1 {
+		return nil, errors.New("No ASGs found")
+	}
+
+	asgs := description.AutoScalingGroups
+	for description.NextToken != nil {
+		description, err = m.service.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+			NextToken:  description.NextToken,
+			MaxRecords: aws.Int64(maxRecords),
+		})
+		if err != nil {
+			glog.V(4).Infof("Failed to describe ASGs : %v", err)
+			return nil, err
+		}
+		asgs = append(asgs, description.AutoScalingGroups...)
+	}
+
+	return asgs, nil
+}
+
+func (m *AwsManager) getAutoscalingGroupsByTag(key string) ([]*autoscaling.Group, error) {
+	tags := []*autoscaling.TagDescription{}
+
+	description, err := m.service.DescribeTags(&autoscaling.DescribeTagsInput{
+		Filters: []*autoscaling.Filter{
+			{
+				Name:   aws.String("key"),
+				Values: []*string{aws.String(key)},
+			},
+		},
+		MaxRecords: aws.Int64(maxRecords),
+	})
+	if err != nil {
+		glog.V(4).Infof("Failed to describe ASG tags for key %s : %v", key, err)
+		return nil, err
+	}
+	if len(description.Tags) < 1 {
+		return nil, fmt.Errorf("Unable to find ASGs for tag key %s", key)
+	}
+	tags = append(tags, description.Tags...)
+
+	for description.NextToken != nil {
+		description, err = m.service.DescribeTags(&autoscaling.DescribeTagsInput{
+			NextToken:  description.NextToken,
+			MaxRecords: aws.Int64(maxRecords),
+		})
+		if err != nil {
+			glog.V(4).Infof("Failed to describe ASG tags for key %s: %v", key, err)
+			return nil, err
+		}
+		tags = append(tags, description.Tags...)
+	}
+
+	asgNames := []string{}
+	for _, t := range tags {
+		asgName := t.ResourceId
+		asgNames = append(asgNames, *asgName)
+	}
+
+	asgs, err := m.getAutoscalingGroupsByNames(asgNames)
+	if err != nil {
+		return nil, err
+	}
+
+	return asgs, nil
 }
 
 // GetAsgNodes returns Asg nodes.

--- a/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
+++ b/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
@@ -41,9 +41,11 @@ func NewCloudProviderBuilder(cloudProviderFlag string, cloudConfig string) Cloud
 }
 
 // Build a cloud provider from static settings contained in the builder and dynamic settings passed via args
-func (b CloudProviderBuilder) Build(nodeGroupsFlag []string) cloudprovider.CloudProvider {
+func (b CloudProviderBuilder) Build(discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) cloudprovider.CloudProvider {
 	var err error
 	var cloudProvider cloudprovider.CloudProvider
+
+	nodeGroupsFlag := discoveryOpts.NodeGroupSpecs
 
 	if b.cloudProviderFlag == "gce" {
 		// GCE Manager
@@ -84,7 +86,7 @@ func (b CloudProviderBuilder) Build(nodeGroupsFlag []string) cloudprovider.Cloud
 		if awsError != nil {
 			glog.Fatalf("Failed to create AWS Manager: %v", err)
 		}
-		cloudProvider, err = aws.BuildAwsCloudProvider(awsManager, nodeGroupsFlag)
+		cloudProvider, err = aws.BuildAwsCloudProvider(awsManager, discoveryOpts)
 		if err != nil {
 			glog.Fatalf("Failed to create AWS cloud provider: %v", err)
 		}

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -35,6 +35,14 @@ type CloudProvider interface {
 	NodeGroupForNode(*apiv1.Node) (NodeGroup, error)
 }
 
+// NodeGroupDiscoveryOptions contains various options to configure how a cloud provider discovers node groups
+type NodeGroupDiscoveryOptions struct {
+	// NodeGroupSpecs is specified to statically discover node groups listed in it
+	NodeGroupSpecs []string
+	// NodeGroupAutoDiscoverySpec is specified for automatically discovering node groups according to the specs
+	NodeGroupAutoDiscoverySpec string
+}
+
 // NodeGroup contains configuration info and functions to control a set
 // of nodes that have the same capacity and set of labels.
 type NodeGroup interface {

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -50,5 +50,8 @@ func NewAutoscaler(opts AutoscalerOptions, predicateChecker *simulator.Predicate
 		configFetcher := dynamic.NewConfigFetcher(opts.ConfigFetcherOptions, kubeClient, kubeEventRecorder)
 		return NewDynamicAutoscaler(autoscalerBuilder, configFetcher)
 	}
+	if opts.NodeGroupAutoDiscovery != "" {
+		return NewPollingAutoscaler(autoscalerBuilder)
+	}
 	return autoscalerBuilder.Build()
 }

--- a/cluster-autoscaler/core/autoscaling_context.go
+++ b/cluster-autoscaler/core/autoscaling_context.go
@@ -67,6 +67,8 @@ type AutoscalingOptions struct {
 	ScaleDownUnreadyTime time.Duration
 	// MaxNodesTotal sets the maximum number of nodes in the whole cluster
 	MaxNodesTotal int
+	// NodeGroupAutoDiscovery represents one or more definition(s) of node group auto-discovery
+	NodeGroupAutoDiscovery string
 	// UnregisteredNodeRemovalTime represents how long CA waits before removing nodes that are not registered in Kubernetes")
 	UnregisteredNodeRemovalTime time.Duration
 	// EstimatorName is the estimator used to estimate the number of needed nodes in scale up.
@@ -105,7 +107,10 @@ type AutoscalingOptions struct {
 func NewAutoscalingContext(options AutoscalingOptions, predicateChecker *simulator.PredicateChecker,
 	kubeClient kube_client.Interface, kubeEventRecorder kube_record.EventRecorder, logEventRecorder *utils.LogEventRecorder) *AutoscalingContext {
 	cloudProviderBuilder := builder.NewCloudProviderBuilder(options.CloudProviderName, options.CloudConfig)
-	cloudProvider := cloudProviderBuilder.Build(options.NodeGroups)
+	cloudProvider := cloudProviderBuilder.Build(cloudprovider.NodeGroupDiscoveryOptions{
+		NodeGroupSpecs:             options.NodeGroups,
+		NodeGroupAutoDiscoverySpec: options.NodeGroupAutoDiscovery,
+	})
 	expanderStrategy := factory.ExpanderStrategyFromString(options.ExpanderName)
 	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: options.MaxTotalUnreadyPercentage,

--- a/cluster-autoscaler/core/polling_autoscaler.go
+++ b/cluster-autoscaler/core/polling_autoscaler.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/contrib/cluster-autoscaler/metrics"
+)
+
+// PollingAutoscaler is a variant of autoscaler which polls the source-of-truth every time RunOnce is invoked
+type PollingAutoscaler struct {
+	autoscaler        Autoscaler
+	autoscalerBuilder AutoscalerBuilder
+}
+
+// NewPollingAutoscaler builds a PollingAutoscaler from required parameters
+func NewPollingAutoscaler(autoscalerBuilder AutoscalerBuilder) *PollingAutoscaler {
+	return &PollingAutoscaler{
+		autoscaler:        autoscalerBuilder.Build(),
+		autoscalerBuilder: autoscalerBuilder,
+	}
+}
+
+// CleanUp does the work required before all the iterations of a polling autoscaler run
+func (a *PollingAutoscaler) CleanUp() {
+	a.autoscaler.CleanUp()
+}
+
+// ExitCleanUp cleans-up after autoscaler, so no mess remains after process termination.
+func (a *PollingAutoscaler) ExitCleanUp() {
+	a.autoscaler.ExitCleanUp()
+}
+
+// RunOnce represents a single iteration of a polling autoscaler inside the CA's control-loop
+func (a *PollingAutoscaler) RunOnce(currentTime time.Time) {
+	reconfigureStart := time.Now()
+	metrics.UpdateLastTime("poll")
+	if err := a.Poll(); err != nil {
+		glog.Errorf("Failed to poll : %v", err)
+	}
+	metrics.UpdateDuration("poll", reconfigureStart)
+	a.autoscaler.RunOnce(currentTime)
+}
+
+// Poll latest data from cloud provider to recreate this autoscaler
+func (a *PollingAutoscaler) Poll() error {
+	// For safety, any config change should stop and recreate all the stuff running in CA hence recreating all the Autoscaler instance here
+	// See https://github.com/kubernetes/contrib/pull/2226#discussion_r94126064
+	a.autoscaler = a.autoscalerBuilder.Build()
+	glog.V(4).Infof("Poll finished")
+
+	return nil
+}

--- a/cluster-autoscaler/core/polling_autoscaler_test.go
+++ b/cluster-autoscaler/core/polling_autoscaler_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+)
+
+func TestRunOnce(t *testing.T) {
+	currentTime := time.Now()
+
+	initialAutoscaler := &AutoscalerMock{}
+
+	newAutoscaler := &AutoscalerMock{}
+	newAutoscaler.On("RunOnce", currentTime).Once()
+
+	builder := &AutoscalerBuilderMock{}
+	builder.On("Build").Return(initialAutoscaler).Once()
+	builder.On("Build").Return(newAutoscaler).Once()
+
+	a := NewPollingAutoscaler(builder)
+	a.RunOnce(currentTime)
+
+	initialAutoscaler.AssertNotCalled(t, "RunOnce", mock.AnythingOfType("time.Time"))
+	newAutoscaler.AssertExpectations(t)
+	builder.AssertExpectations(t)
+}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -66,6 +66,7 @@ var (
 	cloudConfig             = flag.String("cloud-config", "", "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	configMapName           = flag.String("configmap", "", "The name of the ConfigMap containing settings used for dynamic reconfiguration. Empty string for no ConfigMap.")
 	namespace               = flag.String("namespace", "kube-system", "Namespace in which cluster-autoscaler run. If a --configmap flag is also provided, ensure that the configmap exists in this namespace before CA runs.")
+	nodeGroupAutoDiscovery  = flag.String("node-group-auto-discovery", "", "One or more definition(s) of node group auto-discovery. A definition is expressed `<name of discoverer per cloud provider>:[<key>[=<value>]]`. For example, specifying `--cloud-provider aws` and `--node-group-auto-discovery asg:tag=cluster-autoscaler/auto-discovery/enabled` resuls in ASGs tagged with `cluster-autoscaler/auto-discovery/enabled` to be considered as target node groups")
 	verifyUnschedulablePods = flag.Bool("verify-unschedulable-pods", true,
 		"If enabled CA will ensure that each pod marked by Scheduler as unschedulable actually can't be scheduled on any node."+
 			"This prevents from adding unnecessary nodes in situation when CA and Scheduler have different configuration.")
@@ -103,6 +104,7 @@ func createAutoscalerOptions() core.AutoscalerOptions {
 	autoscalingOpts := core.AutoscalingOptions{
 		CloudConfig:                   *cloudConfig,
 		CloudProviderName:             *cloudProviderFlag,
+		NodeGroupAutoDiscovery:        *nodeGroupAutoDiscovery,
 		MaxTotalUnreadyPercentage:     *maxTotalUnreadyPercentage,
 		OkTotalUnreadyCount:           *okTotalUnreadyCount,
 		EstimatorName:                 *estimatorFlag,

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -88,6 +88,7 @@ min-replica-count
 netrc-dir
 network-config
 nginx-configmap
+node-group-auto-discovery
 nonblocking-jenkins-jobs
 number-of-old-test-results
 ok-total-unready-count


### PR DESCRIPTION
@mwielgus @Raffo @andrewsykim @osxi Would you mind reviewing this?

---

This is an alternative implementation of #1982

Notable differences from the original PR are:

* A new flag named `--node-group-auto-discovery` is introduced for opting in to enable the auto-discovery feature.
  * For example, specifying `--cloud-provider aws --node-group-auto-discovery asg:tag=k8s.io/cluster-autoscaler/enabled` instructs CA to auto-discover ASGs tagged with `k8s.io/cluster-autoscaler/enabled` to be used as target node groups
* The new code path introduced by this PR is executed only when `node-group-auto-discovery` is specified. There is relatively less chance to break existing features by this change

Other notes:

* ~~I thought it might be a good idea to implement this feature on top of the dynamic reconfiguration #2181 initially~~
  * ~~However it turned out it is easier and less verbose to just implement an alternative aws cloud provider like what I've done for this PR~~
* We rely mainly on the `DescribeTags` API rather than `DescribeAutoScalingGroups` so that AWS can filter out unnecessary ASGs which doesn't belong to the k8s cluster, for us.
  * If we relied on `DescribeAutoScalingGroups` here, as it doesn't support `Filter`ing, we'd need to iterate over ALL the ASGs available in an AWS account, which isn't desirable due to unnecessary excessive API calls and network usages

Possible future improvements before recommending this to everyone:

* Cache the result of an auto-discovery for a configurable period, so that we won't invoke DescribeTags and DescribeAutoScalingGroup APIs too many times
