### PR TITLE
[Ansible] remove conflicted configure task

### DIFF
--- a/ansible/roles/node/tasks/retrieve-systemd-files.yml
+++ b/ansible/roles/node/tasks/retrieve-systemd-files.yml
@@ -15,23 +15,6 @@
     https_proxy: "{{ https_proxy|default('') }}"
     no_proxy: "{{ no_proxy|default('') }}"
 
-- name: Get Systemd config files from Kubernetes repository
-  get_url:
-    url=https://raw.githubusercontent.com/kubernetes/contrib/master/init/systemd/environ/{{ item }}
-    dest={{ kube_config_dir }}/{{ item }}
-    force=yes
-  register: "{{ item }}_default"
-  notify:
-    - reload systemd
-  with_items:
-    - config
-    - kubelet
-    - proxy
-  environment:
-    http_proxy: "{{ http_proxy|default('') }}"
-    https_proxy: "{{ https_proxy|default('') }}"
-    no_proxy: "{{ no_proxy|default('') }}"
-
 - name: Get Systemd tmpfile from Kubernetes repository
   get_url:
     url=https://raw.githubusercontent.com/kubernetes/contrib/master/init/systemd/tmpfiles.d/kubernetes.conf


### PR DESCRIPTION
I found the task **Get Systemd config files from Kubernetes repository** is conflicted with following tasks, and it override the correct config, causing the cluster deploy failed.

- https://github.com/kubernetes/contrib/blob/master/ansible/roles/kubernetes/tasks/configure.yml
- https://github.com/kubernetes/contrib/blob/master/ansible/roles/node/tasks/kubelet-configure.yml
- https://github.com/kubernetes/contrib/blob/master/ansible/roles/node/tasks/proxy-configure.yml