### PR TITLE
WIP: Delay after starting keepalived and before reconfiguring

### DIFF
--- a/keepalived-vip/keepalived.go
+++ b/keepalived-vip/keepalived.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"syscall"
 	"text/template"
+	"time"
 
 	"github.com/golang/glog"
 	k8sexec "k8s.io/kubernetes/pkg/util/exec"
@@ -114,11 +115,13 @@ func (k *keepalived) Start() {
 	k.cmd.Stdout = os.Stdout
 	k.cmd.Stderr = os.Stderr
 
-	k.started = true
-
 	if err := k.cmd.Start(); err != nil {
 		glog.Errorf("keepalived error: %v", err)
 	}
+
+	// Give keepalived enough time to install its SIGHUP handler before we send the signal
+	time.Sleep(1000 * time.Millisecond)
+	k.started = true
 
 	if err := k.cmd.Wait(); err != nil {
 		glog.Fatalf("keepalived error: %v", err)


### PR DESCRIPTION
This fixes #2744 for me.

This isn't a really good fix because almost any time that you fix a race condition by using a sleep there's something wrong.

k.started definitely should not be set to true before the k.cmd.Start() call.

Anyone got a better solution to the sleep? I thought about waiting on the PID file creation by keepalived but unfortunately by code inspection keepalived creates that file before the signal handler is installed so to truly fix the race condition we would need an upstream fix in keepalived.

Open to other suggestions though.