### PR TITLE
Change maintainer & bump tag for metadata-proxy

### DIFF
--- a/metadata-proxy/Dockerfile
+++ b/metadata-proxy/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM gcr.io/google-containers/debian-base-amd64:0.1
-LABEL maintainer "qlee@google.com"
+LABEL maintainer "ihmccreery@google.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \

--- a/metadata-proxy/Makefile
+++ b/metadata-proxy/Makefile
@@ -16,7 +16,7 @@
 
 # TAG is the version to build and push to.
 PREFIX = gcr.io/google-containers
-TAG = 0.1.2
+TAG = 0.1.3
 
 build:
 	# We explicitly add "--pull" flag to always fetch the latest version


### PR DESCRIPTION
For CVE 2016-9063.  I've already pushed the newly built container.