### PR TITLE
Fallback to node internal IP if external IP is not set

### DIFF
--- a/keepalived-vip/utils.go
+++ b/keepalived-vip/utils.go
@@ -100,7 +100,7 @@ func getPodDetails(kubeClient *unversioned.Client) (*podInfo, error) {
 			}
 		}
 
-		if externalIP == "" && address.Type == api.NodeLegacyHostIP {
+		if externalIP == "" && (address.Type == api.NodeLegacyHostIP || address.Type == api.NodeInternalIP) {
 			externalIP = address.Address
 		}
 	}


### PR DESCRIPTION
Ref. this comment: https://github.com/kubernetes/kubernetes/issues/42125#issuecomment-320137328

Right now kube-keepalived does not work if using a cloud provider as the external IP field cannot be set.

I'm using my own cloud provider (https://github.com/munnerz/keepalived-cloud-provider) that automatically configures kube-keepalived-vip for service `LoadBalancer` support. Without this change, it will not work with any version of Kubernetes that doesn't use the old `NodeLegacyHostIP`.