### PR TITLE
Use correct property name for log.dir

### DIFF
--- a/statefulsets/kafka/kafka.yaml
+++ b/statefulsets/kafka/kafka.yaml
@@ -74,7 +74,7 @@ spec:
         - "exec kafka-server-start.sh /opt/kafka/config/server.properties --override broker.id=${HOSTNAME##*-} \
           --override listeners=PLAINTEXT://:9093 \
           --override zookeeper.connect=zk-0.zk-svc.default.svc.cluster.local:2181,zk-1.zk-svc.default.svc.cluster.local:2181,zk-2.zk-svc.default.svc.cluster.local:2181 \
-          --override log.dir=/var/lib/kafka \
+          --override log.dirs=/var/lib/kafka \
           --override auto.create.topics.enable=true \
           --override auto.leader.rebalance.enable=true \
           --override background.threads=10 \


### PR DESCRIPTION
The correct property name for log.dir  is log.dirs
