### PR TITLE
use publicly available event-exporter image

### DIFF
--- a/fluentd/event-exporter/README.md
+++ b/fluentd/event-exporter/README.md
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
       - name: event-exporter
-        image: gcr.io/google.com/vmik-k8s-testing-0/event-exporter:v0.1.0
+        image: gcr.io/google-containers/event-exporter:v0.1.4
         command:
         - '/event-exporter'
 ```

--- a/fluentd/event-exporter/example/event-exporter-deployment.yaml
+++ b/fluentd/event-exporter/example/event-exporter-deployment.yaml
@@ -12,6 +12,6 @@ spec:
       serviceAccountName: event-exporter-sa
       containers:
       - name: event-exporter
-        image: gcr.io/google.com/vmik-k8s-testing-0/event-exporter:v0.1.0
+        image: gcr.io/google-containers/event-exporter:v0.1.4
         command:
         - '/event-exporter'


### PR DESCRIPTION
Change url in examples from private `google.com/vmik-k8s-testing-0` to public `gcr.io/google-containers`