### PR TITLE
exec-healthz: Use alpine as base image on all platforms

### DIFF
--- a/exec-healthz/Makefile
+++ b/exec-healthz/Makefile
@@ -37,16 +37,16 @@ ifeq ($(ARCH),amd64)
     BASEIMAGE?=alpine
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=armel/busybox
+    BASEIMAGE?=arm32v6/alpine
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=aarch64/busybox
+    BASEIMAGE?=arm64v8/alpine
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=ppc64le/busybox
+    BASEIMAGE?=ppc64le/alpine
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=s390x/busybox
+    BASEIMAGE?=s390x/alpine
 endif
 
 IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)


### PR DESCRIPTION
Fixes #2661. See discussions on #2670.

<s>Some others user:group configurations are imported from kubernetes/dns#31.</s> (This PR does not change user:group anymore.)

/assign @bowei @luxas 
@guirish Could you please build/test s390x image with this? I don't have the correct environment. Thanks :)