### PR TITLE
replace localhost to 127.0.0.1 as dns resolve localhost may have issue

### DIFF
--- a/rescheduler/rescheduler.go
+++ b/rescheduler/rescheduler.go
@@ -81,7 +81,7 @@ var (
 		`How long should rescheduler wait for critical pod to be scheduled
 		 after evicting pods to make a spot for it.`)
 
-	listenAddress = flags.String("listen-address", "localhost:9235",
+	listenAddress = flags.String("listen-address", "127.0.0.1:9235",
 		`Address to listen on for serving prometheus metrics`)
 )
 


### PR DESCRIPTION
related to issue https://github.com/kubernetes/contrib/issues/2724

in some cases, resolve the localhost may have some problems like below:
root@hchenk8s5:/var/log# host localhost
localhost.eng.platformlab.ibm.com has address 9.111.159.90
root@hchenk8s5:/var/log# ping -c 1 localhost
PING localhost.localdomain (127.0.0.1) 56(84) bytes of data.

so we may need to use 127.0.0.1:9235 as default listen address when rescheduler started. 