### PR TITLE
Bump images that use debian-base image again

### DIFF
--- a/fluentd/event-exporter/Makefile
+++ b/fluentd/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = gcr.io/google-containers
 IMAGE_NAME = event-exporter
-TAG = v0.1.2
+TAG = v0.1.3
 
 build:
 	${ENVVAR} godep go build -a -o ${BINARY_NAME}

--- a/fluentd/fluentd-gcp-image/Makefile
+++ b/fluentd/fluentd-gcp-image/Makefile
@@ -26,7 +26,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google-containers
-TAG = 2.0.6
+TAG = 2.0.7
 
 build:
 	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/metadata-proxy/Makefile
+++ b/metadata-proxy/Makefile
@@ -16,7 +16,7 @@
 
 # TAG is the version to build and push to.
 PREFIX = gcr.io/google-containers
-TAG = 0.1.1
+TAG = 0.1.2
 
 build:
 	# We explicitly add "--pull" flag to always fetch the latest version


### PR DESCRIPTION
This is a rehash of #2633. After pushing the images and updating Kubernetes, we discovered that the fluentd container was crashing, as the updated `debian-base` image had unexpectedly removed libcap2 (kubernetes/kubernetes#47600).

I've since pushed a new `debian-base` image (kubernetes/kubernetes#47616). I'm guessing that only the fluentd image needs to be bumped, but I'm going to update all of them out of an abundance of caution.

/cc @Q-Lee @crassirostris @timstclair @eparis