### PR TITLE
Add glog flags to rescheduler

### DIFF
--- a/rescheduler/Makefile
+++ b/rescheduler/Makefile
@@ -3,7 +3,7 @@ all: build
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64
 REGISTRY = gcr.io/google-containers
-TAG = v0.3.0
+TAG = v0.3.1
 
 deps:
 	go get github.com/tools/godep

--- a/rescheduler/rescheduler.go
+++ b/rescheduler/rescheduler.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"encoding/json"
+	goflag "flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -85,8 +86,16 @@ var (
 )
 
 func main() {
-	glog.Infof("Running Rescheduler")
+	flags.AddGoFlagSet(goflag.CommandLine)
+
+	// Log to stderr by default and fix usage message accordingly
+	logToStdErr := flags.Lookup("logtostderr")
+	logToStdErr.DefValue = "true"
+	flags.Set("logtostderr", "true")
+
 	flags.Parse(os.Args)
+
+	glog.Infof("Running Rescheduler")
 
 	go func() {
 		http.Handle("/metrics", prometheus.Handler())


### PR DESCRIPTION
This PR adds flags from the `glog` package to `rescheduler`. This enables passing `--logtostderr=true` to rescheduler in order to have Docker gather the logs, as opposed to logging them to the filesystem inside the container.

Fixes https://github.com/kubernetes/contrib/issues/2518.