### PR TITLE
[service-loadbalancer] Update README on namespaces

### DIFF
--- a/service-loadbalancer/README.md
+++ b/service-loadbalancer/README.md
@@ -243,7 +243,7 @@ $ mysql -u root -ppassword --host 104.197.63.17 --port 3306 -e 'show databases;'
 
 #### Cross-namespace loadbalancing
 
-By default, the loadbalancer only listens for services in the `default` namespace. You can list available namespaces via:
+By default, the loadbalancer will listen for services in all namespaces. You can list available namespaces via:
 ```
 $ kubectl get namespaces
 NAME          LABELS    STATUS    AGE
@@ -251,7 +251,7 @@ default       <none>    Active    1d
 kube-system   <none>    Active    1d
 ```
 
-You can tell it to expose services on a different namespace through a command line argument. Currently, each namespace needs a different loadbalancer (see [wishlist](#wishlist)). Modify the rc.yaml file to supply the namespace argument by adding the following lines to the bottom of the loadbalancer spec:
+You can tell it to expose services only from a specific namespace through a command line argument. Modify the rc.yaml file to supply the namespace argument by adding the following lines to the bottom of the loadbalancer spec:
 ```yaml
 args:
   - --tcp-services=mysql:3306,nginxsvc:443
@@ -389,7 +389,6 @@ status of the services or stats about the traffic
   2. __Redirect__: All traffic is https. HTTP connections are encrypted using load balancer certs.
 
   Currently you need to trigger TCP loadbalancing for your https service by specifying it in loadbalancer.json. Support for the other 2 would be nice.
-- Multinamespace support: Currently the controller only watches a single namespace for services.
 - Support for external services (eg: amazon rds)
 - Dynamically modify loadbalancer.json. Will become unnecessary when we have a loadbalancer resource.
 - Headless services: I just didn't think people would care enough about this.


### PR DESCRIPTION
I got really confused by the README stating that the service loadbalancer only watches the `default` namespace by default. My experience was that I was getting errors about services from other namespaces not playing nicely with haproxy. 

#1709 helped me confirm that, by default, all namespaces are watched, not just `default`, so I thought I'd submit a quick PR to fix this in the docs and hopefully save others some head-bashing... : )