### PR TITLE
[404 server] Update to makefile and owners file and version bump

### DIFF
--- a/404-server/Makefile
+++ b/404-server/Makefile
@@ -20,19 +20,19 @@
 
 all: push
 
-TAG=1.3
+TAG=1.4
 PREFIX?=gcr.io/google_containers/defaultbackend
 ARCH?=amd64
-GOLANG_VERSION=1.7
+GOLANG_VERSION=1.8.3
 TEMP_DIR:=$(shell mktemp -d)
 
-server: server.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GOARM=6 go build -a -installsuffix cgo -ldflags '-w -s' -o server ./server.go
+server:
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GOARM=6 go build -a -installsuffix cgo -ldflags '-w -s' -o server .
 
 container:
 	# Compile the binary inside a container for reliable builds
 	docker pull golang:$(GOLANG_VERSION)
-	docker run --rm -it -v $(PWD):/build golang:$(GOLANG_VERSION) /bin/bash -c "make -C /build server ARCH=$(ARCH)"
+	docker run --rm -it -v $(PWD):/go/src/defaultbackend golang:$(GOLANG_VERSION) /bin/bash -c "make -C /go/src/defaultbackend server ARCH=$(ARCH)"
 
 	docker build --pull -t $(PREFIX)-$(ARCH):$(TAG) .
 

--- a/404-server/OWNERS
+++ b/404-server/OWNERS
@@ -1,8 +1,8 @@
 approvers:
-- bprashanth
+- bowei
 - luxas
 - mikedanese
 reviewers:
-- bprashanth
+- bowei
 - luxas
 - mikedanese


### PR DESCRIPTION
A version of the 404 server hasn't been built with @cmluciano's changes including prometheus metric capturing. Along with bumping the version to 1.4, I made the following changes:

- Use golang 1.8.3 instead of 1.7
- Run 'clean' target before building 'server' target
- 'server' target was building "server.go" but ignoring the other file "metrics.go"
- Moved build location within the golang's gopath - now the vendor directory is used.
- Replaced bprashanth with bowei for reviewer/approver

/assign @mikedanese 
/cc @bowei 