### PR TITLE
Bump to kubernetes 1.5.2 release

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of Kubernetes binaries
-kube_version: 1.4.5
+kube_version: 1.5.2
 
 # Set source of kubernetes binaries
 # Available: packageManager, localBuild, github-release, distribution-rpm


### PR DESCRIPTION
Due to a new --cgroup-driver flag.