### PR TITLE
Make echoheaders nginx container escape &<> to prevent XSS.

### DIFF
--- a/ingress/echoheaders-redirect/nginx.conf
+++ b/ingress/echoheaders-redirect/nginx.conf
@@ -24,13 +24,21 @@ http {
         location / {
             lua_need_request_body on;
             content_by_lua_block {
+                -- replace HTML special characters to prevent XSS.
+                function sanitize(s)
+                    local s, _ = string.gsub(s or "", "[&<>]",
+                        function(m) return string.format("&#x%x;", string.byte(m, 1)) end)
+                    return s
+                end
+
                 ngx.say("CLIENT VALUES:")
                 ngx.say("client_address=", ngx.var.remote_addr)
-                ngx.say("command=", ngx.req.get_method())
-                ngx.say("real path=", ngx.var.request_uri)
-                ngx.say("query=", ngx.var.query_string)
-                ngx.say("request_version=", ngx.req.http_version())
-                ngx.say("request_uri=", ngx.var.scheme.."://"..ngx.var.host..":"..ngx.var.server_port..ngx.var.request_uri)
+                ngx.say("command=", sanitize(ngx.req.get_method()))
+                ngx.say("real path=", sanitize(ngx.var.request_uri))
+                ngx.say("query=", sanitize(ngx.var.query_string))
+                ngx.say("request_version=", sanitize(ngx.req.http_version()))
+
+                ngx.say("request_uri=", sanitize( ngx.var.scheme.."://"..ngx.var.host..":"..ngx.var.server_port..ngx.var.request_uri))
                 ngx.say("")
 
                 ngx.say("SERVER VALUES:")
@@ -46,11 +54,11 @@ http {
 
                 table.sort(keys)
                 for i, key in ipairs(keys) do
-                    ngx.say(key, "=", headers[key])
+                    ngx.say(key, "=", sanitize(headers[key]))
                 end
 
                 ngx.say("BODY:")
-                ngx.print(ngx.var.request_body or "-no body in request-")
+                ngx.print(sanitize(ngx.var.request_body or "-no body in request-"))
             }
         }
     }

--- a/ingress/echoheaders/nginx.conf
+++ b/ingress/echoheaders/nginx.conf
@@ -21,13 +21,29 @@ http {
         location / {
             lua_need_request_body on;
             content_by_lua_block {
+                -- extracted from https://github.com/bungle/lua-resty-template/blob/master/lib/resty/template.lua#L177
+                local HTML_ENTITIES = {
+                    ["&"] = "&amp;",
+                    ["<"] = "&lt;",
+                    [">"] = "&gt;",
+                    ['"'] = "&quot;",
+                    ["'"] = "&#39;"
+                }
+
+                function escape(s)
+                    local s, _ = string.gsub(s or "", "[\"><'&]", HTML_ENTITIES)
+                    return s
+                end
+                -- end extract
+
                 ngx.say("CLIENT VALUES:")
                 ngx.say("client_address=", ngx.var.remote_addr)
-                ngx.say("command=", ngx.req.get_method())
-                ngx.say("real path=", ngx.var.request_uri)
-                ngx.say("query=", ngx.var.query_string)
-                ngx.say("request_version=", ngx.req.http_version())
-                ngx.say("request_uri=", ngx.var.scheme.."://"..ngx.var.host..":"..ngx.var.server_port..ngx.var.request_uri)
+                ngx.say("command=", escape(ngx.req.get_method()))
+                ngx.say("real path=", escape(ngx.var.request_uri))
+                ngx.say("query=", escape(ngx.var.query_string))
+                ngx.say("request_version=", escape(ngx.req.http_version()))
+
+                ngx.say("request_uri=", escape( ngx.var.scheme.."://"..ngx.var.host..":"..ngx.var.server_port..ngx.var.request_uri))
                 ngx.say("")
 
                 ngx.say("SERVER VALUES:")
@@ -43,11 +59,11 @@ http {
 
                 table.sort(keys)
                 for i, key in ipairs(keys) do
-                    ngx.say(key, "=", headers[key])
+                    ngx.say(key, "=", escape(headers[key]))
                 end
 
                 ngx.say("BODY:")
-                ngx.print(ngx.var.request_body or "-no body in request-")
+                ngx.print(escape(ngx.var.request_body or "-no body in request-"))
             }
         }
     }


### PR DESCRIPTION
Tested locally by doing `make container; docker run --rm -p 8080:8080 gcr.io/google_containers/echoserver:1.4` and then `curl 'localhost:8080/xss-<&>'`.

Intentionally not bumping the image tag because that would require multiple patches against old branches to pick up the newer version, and this change is relatively small and safe!