### PR TITLE
Fix service-loadbalancer test failures

### DIFF
--- a/service-loadbalancer/service_loadbalancer_test.go
+++ b/service-loadbalancer/service_loadbalancer_test.go
@@ -205,7 +205,7 @@ func TestGetServices(t *testing.T) {
 func TestNewStaticPageHandler(t *testing.T) {
 	defPagePath, _ := filepath.Abs("haproxy.cfg")
 	defErrorPath, _ := filepath.Abs("template.cfg")
-	defErrURL := "http://www.k8s.io"
+	defErrURL := "https://kubernetes.io"
 
 	testDefPage := "file://" + defPagePath
 	testErrorPage := "file://" + defErrorPath


### PR DESCRIPTION
The previous test case of http://www.k8s.io is now failing becuase it
redirects to https://www.k8s.io, but the certificate being served for
that site isn't valid for that hostname anymore.  This changes it to use
the main kubenetes page which fixes the test failures.