### PR TITLE
Fix nginx.conf to block recursive calls and identity endpoints

### DIFF
--- a/metadata-proxy/Dockerfile
+++ b/metadata-proxy/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM gcr.io/google-containers/debian-base-amd64:0.1
-LABEL maintainer "qlee@google.com"
+LABEL maintainer "ihmccreery@google.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \

--- a/metadata-proxy/Makefile
+++ b/metadata-proxy/Makefile
@@ -16,7 +16,7 @@
 
 # TAG is the version to build and push to.
 PREFIX = gcr.io/google-containers
-TAG = 0.1.2
+TAG = 0.1.3
 
 build:
 	# We explicitly add "--pull" flag to always fetch the latest version

--- a/metadata-proxy/nginx.conf
+++ b/metadata-proxy/nginx.conf
@@ -11,53 +11,79 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 user www-data;
 worker_processes 4;
 pid /run/nginx.pid;
+error_log /dev/stdout;
 
 events {
   worker_connections 20;
 }
 
 http {
+  access_log /dev/stdout;
   server {
     listen 127.0.0.1:988;
+    # When serving 301s, don't redirect to port 988.
+    port_in_redirect off;
 
     # By default, return 403. This protects us from new API versions.
     location / {
-        return 403;
+        return 403 "This metadata API is not allowed by the metadata proxy.";
     }
-
     # Allow for REST discovery.
     location = / {
+        if ($args ~* "^(.+&)?recursive=") {
+                return 403 "?recursive calls are not allowed by the metadata proxy.";
+        }
         proxy_pass http://169.254.169.254;
     }
     location = /computeMetadata/ {
+        if ($args ~* "^(.+&)?recursive=") {
+                return 403 "?recursive calls are not allowed by the metadata proxy.";
+        }
         proxy_pass http://169.254.169.254;
     }
 
     # By default, allow the v0.1, v1beta1, and v1 APIs.
     location /0.1/ {
+        if ($args ~* "^(.+&)?recursive=") {
+                return 403 "?recursive calls are not allowed by the metadata proxy.";
+        }
         proxy_pass http://169.254.169.254;
     }
     location /computeMetadata/v1beta1/ {
+        if ($args ~* "^(.+&)?recursive=") {
+                return 403 "?recursive calls are not allowed by the metadata proxy.";
+        }
         proxy_pass http://169.254.169.254;
     }
     location /computeMetadata/v1/ {
+        if ($args ~* "^(.+&)?recursive=") {
+                return 403 "?recursive calls are not allowed by the metadata proxy.";
+        }
         proxy_pass http://169.254.169.254;
     }
 
     # Return a 403 for the kube-env attribute in all allowed API versions.
     location /0.1/meta-data/attributes/kube-env {
-        return 403;
+        return 403 "This metadata endpoint is concealed by the metadata proxy.";
     }
     location /computeMetadata/v1beta1/instance/attributes/kube-env {
-        return 403;
+        return 403 "This metadata endpoint is concealed by the metadata proxy.";
     }
     location /computeMetadata/v1/instance/attributes/kube-env {
-        return 403;
+        return 403 "This metadata endpoint is concealed by the metadata proxy.";
     }
-
+    # Return a 403 for instance identity in all allowed API versions.
+    location ~ /0.1/meta-data/service-accounts/.+/identity {
+        return 403 "This metadata endpoint is concealed by the metadata proxy.";
+    }
+    location ~ /computeMetadata/v1beta1/instance/service-accounts/.+/identity {
+        return 403 "This metadata endpoint is concealed by the metadata proxy.";
+    }
+    location ~ /computeMetadata/v1/instance/service-accounts/.+/identity {
+        return 403 "This metadata endpoint is concealed by the metadata proxy.";
+    }
   }
 }


### PR DESCRIPTION
These changes reflect https://github.com/kubernetes/kubernetes/pull/51302.

We should make these changes here and get rid of the configmap in https://github.com/kubernetes/kubernetes/pull/51302, because configmaps have no good update strategy.  Specifically, if the master version changes, the configmap will change, but pods making up the daemonset won't get restarted (unless the version of the container changed as well), so they won't update their config (the configmap volume may change, but nginx won't reload it).

cc @ahmetb @destijl @mikedanese @Q-Lee.