### PR TITLE
Watch multiple components by one prometheus-to-sd.

### DIFF
--- a/prometheus-to-sd/config/source_config.go
+++ b/prometheus-to-sd/config/source_config.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"k8s.io/contrib/prometheus-to-sd/flags"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// SourceConfig contains data specific for scraping one component.
+type SourceConfig struct {
+	Component   string
+	Host        string
+	Port        uint
+	Whitelisted []string
+}
+
+// NewSourceConfig creates a new SourceConfig based on string representation of fields.
+func NewSourceConfig(component string, host string, port string, whitelisted string) (*SourceConfig, error) {
+	if port == "" {
+		return nil, fmt.Errorf("No port provided.")
+	}
+
+	portNum, err := strconv.ParseUint(port, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	var whitelistedList []string
+	if whitelisted != "" {
+		whitelistedList = strings.Split(whitelisted, ",")
+	}
+
+	return &SourceConfig{
+		Component:   component,
+		Host:        host,
+		Port:        uint(portNum),
+		Whitelisted: whitelistedList,
+	}, nil
+}
+
+// ParseSourceConfig creates a new SourceConfig based on the provided flags.Uri instance.
+func ParseSourceConfig(uri flags.Uri) (*SourceConfig, error) {
+	host, port, err := net.SplitHostPort(uri.Val.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	component := uri.Key
+	values := uri.Val.Query()
+	whitelisted := values.Get("whitelisted")
+
+	return NewSourceConfig(component, host, port, whitelisted)
+}

--- a/prometheus-to-sd/config/source_config_test.go
+++ b/prometheus-to-sd/config/source_config_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/contrib/prometheus-to-sd/flags"
+	"net/url"
+	"testing"
+)
+
+func TestNewSourceConfig(t *testing.T) {
+	correct := [...]struct {
+		component   string
+		host        string
+		port        string
+		whitelisted string
+		output      SourceConfig
+	}{
+		{"testComponent", "localhost", "1234", "a,b,c,d",
+			SourceConfig{
+				Component:   "testComponent",
+				Host:        "localhost",
+				Port:        1234,
+				Whitelisted: []string{"a", "b", "c", "d"},
+			},
+		},
+
+		{"testComponent", "localhost", "1234", "",
+			SourceConfig{
+				Component:   "testComponent",
+				Host:        "localhost",
+				Port:        1234,
+				Whitelisted: nil,
+			},
+		},
+	}
+
+	for _, c := range correct {
+		res, err := NewSourceConfig(c.component, c.host, c.port, c.whitelisted)
+		if assert.NoError(t, err) {
+			assert.Equal(t, c.output, *res)
+		}
+	}
+}
+
+func TestParseSourceConfig(t *testing.T) {
+	correct := struct {
+		in     flags.Uri
+		output SourceConfig
+	}{
+		flags.Uri{
+			Key: "testComponent",
+			Val: url.URL{
+				Scheme:   "http",
+				Host:     "hostname:1234",
+				RawQuery: "whitelisted=a,b,c,d",
+			},
+		},
+		SourceConfig{
+			Component:   "testComponent",
+			Host:        "hostname",
+			Port:        1234,
+			Whitelisted: []string{"a", "b", "c", "d"},
+		},
+	}
+
+	res, err := ParseSourceConfig(correct.in)
+	if assert.NoError(t, err) {
+		assert.Equal(t, correct.output, *res)
+	}
+
+	incorrect := [...]flags.Uri{
+		{
+			Key: "incorrectHost",
+			Val: url.URL{
+				Scheme:   "http",
+				Host:     "hostname[:1234",
+				RawQuery: "whitelisted=a,b,c,d",
+			},
+		},
+		{
+			Key: "noPort",
+			Val: url.URL{
+				Scheme:   "http",
+				Host:     "hostname",
+				RawQuery: "whitelisted=a,b,c,d",
+			},
+		},
+	}
+
+	for _, c := range incorrect {
+		res, err = ParseSourceConfig(c)
+		assert.Error(t, err)
+	}
+}

--- a/prometheus-to-sd/flags/flags.go
+++ b/prometheus-to-sd/flags/flags.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file was copied from https://github.com/kubernetes/heapster/tree/master/common/flags.
+// TODO: Move this file to a repository that can be accessed both by heapster and contrib repos.
+
+package flags
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// Uri contains information about one flag instance.
+type Uri struct {
+	Key string
+	Val url.URL
+}
+
+func (u *Uri) String() string {
+	val := u.Val.String()
+	if val == "" {
+		return fmt.Sprintf("%s", u.Key)
+	}
+	return fmt.Sprintf("%s:%s", u.Key, val)
+}
+
+// Set parses single instance of a flag.
+func (u *Uri) Set(value string) error {
+	s := strings.SplitN(value, ":", 2)
+	if s[0] == "" {
+		return fmt.Errorf("missing uri key in '%s'", value)
+	}
+	u.Key = s[0]
+	if len(s) > 1 && s[1] != "" {
+		e := os.ExpandEnv(s[1])
+		uri, err := url.Parse(e)
+		if err != nil {
+			return err
+		}
+		u.Val = *uri
+	}
+	return nil
+}
+
+// Uris holds values of a repeated flag.
+type Uris []Uri
+
+// String returns human-readable representation of a repeated flag.
+func (us *Uris) String() string {
+	var b bytes.Buffer
+	b.WriteString("[")
+	for i, u := range *us {
+		if i > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString(u.String())
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+// Set parses value and appends to us.
+func (us *Uris) Set(value string) error {
+	var u Uri
+	if err := u.Set(value); err != nil {
+		return err
+	}
+	*us = append(*us, u)
+	return nil
+}
+
+// Type returns type.
+func (us *Uris) Type() string {
+	return fmt.Sprintf("%T", us)
+}

--- a/prometheus-to-sd/flags/flags_test.go
+++ b/prometheus-to-sd/flags/flags_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file was copied from https://github.com/kubernetes/heapster/tree/master/common/flags.
+// TODO: Move this file to a repository that can be accessed both by heapster and contrib repos.
+package flags
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUriString(t *testing.T) {
+	tests := [...]struct {
+		in   Uri
+		want string
+	}{
+		{
+			Uri{
+				Key: "gcm",
+			},
+			"gcm",
+		},
+		{
+			Uri{
+				Key: "influxdb",
+				Val: url.URL{
+					Scheme:   "http",
+					Host:     "monitoring-influxdb:8086",
+					RawQuery: "key=val&key2=val2",
+				},
+			},
+			"influxdb:http://monitoring-influxdb:8086?key=val&key2=val2",
+		},
+	}
+	for _, c := range tests {
+		assert.Equal(t, c.want, c.in.String())
+	}
+}
+
+func TestUriSet(t *testing.T) {
+	tests := [...]struct {
+		in      string
+		want    Uri
+		wantErr bool
+	}{
+		{"", Uri{}, true},
+		{":", Uri{}, true},
+		{":foo", Uri{}, true},
+		{"key:incorrecturl/%gh&%ij", Uri{}, true},
+		{
+			"gcm",
+			Uri{Key: "gcm"},
+			false,
+		},
+		{
+			"gcm:",
+			Uri{Key: "gcm"},
+			false,
+		},
+		{
+			"influxdb:http://monitoring-influxdb:8086?key=val&key2=val2",
+			Uri{
+				Key: "influxdb",
+				Val: url.URL{
+					Scheme:   "http",
+					Host:     "monitoring-influxdb:8086",
+					RawQuery: "key=val&key2=val2",
+				},
+			},
+			false,
+		},
+		{
+			"gcm:?metrics=all",
+			Uri{
+				Key: "gcm",
+				Val: url.URL{
+					RawQuery: "metrics=all",
+				},
+			},
+			false,
+		},
+	}
+	for _, c := range tests {
+		var uri Uri
+		err := uri.Set(c.in)
+		if c.wantErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, c.want, uri)
+		}
+	}
+}
+
+func TestUrisString(t *testing.T) {
+	tests := [...]struct {
+		in   Uris
+		want string
+	}{
+		{
+			Uris{
+				Uri{Key: "gcm"},
+			},
+			"[gcm]",
+		},
+		{
+			Uris{
+				Uri{Key: "gcm"},
+				Uri{
+					Key: "influxdb",
+					Val: url.URL{Path: "foo"},
+				},
+			},
+			"[gcm influxdb:foo]",
+		},
+	}
+	for _, c := range tests {
+		assert.Equal(t, c.want, c.in.String())
+	}
+}
+
+func TestUrisSet(t *testing.T) {
+	tests := [...]struct {
+		in      []string
+		want    Uris
+		wantErr bool
+	}{
+		{[]string{""}, Uris{}, true},
+		{[]string{":foo"}, Uris{}, true},
+		{
+			[]string{"gcm"},
+			Uris{
+				Uri{Key: "gcm"},
+			},
+			false,
+		},
+		{
+			[]string{"gcm", "influxdb:foo"},
+			Uris{
+				Uri{Key: "gcm"},
+				Uri{
+					Key: "influxdb",
+					Val: url.URL{Path: "foo"},
+				},
+			},
+			false,
+		},
+	}
+	for _, c := range tests {
+		var uris Uris
+		var err error
+		for _, s := range c.in {
+			if err = uris.Set(s); err != nil {
+				break
+			}
+		}
+		if c.wantErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, c.want, uris)
+		}
+	}
+}

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"flag"
-	"strings"
+	"strconv"
 	"time"
 
 	"github.com/golang/glog"
