### PR TITLE
Update labels of metric descriptors if they change

### DIFF
--- a/prometheus-to-sd/config/source_config.go
+++ b/prometheus-to-sd/config/source_config.go
@@ -18,11 +18,11 @@ package config
 
 import (
 	"fmt"
+	"github.com/golang/glog"
 	"k8s.io/contrib/prometheus-to-sd/flags"
 	"net"
 	"strconv"
 	"strings"
-	"github.com/golang/glog"
 )
 
 // SourceConfig contains data specific for scraping one component.
@@ -71,8 +71,9 @@ func parseSourceConfig(uri flags.Uri) (*SourceConfig, error) {
 	return newSourceConfig(component, host, port, whitelisted)
 }
 
-func (this *SourceConfig) UpdateWhitelistedMetrics(list []string) {
-	this.Whitelisted = list
+// UpdateWhitelistedMetrics sets passed list as a list of whitelisted metrics.
+func (config *SourceConfig) UpdateWhitelistedMetrics(list []string) {
+	config.Whitelisted = list
 }
 
 // SourceConfigsFromFlags creates a slice of SourceConfig's base on the provided flags.

--- a/prometheus-to-sd/config/source_config_test.go
+++ b/prometheus-to-sd/config/source_config_test.go
@@ -51,7 +51,7 @@ func TestNewSourceConfig(t *testing.T) {
 	}
 
 	for _, c := range correct {
-		res, err := NewSourceConfig(c.component, c.host, c.port, c.whitelisted)
+		res, err := newSourceConfig(c.component, c.host, c.port, c.whitelisted)
 		if assert.NoError(t, err) {
 			assert.Equal(t, c.output, *res)
 		}
@@ -79,7 +79,7 @@ func TestParseSourceConfig(t *testing.T) {
 		},
 	}
 
-	res, err := ParseSourceConfig(correct.in)
+	res, err := parseSourceConfig(correct.in)
 	if assert.NoError(t, err) {
 		assert.Equal(t, correct.output, *res)
 	}
@@ -104,7 +104,7 @@ func TestParseSourceConfig(t *testing.T) {
 	}
 
 	for _, c := range incorrect {
-		_, err = ParseSourceConfig(c)
+		_, err = parseSourceConfig(c)
 		assert.Error(t, err)
 	}
 }

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -131,7 +131,7 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 			glog.Warningf("Error while getting Prometheus metrics %v", err)
 			continue
 		}
-		metricDescriptorCache.UpdateMetricDescriptors(metrics)
+		metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)
 		ts := translator.TranslatePrometheusToStackdriver(commonConfig, metrics, sourceConfig.Whitelisted)
 		translator.SendToStackdriver(stackdriverService, gceConf, ts)
 	}

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -100,7 +100,12 @@ func main() {
 
 func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *config.GceConfig, podConfig *config.PodConfig, sourceConfig config.SourceConfig) {
 	glog.Infof("Running prometheus-to-sd, monitored target is %s %v:%v", sourceConfig.Component, sourceConfig.Host, sourceConfig.Port)
-	metricDescriptorCache := translator.NewMetricDescriptorCache(stackdriverService, gceConf, sourceConfig.Component)
+	commonConfig := &config.CommonConfig{
+		GceConfig:     gceConf,
+		PodConfig:     podConfig,
+		ComponentName: sourceConfig.Component,
+	}
+	metricDescriptorCache := translator.NewMetricDescriptorCache(stackdriverService, commonConfig)
 	signal := time.After(0)
 	useWhitelistedMetricsAutodiscovery := *autoWhitelistMetrics && len(sourceConfig.Whitelisted) == 0
 
@@ -122,11 +127,6 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 			continue
 		}
 		metrics, err := translator.GetPrometheusMetrics(sourceConfig.Host, sourceConfig.Port)
-		commonConfig := &config.CommonConfig{
-			GceConfig:     gceConf,
-			PodConfig:     podConfig,
-			ComponentName: sourceConfig.Component,
-		}
 		if err != nil {
 			glog.Warningf("Error while getting Prometheus metrics %v", err)
 			continue

--- a/prometheus-to-sd/main.go
+++ b/prometheus-to-sd/main.go
@@ -132,7 +132,7 @@ func readAndPushDataToStackdriver(stackdriverService *v3.Service, gceConf *confi
 			continue
 		}
 		metricDescriptorCache.UpdateMetricDescriptors(metrics, sourceConfig.Whitelisted)
-		ts := translator.TranslatePrometheusToStackdriver(commonConfig, metrics, sourceConfig.Whitelisted)
+		ts := translator.TranslatePrometheusToStackdriver(commonConfig, sourceConfig.Whitelisted, metrics, metricDescriptorCache)
 		translator.SendToStackdriver(stackdriverService, gceConf, ts)
 	}
 }

