### PR TITLE
Update metric descriptors before pushing metrics.

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -4,7 +4,6 @@ allowed-shame-domains
 api-override
 api-token
 auto-whitelist-metrics
-auto-whitelist-metrics-resolution
 balance-algorithm
 batch-url
 block-path-config
@@ -87,6 +86,7 @@ max-nodes-total
 max-pr-number
 max-sync-failures
 max-total-unready-percentage
+metric-descriptors-resolution
 metrics-resolution
 min-pr-number
 min-replica-count

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	dto "github.com/prometheus/client_model/go"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	v3 "google.golang.org/api/monitoring/v3"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/contrib/prometheus-to-sd/config"
 	"k8s.io/contrib/prometheus-to-sd/flags"
 	"k8s.io/contrib/prometheus-to-sd/translator"
+	"strings"
 )
 
 var (
@@ -48,6 +50,8 @@ var (
 	apioverride = flag.String("api-override", "",
 		"The stackdriver API endpoint to override the default one used (which is prod).")
 	source = flags.Uris{}
+
+	customMetricsPrefix = "custom.googleapis.com"
 )
 
 func main() {
@@ -122,12 +126,12 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 
 	for range time.Tick(*resolution) {
 		glog.V(4).Infof("Scraping metrics of component %v", sourceConfig.Component)
-
+		var metricDescriptors map[string]*v3.MetricDescriptor
 		select {
 		case <-signal:
 			glog.V(4).Infof("Updating metrics cache for component %v", sourceConfig.Component)
-			metricDescriptors, err := translator.GetMetricDescriptors(stackdriverService, gceConf, sourceConfig.Component);
-			if err != nil {
+			var err error
+			if metricDescriptors, err = translator.GetMetricDescriptors(stackdriverService, gceConf, sourceConfig.Component); err != nil {
 				glog.Warningf("Error while fetching metric descriptors for %v: %v", sourceConfig.Component, err)
 			}
 			if useWhitelistedMetricsAutodiscovery {
@@ -146,7 +150,9 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 			glog.Warningf("Error while getting Prometheus metrics %v", err)
 			continue
 		}
-
+		if metricDescriptors != nil {
+			updateMetricDescriptorsDescription(stackdriverService, gceConf, metricDescriptors, metrics)
+		}
 		ts := translator.TranslatePrometheusToStackdriver(gceConf, sourceConfig.Component, metrics, sourceConfig.Whitelisted)
 		translator.SendToStackdriver(stackdriverService, gceConf, ts)
 	}
@@ -156,5 +162,18 @@ func updateWhitelistedMetrics(sourceConfig *config.SourceConfig, metricDescripto
 	sourceConfig.Whitelisted = nil
 	for metricName := range metricDescriptors {
 		sourceConfig.Whitelisted = append(sourceConfig.Whitelisted, metricName)
+	}
+}
+
+func updateMetricDescriptorsDescription(stackdriverService *v3.Service,
+	config *config.GceConfig,
+	descriptors map[string]*v3.MetricDescriptor,
+	metrics map[string]*dto.MetricFamily) {
+	for _, metricFamily := range metrics {
+		metricDescriptor, ok := descriptors[metricFamily.GetName()]
+		if (!ok || metricDescriptor.Description != metricFamily.GetHelp()) && strings.HasPrefix(metricDescriptor.Type, customMetricsPrefix) {
+			updatedMetricDescriptor := translator.MetricFamilyToMetricDescriptor(config, *component, metricFamily)
+			translator.CreateMetricDescriptor(stackdriverService, config, updatedMetricDescriptor)
+		}
 	}
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -43,7 +43,7 @@ var (
 		"Comma-separated list of whitelisted metrics. If empty all metrics will be exported. DEPRECATED: Use --source instead.")
 	autoWhitelistMetrics = flag.Bool("auto-whitelist-metrics", false,
 		"If component has no whitelisted metrics, prometheus-to-sd will fetch them from Stackdriver.")
-	autoWhitelistMetricsResolution = flag.Duration("auto-whitelist-metrics-resolution", 10*time.Minute,
+	metricDescriptorsResolution = flag.Duration("metric-descriptors-resolution", 10*time.Minute,
 		"The resolution at which prometheus-to-sd will scrape metric descriptors from Stackdriver.")
 	apioverride = flag.String("api-override", "",
 		"The stackdriver API endpoint to override the default one used (which is prod).")
@@ -57,27 +57,7 @@ func main() {
 	defer glog.Flush()
 	flag.Parse()
 
-	var sourceConfigs []config.SourceConfig
-
-	for _, c := range source {
-		if sourceConfig, err := config.ParseSourceConfig(c); err != nil {
-			glog.Fatalf("Error while parsing source config flag %v: %v", c, err)
-		} else {
-			sourceConfigs = append(sourceConfigs, *sourceConfig)
-		}
-	}
-
-	if len(source) == 0 && *component != "" {
-		glog.Warningf("--component, --host, --port and --whitelisted flags are deprecated. Please use --source instead.")
-		portStr := strconv.FormatUint(uint64(*port), 10)
-
-		if sourceConfig, err := config.NewSourceConfig(*component, *host, portStr, *whitelisted); err != nil {
-			glog.Fatalf("Error while parsing --component flag: %v", err)
-		} else {
-			glog.Infof("Created a new source instance from --component flag: %+v", sourceConfig)
-			sourceConfigs = append(sourceConfigs, *sourceConfig)
-		}
-	}
+	sourceConfigs := extractSourceConfigsFromFlags()
 
 	gceConf, err := config.GetGceConfig(*metricsPrefix)
 	if err != nil {
@@ -103,50 +83,78 @@ func main() {
 		glog.V(4).Infof("Starting goroutine for %+v", sourceConfig)
 
 		// Pass sourceConfig as a parameter to avoid using the last sourceConfig by all goroutines.
-		go func(sourceConfig config.SourceConfig) {
-			glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", sourceConfig.Component, sourceConfig.Host, sourceConfig.Port)
-
-			signal := time.After(0)
-			useWhitelistedMetricsAutodiscovery := *autoWhitelistMetrics && len(sourceConfig.Whitelisted) == 0
-
-			for range time.Tick(*resolution) {
-				glog.V(4).Infof("Scraping metrics of component %v", sourceConfig.Component)
-
-				if useWhitelistedMetricsAutodiscovery {
-					select {
-					case <-signal:
-						glog.V(4).Infof("Updating metrics cache for component %v", sourceConfig.Component)
-						if metricDescriptors, err := translator.GetMetricDescriptors(stackdriverService, gceConf, sourceConfig.Component); err == nil {
-							sourceConfig.Whitelisted = nil
-							for metricName := range metricDescriptors {
-								sourceConfig.Whitelisted = append(sourceConfig.Whitelisted, metricName)
-							}
-						} else {
-							glog.Warningf("Error while fetching metric descriptors for %v: %v", sourceConfig.Component, err)
-						}
-
-						signal = time.After(*autoWhitelistMetricsResolution)
-					default:
-					}
-
-					if len(sourceConfig.Whitelisted) == 0 {
-						glog.V(4).Infof("Skipping %v component as there are no metric to expose.", sourceConfig.Component)
-						continue
-					}
-				}
-
-				metrics, err := translator.GetPrometheusMetrics(sourceConfig.Host, sourceConfig.Port)
-				if err != nil {
-					glog.Warningf("Error while getting Prometheus metrics %v", err)
-					continue
-				}
-
-				ts := translator.TranslatePrometheusToStackdriver(gceConf, sourceConfig.Component, metrics, sourceConfig.Whitelisted)
-				translator.SendToStackdriver(stackdriverService, gceConf, ts)
-			}
-		}(sourceConfig)
+		go readAndPushDataToStackdriver(stackdriverService, gceConf, sourceConfig)
 	}
 
 	// As worker goroutines work forever, block main thread as well.
 	<-make(chan int)
+}
+
+func extractSourceConfigsFromFlags() []config.SourceConfig {
+	var sourceConfigs []config.SourceConfig
+	for _, c := range source {
+		if sourceConfig, err := config.ParseSourceConfig(c); err != nil {
+			glog.Fatalf("Error while parsing source config flag %v: %v", c, err)
+		} else {
+			sourceConfigs = append(sourceConfigs, *sourceConfig)
+		}
+	}
+
+	if len(source) == 0 && *component != "" {
+		glog.Warningf("--component, --host, --port and --whitelisted flags are deprecated. Please use --source instead.")
+		portStr := strconv.FormatUint(uint64(*port), 10)
+
+		if sourceConfig, err := config.NewSourceConfig(*component, *host, portStr, *whitelisted); err != nil {
+			glog.Fatalf("Error while parsing --component flag: %v", err)
+		} else {
+			glog.Infof("Created a new source instance from --component flag: %+v", sourceConfig)
+			sourceConfigs = append(sourceConfigs, *sourceConfig)
+		}
+	}
+	return sourceConfigs
+}
+
+func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *config.GceConfig, sourceConfig config.SourceConfig) {
+	glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", sourceConfig.Component, sourceConfig.Host, sourceConfig.Port)
+
+	signal := time.After(0)
+	useWhitelistedMetricsAutodiscovery := *autoWhitelistMetrics && len(sourceConfig.Whitelisted) == 0
+
+	for range time.Tick(*resolution) {
+		glog.V(4).Infof("Scraping metrics of component %v", sourceConfig.Component)
+
+		select {
+		case <-signal:
+			glog.V(4).Infof("Updating metrics cache for component %v", sourceConfig.Component)
+			metricDescriptors, err := translator.GetMetricDescriptors(stackdriverService, gceConf, sourceConfig.Component);
+			if err != nil {
+				glog.Warningf("Error while fetching metric descriptors for %v: %v", sourceConfig.Component, err)
+			}
+			if useWhitelistedMetricsAutodiscovery {
+				updateWhitelistedMetrics(&sourceConfig, metricDescriptors)
+			}
+			signal = time.After(*metricDescriptorsResolution)
+		default:
+		}
+		if useWhitelistedMetricsAutodiscovery && len(sourceConfig.Whitelisted) == 0 {
+			glog.V(4).Infof("Skipping %v component as there are no metric to expose.", sourceConfig.Component)
+			continue
+		}
+
+		metrics, err := translator.GetPrometheusMetrics(sourceConfig.Host, sourceConfig.Port)
+		if err != nil {
+			glog.Warningf("Error while getting Prometheus metrics %v", err)
+			continue
+		}
+
+		ts := translator.TranslatePrometheusToStackdriver(gceConf, sourceConfig.Component, metrics, sourceConfig.Whitelisted)
+		translator.SendToStackdriver(stackdriverService, gceConf, ts)
+	}
+}
+
+func updateWhitelistedMetrics(sourceConfig *config.SourceConfig, metricDescriptors map[string]*v3.MetricDescriptor) {
+	sourceConfig.Whitelisted = nil
+	for metricName := range metricDescriptors {
+		sourceConfig.Whitelisted = append(sourceConfig.Whitelisted, metricName)
+	}
 }

--- a/prometheus-to-sd/translator/stackdriver.go
+++ b/prometheus-to-sd/translator/stackdriver.go
@@ -38,7 +38,7 @@ func SendToStackdriver(service *v3.Service, config *config.GceConfig, ts []*v3.T
 		return
 	}
 
-	proj := fmt.Sprintf("projects/%s", config.Project)
+	proj := createProjectName(config)
 
 	var wg sync.WaitGroup
 	for i := 0; i < len(ts); i += maxTimeseriesesPerRequest {
@@ -60,13 +60,8 @@ func SendToStackdriver(service *v3.Service, config *config.GceConfig, ts []*v3.T
 	glog.V(4).Infof("Successfully sent %v timeserieses to Stackdriver", len(ts))
 }
 
-// GetMetricType formats a Metric.Type for given component and metric names.
-func GetMetricType(config *config.GceConfig, component string, metricName string) string {
-	return fmt.Sprintf("%s/%s/%s", config.MetricsPrefix, component, metricName)
-}
-
-// ParseMetricType extracts component and metricName from Metric.Type (e.g. output of GetMetricType).
-func ParseMetricType(config *config.GceConfig, metricType string) (component, metricName string, err error) {
+// parseMetricType extracts component and metricName from Metric.Type (e.g. output of getMetricType).
+func parseMetricType(config *config.GceConfig, metricType string) (component, metricName string, err error) {
 	if !strings.HasPrefix(metricType, config.MetricsPrefix) {
 		return "", "", fmt.Errorf("MetricType is expected to have prefix: %v. Got %v instead.", config.MetricsPrefix, metricType)
 	}
@@ -83,13 +78,13 @@ func ParseMetricType(config *config.GceConfig, metricType string) (component, me
 
 // GetMetricDescriptors fetches all metric descriptors of all metrics defined for given component.
 func GetMetricDescriptors(service *v3.Service, config *config.GceConfig, component string) (map[string]*v3.MetricDescriptor, error) {
-	proj := fmt.Sprintf("projects/%s", config.Project)
+	proj := createProjectName(config)
 
 	metrics := make(map[string]*v3.MetricDescriptor)
 
 	fn := func(page *v3.ListMetricDescriptorsResponse) error {
 		for _, metricDescriptor := range page.MetricDescriptors {
-			if _, metricName, err := ParseMetricType(config, metricDescriptor.Type); err == nil {
+			if _, metricName, err := parseMetricType(config, metricDescriptor.Type); err == nil {
 				metrics[metricName] = metricDescriptor
 			} else {
 				glog.Warningf("Unable to parse %v: %v", metricDescriptor.Type, err)
@@ -102,4 +97,13 @@ func GetMetricDescriptors(service *v3.Service, config *config.GceConfig, compone
 	filter := fmt.Sprintf("metric.type = starts_with(\"%s/%s\")", config.MetricsPrefix, component)
 
 	return metrics, service.Projects.MetricDescriptors.List(proj).Filter(filter).Pages(nil, fn)
+}
+
+// CreateMetricDescriptor creates or updates existing MetricDescriptor.
+func CreateMetricDescriptor(service *v3.Service, config *config.GceConfig, metricDescriptor *v3.MetricDescriptor) {
+	projectName := createProjectName(config)
+	_, err := service.Projects.MetricDescriptors.Create(projectName, metricDescriptor).Do()
+	if err != nil {
+		glog.Errorf("Error in attempt to update metric descriptor %v", err)
+	}
 }

--- a/prometheus-to-sd/translator/stackdriver_test.go
+++ b/prometheus-to-sd/translator/stackdriver_test.go
@@ -25,13 +25,13 @@ import (
 func TestGetMetricType(t *testing.T) {
 	testConfig := &config.GceConfig{MetricsPrefix: "container.googleapis.com/master"}
 	expected := "container.googleapis.com/master/component/name"
-	assert.Equal(t, expected, GetMetricType(testConfig, "component", "name"))
+	assert.Equal(t, expected, getMetricType(testConfig, "component", "name"))
 }
 
 func TestParseMetricType(t *testing.T) {
 	testConfig := &config.GceConfig{MetricsPrefix: "container.googleapis.com/master"}
 	correct := "container.googleapis.com/master/component/name"
-	component, metricName, err := ParseMetricType(testConfig, correct)
+	component, metricName, err := parseMetricType(testConfig, correct)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, "component", component)
@@ -39,10 +39,10 @@ func TestParseMetricType(t *testing.T) {
 	}
 
 	incorrect1 := "container.googleapis.com/master/component"
-	_, _, err = ParseMetricType(testConfig, incorrect1)
+	_, _, err = parseMetricType(testConfig, incorrect1)
 	assert.Error(t, err)
 
 	incorrect2 := "incorrect.prefix.com/master/component"
-	_, _, err = ParseMetricType(testConfig, incorrect2)
+	_, _, err = parseMetricType(testConfig, incorrect2)
 	assert.Error(t, err)
 }

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -41,99 +41,136 @@ func (ts ByMetricTypeReversed) Less(i, j int) bool {
 	return ts[i].Metric.Type > ts[j].Metric.Type
 }
 
+var gceConfig = &config.GceConfig{
+	Project:       "test-proj",
+	Zone:          "us-central1-f",
+	Cluster:       "test-cluster",
+	Instance:      "kubernetes-master.c.test-proj.internal",
+	MetricsPrefix: "container.googleapis.com/master",
+}
+
+var component = "testcomponent"
+
+var metricTypeGauge = dto.MetricType_GAUGE
+var metricTypeCounter = dto.MetricType_COUNTER
+var metricTypeHistogram = dto.MetricType_HISTOGRAM
+var testMetricName = "test_name"
+var testMetricHistogram = "test_histogram"
+var unrelatedMetric = "unrelated_metric"
+var testMetricDescription = "Description 1"
+var testMetricHistogramDescription = "Description 2"
+
+var metrics = map[string]*dto.MetricFamily{
+	testMetricName: {
+		Name: &testMetricName,
+		Type: &metricTypeCounter,
+		Help: &testMetricDescription,
+		Metric: []*dto.Metric{
+			{
+				Label: []*dto.LabelPair{
+					{
+						Name:  stringPtr("labelName"),
+						Value: stringPtr("labelValue1"),
+					},
+				},
+				Counter: &dto.Counter{Value: floatPtr(42.0)},
+			},
+			{
+				Label: []*dto.LabelPair{
+					{
+						Name:  stringPtr("labelName"),
+						Value: stringPtr("labelValue2"),
+					},
+				},
+				Counter: &dto.Counter{Value: floatPtr(106.0)},
+			},
+		},
+	},
+	processStartTimeMetric: {
+		Name: stringPtr(processStartTimeMetric),
+		Type: &metricTypeGauge,
+		Metric: []*dto.Metric{
+			{
+				Gauge: &dto.Gauge{Value: floatPtr(1234567890.0)},
+			},
+		},
+	},
+	unrelatedMetric: {
+		Name: &unrelatedMetric,
+		Type: &metricTypeGauge,
+		Metric: []*dto.Metric{
+			{
+				Gauge: &dto.Gauge{Value: floatPtr(23.0)},
+			},
+		},
+	},
+	testMetricHistogram: {
+		Name: &testMetricHistogram,
+		Type: &metricTypeHistogram,
+		Help: &testMetricHistogramDescription,
+		Metric: []*dto.Metric{
+			{
+				Histogram: &dto.Histogram{
+					SampleCount: intPtr(5),
+					SampleSum:   floatPtr(13),
+					Bucket: []*dto.Bucket{
+						{
+							CumulativeCount: intPtr(1),
+							UpperBound:      floatPtr(1),
+						},
+						{
+							CumulativeCount: intPtr(4),
+							UpperBound:      floatPtr(3),
+						},
+						{
+							CumulativeCount: intPtr(4),
+							UpperBound:      floatPtr(5),
+						},
+						{
+							CumulativeCount: intPtr(5),
+							UpperBound:      floatPtr(math.Inf(1)),
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var metricDescriptors = map[string]*v3.MetricDescriptor{
+	testMetricName: {
+		Type:        "container.googleapis.com/master/testcomponent/test_name",
+		Description: testMetricDescription,
+		MetricKind:  "CUMULATIVE",
+		ValueType:   "INT64",
+		Labels: []*v3.LabelDescriptor{
+			{
+				Key: "labelName",
+			},
+		},
+	},
+	processStartTimeMetric: {
+		Type:       "container.googleapis.com/master/testcomponent/process_start_time_seconds",
+		MetricKind: "GAUGE",
+		ValueType:  "INT64",
+	},
+	unrelatedMetric: {
+		Type:       "container.googleapis.com/master/testcomponent/unrelated_metric",
+		MetricKind: "GAUGE",
+		ValueType:  "INT64",
+	},
+	testMetricHistogram: {
+		Type:        "container.googleapis.com/master/testcomponent/test_histogram",
+		Description: testMetricHistogramDescription,
+		MetricKind:  "CUMULATIVE",
+		ValueType:   "DISTRIBUTION",
+	},
+}
+
 func TestTranslatePrometheusToStackdriver(t *testing.T) {
 	epsilon := float64(0.001)
-	config := &config.GceConfig{
-		Project:       "test-proj",
-		Zone:          "us-central1-f",
-		Cluster:       "test-cluster",
-		Instance:      "kubernetes-master.c.test-proj.internal",
-		MetricsPrefix: "container.googleapis.com/master",
-	}
 
-	metricTypeGauge := dto.MetricType_GAUGE
-	metricTypeCounter := dto.MetricType_COUNTER
-	metricTypeHistogram := dto.MetricType_HISTOGRAM
-	testMetricName := "test_name"
-	testMetricHistogram := "test_histogram"
-	unrelatedMetric := "unrelated_metric"
-
-	metrics := map[string]*dto.MetricFamily{
-		testMetricName: {
-			Name: &testMetricName,
-			Type: &metricTypeCounter,
-			Metric: []*dto.Metric{
-				{
-					Label: []*dto.LabelPair{
-						{
-							Name:  stringPtr("labelName"),
-							Value: stringPtr("labelValue1"),
-						},
-					},
-					Counter: &dto.Counter{Value: floatPtr(42.0)},
-				},
-				{
-					Label: []*dto.LabelPair{
-						{
-							Name:  stringPtr("labelName"),
-							Value: stringPtr("labelValue2"),
-						},
-					},
-					Counter: &dto.Counter{Value: floatPtr(106.0)},
-				},
-			},
-		},
-		processStartTimeMetric: {
-			Name: stringPtr(processStartTimeMetric),
-			Type: &metricTypeGauge,
-			Metric: []*dto.Metric{
-				{
-					Gauge: &dto.Gauge{Value: floatPtr(1234567890.0)},
-				},
-			},
-		},
-		unrelatedMetric: {
-			Name: &unrelatedMetric,
-			Type: &metricTypeGauge,
-			Metric: []*dto.Metric{
-				{
-					Gauge: &dto.Gauge{Value: floatPtr(23.0)},
-				},
-			},
-		},
-		testMetricHistogram: {
-			Name: &testMetricHistogram,
-			Type: &metricTypeHistogram,
-			Metric: []*dto.Metric{
-				{
-					Histogram: &dto.Histogram{
-						SampleCount: intPtr(5),
-						SampleSum:   floatPtr(13),
-						Bucket: []*dto.Bucket{
-							{
-								CumulativeCount: intPtr(1),
-								UpperBound:      floatPtr(1),
-							},
-							{
-								CumulativeCount: intPtr(4),
-								UpperBound:      floatPtr(3),
-							},
-							{
-								CumulativeCount: intPtr(4),
-								UpperBound:      floatPtr(5),
-							},
-							{
-								CumulativeCount: intPtr(5),
-								UpperBound:      floatPtr(math.Inf(1)),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	ts := TranslatePrometheusToStackdriver(config, "testcomponent", metrics, []string{testMetricName, testMetricHistogram})
+	ts := TranslatePrometheusToStackdriver(gceConfig, component, metrics, []string{testMetricName, testMetricHistogram})
 
 	assert.Equal(t, 3, len(ts))
 	// TranslatePrometheusToStackdriver uses maps to represent data, so order of output is randomized.
@@ -188,6 +225,14 @@ func TestTranslatePrometheusToStackdriver(t *testing.T) {
 	assert.Equal(t, int64(3), counts[1])
 	assert.Equal(t, int64(0), counts[2])
 	assert.Equal(t, int64(1), counts[3])
+}
+
+func TestMetricFamilyToMetricDescriptor(t *testing.T) {
+	for metricName, metric := range metrics {
+		metricDescriptor := MetricFamilyToMetricDescriptor(gceConfig, component, metric)
+		expectedMetricDescriptor := metricDescriptors[metricName]
+		assert.Equal(t, metricDescriptor, expectedMetricDescriptor)
+	}
 }
 
 func floatPtr(val float64) *float64 {


### PR DESCRIPTION
Currently prometheus-to-sd ignores description of metrics and as result
stackdriver autogenerates it. Now before pushing metrics it's going to
check if MetricDescriptor exists or has changed and update it if it
neccessary. This check is performed every hour.