### PR TITLE
[keepalived-vip] Watch the VIP->service configmap for changes

### DIFF
--- a/keepalived-vip/controller.go
+++ b/keepalived-vip/controller.go
@@ -102,7 +102,7 @@ func (c vipByNameIPPort) Less(i, j int) bool {
 	return iPort < jPort
 }
 
-type StoreToConfigMapLister struct {
+type storeToConfigMapLister struct {
 	cache.Indexer
 }
 
@@ -115,7 +115,7 @@ type ipvsControllerController struct {
 	cmController      *cache.Controller
 	svcLister         cache.StoreToServiceLister
 	epLister          cache.StoreToEndpointsLister
-	cmLister          StoreToConfigMapLister
+	cmLister          storeToConfigMapLister
 	reloadRateLimiter flowcontrol.RateLimiter
 	keepalived        *keepalived
 	configMapName     string
@@ -131,7 +131,6 @@ type ipvsControllerController struct {
 	syncQueue *taskQueue
 	stopCh    chan struct{}
 }
-
 
 // getEndpoints returns a list of <endpoint ip>:<port> for a given service/target port combination.
 func (ipvsc *ipvsControllerController) getEndpoints(

--- a/keepalived-vip/main.go
+++ b/keepalived-vip/main.go
@@ -125,6 +125,10 @@ func main() {
 	ipvsc := newIPVSController(kubeClient, namespace, *useUnicast, *configMapName, *vrid)
 	go ipvsc.epController.Run(wait.NeverStop)
 	go ipvsc.svcController.Run(wait.NeverStop)
+	if ipvsc.cmController != nil {
+		// Possibility the controller may not exist if configmap name is malformed
+		go ipvsc.cmController.Run(wait.NeverStop)
+	}
 
 	go ipvsc.syncQueue.run(time.Second, ipvsc.stopCh)
 


### PR DESCRIPTION
This PR fixes issue #2736 
Any update to the config map will now cause kube-keepalived-vip to update and activate the ipvs configuration. Let me know what you think. Thanks.
