### PR TITLE
Enabling Multi-arch support in Ansible scripts

### DIFF
--- a/ansible/roles/common/defaults/main.yaml
+++ b/ansible/roles/common/defaults/main.yaml
@@ -13,3 +13,7 @@ is_coreos: false
 has_rpm: false
 has_firewalld: false
 has_iptables: false
+
+#Set ansible_architecture as amd64 if it's x86_64
+ansible_architecture: "amd64"
+when: ansible_architecture == "x86_64"

--- a/ansible/roles/etcd/defaults/main.yaml
+++ b/ansible/roles/etcd/defaults/main.yaml
@@ -55,7 +55,7 @@ etcd_listen_client_legacy_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_
 etcd_data_dir: /var/lib/etcd
 
 etcd_download_url_base: "https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}"
-etcd_download_url: "{{ etcd_download_url_base }}/etcd-v{{ etcd_version }}-linux-amd64.tar.gz"
+etcd_download_url: "{{ etcd_download_url_base }}/etcd-v{{ etcd_version }}-linux-{{ ansible_architecture }}.tar.gz"
 
 etcd_enable: true
 

--- a/ansible/roles/etcd/tasks/etcd-install-github-release.yml
+++ b/ansible/roles/etcd/tasks/etcd-install-github-release.yml
@@ -11,13 +11,13 @@
 
 - name: Extract tar file
   unarchive:
-    src: "{{ ansible_temp_dir }}/etcd-v{{ etcd_version }}-linux-amd64.tar.gz"
+    src: "{{ ansible_temp_dir }}/etcd-v{{ etcd_version }}-linux-{{ ansible_architecture }}.tar.gz"
     dest: /usr/local
     copy: no
 
 - name: Create symlinks
   file:
-    src: /usr/local/etcd-v{{ etcd_version }}-linux-amd64/{{ item }}
+    src: /usr/local/etcd-v{{ etcd_version }}-linux-{{ ansible_architecture }}/{{ item }}
     dest: /usr/bin/{{ item }}
     state: link
   with_items:

--- a/ansible/roles/flannel/defaults/main.yaml
+++ b/ansible/roles/flannel/defaults/main.yaml
@@ -9,14 +9,14 @@ flannel_source_type: package
 flannel_releases_dir: /opt
 
 #flannel_version
-flannel_version: 0.5.5
+flannel_version: 0.7.1
 
 #The backend that flannel should use
 flannel_backend: vxlan
 
 #The default url to download the flannel tar from
 flannel_download_url_base: "https://github.com/coreos/flannel/releases/download/v{{ flannel_version }}"
-flannel_download_url: "{{ flannel_download_url_base }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz"
+flannel_download_url: "{{ flannel_download_url_base }}/flannel-v{{ flannel_version }}-linux-{{ ansible_architecture }}.tar.gz"
 
 flannel_etcd_use_certs: false
 flannel_etcd_certs_dir: "/etc/flanneld/certs"

--- a/ansible/roles/flannel/tasks/github-release.yml
+++ b/ansible/roles/flannel/tasks/github-release.yml
@@ -15,14 +15,14 @@
 
 - name: Extract tar file
   unarchive:
-    src: "{{ ansible_temp_dir }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz"
+    src: "{{ ansible_temp_dir }}/flannel-v{{ flannel_version }}-linux-{{ ansible_architecture }}.tar.gz"
     dest: "{{ flannel_releases_dir }}"
     copy: no
   when: st.stat.isdir is not defined
 
 - name: Create symlinks
   file:
-    src: "{{ flannel_releases_dir }}/flannel-{{ flannel_version }}/{{ item }}"
+    src: "{{ flannel_releases_dir }}/{{ item }}"
     dest: "{{ bin_dir }}/{{ item }}"
     state: link
     force: yes

--- a/ansible/roles/kubernetes-addons/templates/dns/kubedns-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/dns/kubedns-controller.yaml.j2
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-amd64:1.8
+        image: gcr.io/google_containers/kubedns-{{ ansible_architecture }}:1.8
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -83,7 +83,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-{{ ansible_architecture }}:1.4
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq
@@ -106,7 +106,7 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.2
+        image: gcr.io/google_containers/exechealthz-{{ ansible_architecture }}:1.2
         resources:
           limits:
             memory: 50Mi

--- a/ansible/roles/kubernetes-addons/templates/kube-dash/kube-dash-rc.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-dash/kube-dash-rc.yaml.j2
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.2
+        image: gcr.io/google_containers/kubernetes-dashboard-{{ ansible_architecture }}:v1.4.2
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/ansible/roles/kubernetes-addons/templates/kube-ui/dashboard-controller.yaml.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-ui/dashboard-controller.yaml.j2
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0
+        image: gcr.io/google_containers/kubernetes-dashboard-{{ ansible_architecture }}:v1.1.0
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -22,7 +22,7 @@ kube_script_dir: /usr/libexec/kubernetes
 kube_config_dir: /etc/kubernetes
 
 # The URL to download Kubernetes binaries from.
-kube_download_url_base: https://storage.googleapis.com/kubernetes-release/release/v{{ kube_version }}/bin/linux/amd64
+kube_download_url_base: https://storage.googleapis.com/kubernetes-release/release/v{{ kube_version }}/bin/linux/{{ ansible_architecture }}
 
 # The URL do download distribution rpms shipping kubernetes binaries from
 kube_rpm_url_base: https://kojipkgs.fedoraproject.org//packages/kubernetes/1.2.0/0.27.git4a3f9c5.fc25/x86_64


### PR DESCRIPTION
This PR enables multi-arch support for ansible scripts when github-release option is chosen. 

 - By default for x86_64 machines the packages have amd64 as arch, so we need to set ansible_architecture as amd64 when it's x86_64. 

 - Flannel new version has a different directory structure compared to older version, so had to change the version too with flannel.
