### PR TITLE
Bump images that use debian-base image

### DIFF
--- a/fluentd/event-exporter/Makefile
+++ b/fluentd/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = gcr.io/google-containers
 IMAGE_NAME = event-exporter
-TAG = v0.1.1
+TAG = v0.1.2
 
 build:
 	${ENVVAR} godep go build -a -o ${BINARY_NAME}

--- a/fluentd/fluentd-gcp-image/Makefile
+++ b/fluentd/fluentd-gcp-image/Makefile
@@ -26,7 +26,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google-containers
-TAG = 2.0.5
+TAG = 2.0.6
 
 build:
 	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/metadata-proxy/Makefile
+++ b/metadata-proxy/Makefile
@@ -15,8 +15,8 @@
 .PHONY:	build push
 
 # TAG is the version to build and push to.
-PREFIX = gcr.io/google_containers
-TAG = 0.1
+PREFIX = gcr.io/google-containers
+TAG = 0.1.1
 
 build:
 	# We explicitly add "--pull" flag to always fetch the latest version

--- a/prometheus-to-sd/Makefile
+++ b/prometheus-to-sd/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 PREFIX = gcr.io/google-containers
-TAG = v0.1.2
+TAG = v0.1.3
 
 build:
 	$(ENVVAR) godep go build -a -o monitor


### PR DESCRIPTION
I recently updated the `debian-base-*` image off upstream with fixes for a number of CVEs.
The downstream images now need to be updated, which I've done in this PR, bumping the patch version for each.

I haven't yet pushed any of these images.
After doing so, I'll need to follow up with additional changes in the manifests.

x-ref https://github.com/kubernetes/kubernetes/issues/47386
cc @Q-Lee @crassirostris 