### PR TITLE
Fix cni-plugins/to_docker/bin/c2d: return code should be an int

### DIFF
--- a/cni-plugins/to_docker/bin/c2d
+++ b/cni-plugins/to_docker/bin/c2d
@@ -30,7 +30,7 @@ else
     cat <<EOF
 {
   "cniVersion": "0.1.0",
-  "code": "${RC}",
+  "code": ${RC},
   "msg": "${0}-inner returned ${RC}",
   "details": $(jq -R -s . < "${LOG}")
 }


### PR DESCRIPTION
It was a string.

Resolves #2646 