@@ -27,33 +27,53 @@ import (
 	v3 "google.golang.org/api/monitoring/v3"
 
 	"k8s.io/contrib/prometheus-to-sd/config"
+	"k8s.io/contrib/prometheus-to-sd/flags"
 	"k8s.io/contrib/prometheus-to-sd/translator"
 )
 
 var (
-	host       = flag.String("target-host", "localhost", "The monitored component's hostname.")
-	port       = flag.Uint("target-port", 80, "The monitored component's port.")
-	component  = flag.String("component", "", "Required: The monitored target's name.")
+	host       = flag.String("target-host", "localhost", "The monitored component's hostname. DEPRECATED: Use --source instead.")
+	port       = flag.Uint("target-port", 80, "The monitored component's port. DEPRECATED: Use --source instead.")
+	component  = flag.String("component", "", "The monitored target's name. DEPRECATED: Use --source instead.")
 	resolution = flag.Duration("metrics-resolution", 60*time.Second,
 		"The resolution at which prometheus-to-sd will scrape the component for metrics.")
 	metricsPrefix = flag.String("stackdriver-prefix", "container.googleapis.com/master",
 		"Prefix that is appended to every metric.")
 	whitelisted = flag.String("whitelisted-metrics", "",
-		"Comma-separated list of whitelisted metrics. If empty all metrics will be exported.")
+		"Comma-separated list of whitelisted metrics. If empty all metrics will be exported. DEPRECATED: Use --source instead.")
 	apioverride = flag.String("api-override", "",
 		"The stackdriver API endpoint to override the default one used (which is prod).")
