### PR TITLE
Fix typo and grammatical error

### DIFF
--- a/statefulsets/zookeeper/README.md
+++ b/statefulsets/zookeeper/README.md
@@ -98,7 +98,7 @@ containers:
 |ZK_ENSEMBLE|string|N/A|A colon separated list of servers in the ensemble.|
 This is a mandatory configuration variable that is used to configure the membership of the 
 ZooKeeper ensemble. It is also used to prevent data loss during accidental scale operations. The 
-set can be computed as as follows. For all integers in the range [0,replicas), prepend the name of 
+set can be computed as follows. For all integers in the range [0,replicas), prepend the name of 
 service followed by a dash to the integer. So for the Stateful Set above, the name is zk and we have
 3 replicas. for the set {0,1,2} we prepend zk- giving us zk-0;zk-1;zk-2.
 
@@ -127,7 +127,7 @@ environment variables may be omitted from the configuration.
 |Variable|Type|Default|Description|
 |:------:|:---:|:-----:|:--------|
 |ZK_MIN_SESSION_TIMEOUT|integer|2 * ZK_TICK_TIME|The minimum session timeout that the ensemble will allow a client to request.|
-|ZK_MAX_SESSION_TIMEOUT|integer|20 * ZK_TICK_TIME|The maximum session timeout that the ensemble will allows a client to request.|
+|ZK_MAX_SESSION_TIMEOUT|integer|20 * ZK_TICK_TIME|The maximum session timeout that the ensemble will allow a client to request.|
 
 #### Data Retention Configuration
 **ZooKeeper does not, by default, purge old transactions logs or snapshots. This can cause 


### PR DESCRIPTION
Fix typo and grammatical error in Kubernetes ZooKeeper