### PR TITLE
Implement ListFilesInBuild

### DIFF
--- a/node-perf-dash/downloader.go
+++ b/node-perf-dash/downloader.go
@@ -20,10 +20,12 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path"
 	"strconv"
+	"strings"
 
 	"k8s.io/contrib/test-utils/utils"
 )
@@ -69,10 +71,19 @@ func (d *LocalDownloader) GetLastestBuildNumber(job string) (int, error) {
 
 // ListFilesInBuild returns the contents of the files with the specified prefix
 // for the test job at the given buildNumber.
-//
-// TODO(yguo0905): Implement this function.
 func (d *LocalDownloader) ListFilesInBuild(job string, buildNumber int, prefix string) ([]string, error) {
-	return nil, fmt.Errorf("ListFilesInBuild() is not yet implemented for local downloader")
+	prefixDir, prefixFile := path.Split(prefix)
+	filesInDir, err := ioutil.ReadDir(path.Join(*localDataDir, fmt.Sprintf("%d", buildNumber), prefixDir))
+	if err != nil {
+		return nil, err
+	}
+	filesInBuild := []string{}
+	for _, file := range filesInDir {
+		if strings.HasPrefix(file.Name(), prefixFile) {
+			filesInBuild = append(filesInBuild, path.Join(prefixDir, file.Name()))
+		}
+	}
+	return filesInBuild, nil
 }
 
 // GetFile returns readcloser of the desired file.


### PR DESCRIPTION
In order to use the node-perf-dash on local runs, it needs to be able to find local files.   A previous refactor left the ListFilesInBuild function with a TODO to implement it.
This PR implements the ListFilesInBuild function, which should allow using the node-perf-dash with local runs again.

I was not sure if this would follow symbolic links or not, so I added a max depth of 10 to avoid an infinite loop.

/assign @yguo0905 