+	source = flags.Uris{}
 )
 
 func main() {
 	flag.Set("logtostderr", "true")
+	flag.Var(&source, "source", "source(s) to watch in [component-name]:http://host:port?whitelisted=a,b,c format")
+
 	defer glog.Flush()
 	flag.Parse()
 
-	if *component == "" {
-		glog.Fatalf("--component flag is required")
+	var sourceConfigs []config.SourceConfig
+
+	for _, c := range source {
+		if sourceConfig, err := config.ParseSourceConfig(c); err != nil {
+			glog.Fatalf("Error while parsing source config flag %v: %v", c, err)
+		} else {
+			sourceConfigs = append(sourceConfigs, *sourceConfig)
+		}
 	}
 
-	glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", *component, *host, *port)
+	if len(source) == 0 && *component != "" {
+		glog.Warningf("--component, --host, --port and --whitelisted flags are deprecated. Please use --source instead.")
+		portStr := strconv.FormatUint(uint64(*port), 10)
+
+		if sourceConfig, err := config.NewSourceConfig(*component, *host, portStr, *whitelisted); err != nil {
+			glog.Fatalf("Error while parsing --component flag: %v", err)
+		} else {
+			glog.Infof("Created a new source instance from --component flag: %+v", sourceConfig)
+			sourceConfigs = append(sourceConfigs, *sourceConfig)
+		}
+	}
 
 	gceConf, err := config.GetGceConfig(*metricsPrefix)
 	if err != nil {
@@ -71,20 +91,31 @@ func main() {
 	}
 	glog.V(4).Infof("Successfully created Stackdriver client")
 
-	var whitelistedList []string
-	if *whitelisted != "" {
-		whitelistedList = strings.Split(*whitelisted, ",")
+	if len(sourceConfigs) == 0 {
+		glog.Fatalf("No sources defined. Please specify at least one --source flag.")
 	}
 
-	for range time.Tick(*resolution) {
-		glog.V(4).Infof("Scraping metrics")
-		metrics, err := translator.GetPrometheusMetrics(*host, *port)
-		if err != nil {
-			glog.Warningf("Error while getting Prometheus metrics %v", err)
-			continue
-		}
+	for _, sourceConfig := range sourceConfigs {
+		glog.V(4).Infof("Starting goroutine for %+v", sourceConfig)
 
-		ts := translator.TranslatePrometheusToStackdriver(gceConf, *component, metrics, whitelistedList)
-		translator.SendToStackdriver(stackdriverService, gceConf, ts)
+		// Pass sourceConfig as a parameter to avoid using the last sourceConfig by all goroutines.
+		go func(sourceConfig config.SourceConfig) {
+			glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", sourceConfig.Component, sourceConfig.Host, sourceConfig.Port)
+
+			for range time.Tick(*resolution) {
+				glog.V(4).Infof("Scraping metrics of component %v", sourceConfig.Component)
+				metrics, err := translator.GetPrometheusMetrics(sourceConfig.Host, sourceConfig.Port)
+				if err != nil {
+					glog.Warningf("Error while getting Prometheus metrics %v", err)
+					continue
+				}
+
+				ts := translator.TranslatePrometheusToStackdriver(gceConf, sourceConfig.Component, metrics, sourceConfig.Whitelisted)
+				translator.SendToStackdriver(stackdriverService, gceConf, ts)
+			}
+		}(sourceConfig)
 	}
+
+	// As worker goroutines work forever, block main thread as well.
+	<-make(chan int)
 }


### PR DESCRIPTION
Before the change, one instance of prometheus-to-sd was able to fetch
data from only one component.

Now, --source flag can be provided multiple times to describe multiple
components to be watched by one instance of prometheus-to-sd.

For backward compatibility, combination of --component, --host, --port
and --whitelisted-metrics is still supported as a method of describing
component to watch.