### PR TITLE
Fix the import path

### DIFF
--- a/pets/peer-finder/peer-finder.go
+++ b/pets/peer-finder/peer-finder.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (


### PR DESCRIPTION
Part of https://github.com/kubernetes/kubernetes/pull/39475, `k8s.io/kubernetes/pkg/util/sets` moved to `k8s.io/apimachinery/pkg/util/sets` so here import path needs to be fixed.