### PR TITLE
Rename OWNERS assignees: to approvers:

### DIFF
--- a/images/OWNERS
+++ b/images/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
 

--- a/statefulsets/OWNERS
+++ b/statefulsets/OWNERS
@@ -1,4 +1,4 @@
-assignees:
+approvers:
 - bprashanth
 - enisoc
 - erictune

--- a/statefulsets/zookeeper/OWNERS
+++ b/statefulsets/zookeeper/OWNERS
@@ -1,4 +1,4 @@
-assignees:
+approvers:
 - bprashanth
 - enisoc
 - erictune


### PR DESCRIPTION
They are effectively the same, assignees is deprecated

ref: https://github.com/kubernetes/test-infra/issues/3851

I broke this into two commits around `vendor/` because I'm not sure it's kosher to be editing vendored OWNERS directly. ref: https://github.com/kubernetes/test-infra/issues/3694