### PR TITLE
[event-exporter] Fix event exporter spam

### DIFF
--- a/fluentd/event-exporter/Makefile
+++ b/fluentd/event-exporter/Makefile
@@ -19,7 +19,7 @@ BINARY_NAME = event-exporter
 
 PREFIX = gcr.io/google-containers
 IMAGE_NAME = event-exporter
-TAG = v0.1.3
+TAG = v0.1.4
 
 build:
 	${ENVVAR} godep go build -a -o ${BINARY_NAME}


### PR DESCRIPTION
Watch framework periodically resets the connections (~one every 15 minutes) which causes a lot of messages about lost events in Stackdriver. Though this change is raising the chances that some events will be lost without a note, the probability of this event is extremely low (it requires to lose whole apiserver event history, e.g. in case of a really long network outage). Note, that in case container is restarted, the message will still be generated.

/cc @piosz 