--- a/prometheus-to-sd/translator/metric_descriptor_cache.go
+++ b/prometheus-to-sd/translator/metric_descriptor_cache.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"github.com/golang/glog"
+	dto "github.com/prometheus/client_model/go"
+	v3 "google.golang.org/api/monitoring/v3"
+
+	"fmt"
+	"k8s.io/contrib/prometheus-to-sd/config"
+	"strings"
+)
+
+var (
+	customMetricsPrefix = "custom.googleapis.com"
+)
+
+type MetricDescriptorCache struct {
+	descriptors map[string]*v3.MetricDescriptor
+	service     *v3.Service
+	config      *config.GceConfig
+	component   string
+	fresh       bool
+}
+
+// NewMetricDescriptorCache creates empty metric descriptor cache for the given component.
+func NewMetricDescriptorCache(service *v3.Service, config *config.GceConfig, component string) *MetricDescriptorCache {
+	return &MetricDescriptorCache{
+		descriptors: make(map[string]*v3.MetricDescriptor),
+		service:     service,
+		config:      config,
+		component:   component,
+		fresh:       false,
+	}
+}
+
+// GetMetricNames returns a list of all metric names from the cache.
+func (this *MetricDescriptorCache) GetMetricNames() []string {
+	keys := make([]string, len(this.descriptors))
+	for k := range this.descriptors {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// MarkStale makes function IsFresh to return false until the next cache refresh.
+func (this *MetricDescriptorCache) MarkStale() {
+	this.fresh = false
+}
+
+// UpdateMetricDescriptors iterates over all metricFamilies and updates metricDescriptors in the Stackdriver if required.
+func (this *MetricDescriptorCache) UpdateMetricDescriptors(metrics map[string]*dto.MetricFamily) {
+	// Perform this operation only if cache was recently refreshed. This is done mostly from the optimization point
+	// of view, we don't want to check all metric descriptors too often, as they should change rarely.
+	if !this.fresh {
+		return
+	}
+	for _, metricFamily := range metrics {
+		this.updateMetricDescriptorIfStale(metricFamily)
+	}
+}
+
+// updateMetricDescriptorIfStale checks if descriptor created from MetricFamily object differs from the existing one
+// and updates if needed.
+func (this *MetricDescriptorCache) updateMetricDescriptorIfStale(metricFamily *dto.MetricFamily) {
+	metricDescriptor, ok := this.descriptors[metricFamily.GetName()]
+	updatedMetricDescriptor := MetricFamilyToMetricDescriptor(this.config, this.component, metricFamily)
+	if strings.HasPrefix(updatedMetricDescriptor.Type, customMetricsPrefix) &&
+		(!ok || descriptorChanged(metricDescriptor, updatedMetricDescriptor)) {
+		this.updateMetricDescriptorInStackdriver(updatedMetricDescriptor)
+		this.descriptors[metricFamily.GetName()] = updatedMetricDescriptor
+	}
+}
+
+func descriptorChanged(original *v3.MetricDescriptor, checked *v3.MetricDescriptor) bool {
+	if original.Description != checked.Description {
+		glog.V(4).Infof("Description is different, %v != %v", original.Description, checked.Description)
+		return true
+	}
+	return false
+}
+
+// updateMetricDescriptorInStackdriver writes metric descriptor to the stackdriver.
+func (this *MetricDescriptorCache) updateMetricDescriptorInStackdriver(metricDescriptor *v3.MetricDescriptor) {
+	glog.V(4).Infof("Updating metric descriptor: %+v", metricDescriptor)
+
+	projectName := createProjectName(this.config)
+	_, err := this.service.Projects.MetricDescriptors.Create(projectName, metricDescriptor).Do()
+	if err != nil {
+		glog.Errorf("Error in attempt to update metric descriptor %v", err)
+	}
+}
+
+// Refresh function fetches all metric descriptors of all metrics defined for given component with a defined prefix
+// and puts them into cache.
+func (this *MetricDescriptorCache) Refresh() {
+	proj := createProjectName(this.config)
+	metrics := make(map[string]*v3.MetricDescriptor)
+	fn := func(page *v3.ListMetricDescriptorsResponse) error {
+		for _, metricDescriptor := range page.MetricDescriptors {
+			if _, metricName, err := parseMetricType(this.config, metricDescriptor.Type); err == nil {
+				metrics[metricName] = metricDescriptor
+			} else {
+				glog.Warningf("Unable to parse %v: %v", metricDescriptor.Type, err)
+			}
+		}
+		return nil
+	}
+	filter := fmt.Sprintf("metric.type = starts_with(\"%s/%s\")", this.config.MetricsPrefix, this.component)
+	err := this.service.Projects.MetricDescriptors.List(proj).Filter(filter).Pages(nil, fn)
+	if err != nil {
+		glog.Warningf("Error while fetching metric descriptors for %v: %v", this.component, err)
+	}
+	this.fresh = true
+}

--- a/prometheus-to-sd/translator/stackdriver.go
+++ b/prometheus-to-sd/translator/stackdriver.go
@@ -42,7 +42,7 @@ func SendToStackdriver(service *v3.Service, config *config.GceConfig, ts []*v3.T
 	proj := createProjectName(config)
 
 	var wg sync.WaitGroup
-	var failedTs uint32 = 0
+	var failedTs uint32
 	for i := 0; i < len(ts); i += maxTimeseriesesPerRequest {
 		end := i + maxTimeseriesesPerRequest
 		if end > len(ts) {
@@ -54,13 +54,13 @@ func SendToStackdriver(service *v3.Service, config *config.GceConfig, ts []*v3.T
 			req := &v3.CreateTimeSeriesRequest{TimeSeries: ts[begin:end]}
 			_, err := service.Projects.TimeSeries.Create(proj, req).Do()
 			if err != nil {
-				atomic.AddUint32(&failedTs, uint32(end - begin))
+				atomic.AddUint32(&failedTs, uint32(end-begin))
 				glog.Errorf("Error while sending request to Stackdriver %v", err)
 			}
 		}(i, end)
 	}
 	wg.Wait()
-	glog.V(4).Infof("Successfully sent %v timeserieses to Stackdriver", uint32(len(ts)) - failedTs)
+	glog.V(4).Infof("Successfully sent %v timeserieses to Stackdriver", uint32(len(ts))-failedTs)
 }
 
 // parseMetricType extracts component and metricName from Metric.Type (e.g. output of getMetricType).

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -174,7 +174,7 @@ var metricDescriptors = map[string]*v3.MetricDescriptor{
 
 func TestTranslatePrometheusToStackdriver(t *testing.T) {
 	epsilon := float64(0.001)
-	cache := NewMetricDescriptorCache(nil, nil, commonConfig.ComponentName)
+	cache := NewMetricDescriptorCache(nil, commonConfig)
 
 	ts := TranslatePrometheusToStackdriver(commonConfig, []string{testMetricName, testMetricHistogram}, metrics, cache)
 

--- a/prometheus-to-sd/translator/translator_test.go
+++ b/prometheus-to-sd/translator/translator_test.go
@@ -174,8 +174,9 @@ var metricDescriptors = map[string]*v3.MetricDescriptor{
 
 func TestTranslatePrometheusToStackdriver(t *testing.T) {
 	epsilon := float64(0.001)
+	cache := NewMetricDescriptorCache(nil, nil, commonConfig.ComponentName)
 
-	ts := TranslatePrometheusToStackdriver(commonConfig, metrics, []string{testMetricName, testMetricHistogram})
+	ts := TranslatePrometheusToStackdriver(commonConfig, []string{testMetricName, testMetricHistogram}, metrics, cache)
 
 	assert.Equal(t, 3, len(ts))
 	// TranslatePrometheusToStackdriver uses maps to represent data, so order of output is randomized.
@@ -234,7 +235,7 @@ func TestTranslatePrometheusToStackdriver(t *testing.T) {
 
 func TestMetricFamilyToMetricDescriptor(t *testing.T) {
 	for metricName, metric := range metrics {
-		metricDescriptor := MetricFamilyToMetricDescriptor(commonConfig, metric)
+		metricDescriptor := MetricFamilyToMetricDescriptor(commonConfig, metric, nil)
 		expectedMetricDescriptor := metricDescriptors[metricName]
 		assert.Equal(t, metricDescriptor, expectedMetricDescriptor)
 	}


### PR DESCRIPTION
This PR includes few minor changes that fixes issues in the prometheus-to-sd component:

1. Component is not trying to update metric descriptor if this metric was not whitelisted.
2. Updates metric descriptor if new label was added.
3. Doesn't send broken metrics to the stackdriver (for example when name is longer than 100 characters or number of labels bigger than 10)
4. If sending of batch of timeserieses to the Stackdriver fails, correct number of sent timeserieses is logged.
