### PR TITLE
keepalived-vip: fix deprecated NodeLegacyHostIP

### DIFF
--- a/keepalived-vip/utils.go
+++ b/keepalived-vip/utils.go
@@ -100,7 +100,7 @@ func getPodDetails(kubeClient *unversioned.Client) (*podInfo, error) {
 			}
 		}
 
-		if externalIP == "" && address.Type == api.NodeLegacyHostIP {
+		if externalIP == "" && address.Type == api.NodeInternalIP {
 			externalIP = address.Address
 		}
 	}


### PR DESCRIPTION
Replace NodeLegacyHostIP with NodeInternalIP.  This is required for
keepalived-vip to work on bare metal, since it has no cloud provider to set
ExternalIP on each node resource.