### PR TITLE
[keepalived-vip] Release 0.11

### DIFF
--- a/keepalived-vip/Makefile
+++ b/keepalived-vip/Makefile
@@ -1,7 +1,7 @@
 all: push
 
-# 0.0 shouldn't clobber any release builds, current "latest" is 0.10
-TAG = 0.10
+# 0.0 shouldn't clobber any release builds, current "latest" is 0.11
+TAG = 0.11
 PREFIX = gcr.io/google_containers/kube-keepalived-vip
 BUILD_IMAGE = build-keepalived
 TEMP_GOPATH = ${GOPATH}:${GOPATH}/src/k8s.io/kubernetes/staging

--- a/keepalived-vip/README.md
+++ b/keepalived-vip/README.md
@@ -106,7 +106,7 @@ Configure the DaemonSet in `vip-daemonset.yaml` to use the ServiceAccount. Add t
       hostNetwork: true
       serviceAccount: kube-keepalived-vip
       containers:
-        - image: gcr.io/google_containers/kube-keepalived-vip:0.9
+        - image: gcr.io/google_containers/kube-keepalived-vip:0.11
 ```
 
 Configure its ClusterRole. _keepalived_ needs to read the pods, nodes, endpoints and services.
@@ -160,7 +160,7 @@ $ kubectl create -f vip-daemonset.yaml
 daemonset "kube-keepalived-vip" created
 $ kubectl get daemonset
 NAME                  CONTAINER(S)          IMAGE(S)                         SELECTOR                        NODE-SELECTOR
-kube-keepalived-vip   kube-keepalived-vip   gcr.io/google_containers/kube-keepalived-vip:0.9   name in (kube-keepalived-vip)   type=worker
+kube-keepalived-vip   kube-keepalived-vip   gcr.io/google_containers/kube-keepalived-vip:0.11   name in (kube-keepalived-vip)   type=worker
 ```
 
 **Note: the DaemonSet yaml file contains a node selector. This is not required, is just an example to show how is possible to limit the nodes where keepalived can run**

--- a/keepalived-vip/vip-daemonset.yaml
+++ b/keepalived-vip/vip-daemonset.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-        - image: gcr.io/google_containers/kube-keepalived-vip:0.9
+        - image: gcr.io/google_containers/kube-keepalived-vip:0.11
           name: kube-keepalived-vip
           imagePullPolicy: Always
           securityContext:

--- a/keepalived-vip/vip-rc.yaml
+++ b/keepalived-vip/vip-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: gcr.io/google_containers/kube-keepalived-vip:0.9
+      - image: gcr.io/google_containers/kube-keepalived-vip:0.11
         name: kube-keepalived-vip
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
Would it be possible to release a new version of keepalived-vip? My nodes don't have an ExternalIP set, which has been fixed in https://github.com/kubernetes/contrib/pull/2705.