### PR TITLE
VIP only with no backend service 

### DIFF
--- a/keepalived-vip/README.md
+++ b/keepalived-vip/README.md
@@ -73,7 +73,7 @@ The only requirement is for [DaemonSets](https://github.com/kubernetes/kubernete
 
 ## Configuration
 
-To expose one or more services use the flag `services-configmap`. The format of the data is: `external IP -> namespace/serviceName`. Optionally it is possible to specify forwarding method using `:` after the service name. The valid options are `NAT` and `DR`. For instance `external IP -> namespace/serviceName:DR`. By default, if the method is not specified it will use NAT.
+To expose one or more services use the flag `services-configmap`. The format of the data is: `external IP -> namespace/serviceName`. Optionally it is possible to specify forwarding method using `:` after the service name. The valid options are `NAT` and `DR`. For instance `external IP -> namespace/serviceName:DR`. By default, if the method is not specified it will use NAT. If the service name is left blank, only the VIP will be assigned and no routing will be done. This is useful e.g. if you run HAProxy in another pod on the same machines with hostnetwork in order to forward incoming smtp requests via  proxy protocol to postfix. 
 
 This IP must be routable within the LAN and must be available. By default the IP address of the pods is used to route the traffic. This means that is one pod dies or a new one is created by a scale event the keepalived configuration file will be updated and reloaded.
 

--- a/keepalived-vip/keepalived.tmpl
+++ b/keepalived-vip/keepalived.tmpl
@@ -30,6 +30,9 @@ vrrp_instance vips {
 }
 
 {{ range $i, $svc := .svcs }}
+{{ if eq $svc.LVSMethod "VIP" }}
+# VIP Service with no pods: {{ $svc.IP }}
+{{ else }}
 # Service: {{ $svc.Name }}
 virtual_server {{ $svc.IP }} {{ $svc.Port }} {
   delay_loop 5
@@ -48,4 +51,5 @@ virtual_server {{ $svc.IP }} {{ $svc.Port }} {
   }
 {{ end }}
 }
+{{ end }}
 {{ end }}

--- a/keepalived-vip/utils.go
+++ b/keepalived-vip/utils.go
@@ -42,7 +42,7 @@ var (
 	invalidIfaces = []string{"lo", "docker0", "flannel.1", "cbr0"}
 	nsSvcLbRegex  = regexp.MustCompile(`(.*)/(.*):(.*)|(.*)/(.*)`)
 	vethRegex     = regexp.MustCompile(`^veth.*`)
-	lvsRegex      = regexp.MustCompile(`NAT`)
+	lvsRegex      = regexp.MustCompile(`NAT|DR`)
 )
 
 type nodeInfo struct {

--- a/keepalived-vip/utils_test.go
+++ b/keepalived-vip/utils_test.go
@@ -32,7 +32,7 @@ func TestParseNsSvcLVS(t *testing.T) {
 		"missing namespace":      {"echoheaders:NAT", "", "", "", true},
 		"default forward method": {"default/echoheaders", "default", "echoheaders", "NAT", false},
 		"with forward method":    {"default/echoheaders:NAT", "default", "echoheaders", "NAT", false},
-		"DR as forward method":   {"default/echoheaders:DR", "", "", "", true},
+		"DR as forward method":   {"default/echoheaders:DR", "default", "echoheaders", "DR", false},
 		"invalid forward method": {"default/echoheaders:AJAX", "", "", "", true},
 	}
 


### PR DESCRIPTION
This Pull Requests enables to let run Keepalived with only attaching the VIP to the node. Then e.g. HAProxy can be run via Daemonset to make use of it.

I use it in order to Forward SMTP via Proxy protocol to postfix. With normal forwarding postfix will njever get the real IP address of the caller.