### PR TITLE
[ansible] swap out deprecated --config argument

### DIFF
--- a/ansible/roles/master/templates/kubelet.j2
+++ b/ansible/roles/master/templates/kubelet.j2
@@ -14,4 +14,4 @@ KUBELET_HOSTNAME="--hostname-override={{ inventory_hostname }}"
 KUBELET_API_SERVER="--api-servers=http://localhost:{{ kube_master_insecure_port }}"
 
 # Add your own!
-KUBELET_ARGS="--register-node=false --config={{ kube_manifest_dir }}"
+KUBELET_ARGS="--register-node=false --pod-manifest-path={{ kube_manifest_dir }}"

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -17,7 +17,7 @@ kube_node_rpms:
 
 kubelet_options:
   - "--kubeconfig={{ kube_config_dir }}/kubelet.kubeconfig"
-  - "--config={{ kube_manifest_dir }}"
+  - "--pod-manifest-path={{ kube_manifest_dir }}"
 
 kube_proxy_options:
   - "--kubeconfig={{ kube_config_dir }}/proxy.kubeconfig"


### PR DESCRIPTION
We're using the deprecated (https://github.com/kubernetes/kubernetes/pull/40048/) `--confg` argument to pass the manifest dir. this fixes that. Tested on kube 1.6.4 and kube 1.5.3.