### PR TITLE
Implement whitelisted metric autodiscovery in prometheus-to-sd.

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -3,6 +3,8 @@ alias-file
 allowed-shame-domains
 api-override
 api-token
+auto-whitelist-metrics
+auto-whitelist-metrics-resolution
 balance-algorithm
 batch-url
 block-path-config

--- a/prometheus-to-sd/translator/stackdriver.go
+++ b/prometheus-to-sd/translator/stackdriver.go
@@ -24,6 +24,7 @@ import (
 	v3 "google.golang.org/api/monitoring/v3"
 
 	"k8s.io/contrib/prometheus-to-sd/config"
+	"strings"
 )
 
 const (
@@ -57,4 +58,48 @@ func SendToStackdriver(service *v3.Service, config *config.GceConfig, ts []*v3.T
 	}
 	wg.Wait()
 	glog.V(4).Infof("Successfully sent %v timeserieses to Stackdriver", len(ts))
+}
+
+// GetMetricType formats a Metric.Type for given component and metric names.
+func GetMetricType(config *config.GceConfig, component string, metricName string) string {
+	return fmt.Sprintf("%s/%s/%s", config.MetricsPrefix, component, metricName)
+}
+
+// ParseMetricType extracts component and metricName from Metric.Type (e.g. output of GetMetricType).
+func ParseMetricType(config *config.GceConfig, metricType string) (component, metricName string, err error) {
+	if !strings.HasPrefix(metricType, config.MetricsPrefix) {
+		return "", "", fmt.Errorf("MetricType is expected to have prefix: %v. Got %v instead.", config.MetricsPrefix, metricType)
+	}
+
+	componentMetricName := strings.TrimPrefix(metricType, fmt.Sprintf("%s/", config.MetricsPrefix))
+	split := strings.SplitN(componentMetricName, "/", 2)
+
+	if len(split) != 2 {
+		return "", "", fmt.Errorf("MetricType should be in format %v/<component>/<name>. Got %v instead.", config.MetricsPrefix, metricType)
+	}
+
+	return split[0], split[1], nil
+}
+
+// GetMetricDescriptors fetches all metric descriptors of all metrics defined for given component.
+func GetMetricDescriptors(service *v3.Service, config *config.GceConfig, component string) (map[string]*v3.MetricDescriptor, error) {
+	proj := fmt.Sprintf("projects/%s", config.Project)
+
+	metrics := make(map[string]*v3.MetricDescriptor)
+
+	fn := func(page *v3.ListMetricDescriptorsResponse) error {
+		for _, metricDescriptor := range page.MetricDescriptors {
+			if _, metricName, err := ParseMetricType(config, metricDescriptor.Type); err == nil {
+				metrics[metricName] = metricDescriptor
+			} else {
+				glog.Warningf("Unable to parse %v: %v", metricDescriptor.Type, err)
+			}
+		}
+
+		return nil
+	}
+
+	filter := fmt.Sprintf("metric.type = starts_with(\"%s/%s\")", config.MetricsPrefix, component)
+
+	return metrics, service.Projects.MetricDescriptors.List(proj).Filter(filter).Pages(nil, fn)
 }

--- a/prometheus-to-sd/translator/stackdriver_test.go
+++ b/prometheus-to-sd/translator/stackdriver_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/contrib/prometheus-to-sd/config"
+	"testing"
+)
+
+func TestGetMetricType(t *testing.T) {
+	testConfig := &config.GceConfig{MetricsPrefix: "container.googleapis.com/master"}
+	expected := "container.googleapis.com/master/component/name"
+	assert.Equal(t, expected, GetMetricType(testConfig, "component", "name"))
+}
+
+func TestParseMetricType(t *testing.T) {
+	testConfig := &config.GceConfig{MetricsPrefix: "container.googleapis.com/master"}
+	correct := "container.googleapis.com/master/component/name"
+	component, metricName, err := ParseMetricType(testConfig, correct)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "component", component)
+		assert.Equal(t, "name", metricName)
+	}
+
+	incorrect1 := "container.googleapis.com/master/component"
+	_, _, err = ParseMetricType(testConfig, incorrect1)
+	assert.Error(t, err)
+
+	incorrect2 := "incorrect.prefix.com/master/component"
+	_, _, err = ParseMetricType(testConfig, incorrect2)
+	assert.Error(t, err)
+}

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -94,7 +94,7 @@ func translateFamily(config *config.GceConfig, component string, family *dto.Met
 
 // assumes that mType is Counter, Gauge or Histogram
 func translateOne(config *config.GceConfig, component string, name string, mType dto.MetricType, metric *dto.Metric, start, end time.Time) *v3.TimeSeries {
-	fullName := fmt.Sprintf("%s/%s/%s", config.MetricsPrefix, component, name)
+	fullName := GetMetricType(config, component, name)
 
 	metricKind := "GAUGE"
 	interval := &v3.TimeInterval{


### PR DESCRIPTION
Now if --auto-whitelist-metrics is provided (default false) and there
are no whitelisted metrics for component, prometheus-to-sd will query
Stackdriver and fetch them.

The known whitelisted metrics are refreshed each
--auto-whitelist-metrics-resolution (default 10 minutes).