### PR TITLE
[Ansible] Use the flanneld env vars for etcd config

### DIFF
--- a/ansible/roles/flannel/templates/flanneld.j2
+++ b/ansible/roles/flannel/templates/flanneld.j2
@@ -1,13 +1,13 @@
 # Flanneld configuration options
 
-# etcd url location.  Point this to the server where etcd runs
-FLANNEL_ETCD="{% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}"
-FLANNEL_ETCD_ENDPOINTS="{% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+# etcd endpoints. Point this to the server where etcd runs
+FLANNELD_ETCD="{% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+FLANNELD_ETCD_ENDPOINTS="{% for node in groups['etcd'] %}{% if etcd_url_scheme is defined %}{{ etcd_url_scheme }}{% else %}http{% endif %}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 
-# etcd config key.  This is the configuration key that flannel queries
+# etcd config etcd key. This is the configuration key that flannel queries
 # For address range assignment
-FLANNEL_ETCD_KEY="/{{ cluster_name }}/network"
-FLANNEL_ETCD_PREFIX="/{{ cluster_name }}/network"
+FLANNELD_ETCD_KEY="/{{ cluster_name }}/network"
+FLANNELD_ETCD_PREFIX="/{{ cluster_name }}/network"
 
 {% if etcd_url_scheme is defined and etcd_url_scheme == 'https' %}
 FLANNELD_ETCD_CAFILE="{{ flannel_etcd_ca_file }}"

--- a/ansible/roles/flannel/templates/flanneld.service
+++ b/ansible/roles/flannel/templates/flanneld.service
@@ -6,7 +6,7 @@ Description=flannel is an etcd backed overlay network for containers
 [Service]
 Type=notify
 EnvironmentFile=/etc/sysconfig/flanneld
-ExecStart={{ bin_dir }}/flanneld --etcd-endpoints=${FLANNEL_ETCD} --etcd-prefix=${FLANNEL_ETCD_KEY} $FLANNEL_OPTIONS
+ExecStart={{ bin_dir }}/flanneld $FLANNEL_OPTIONS
 ExecStartPost={{ bin_dir }}/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
 
 [Install]


### PR DESCRIPTION
See #2555.

Use the flanneld environment variable configuration for the "standard" configuration instead of flags.

/cc @gouyang 