### PR TITLE
metadata-proxy: fix build problems, bump dependencies, bump version to 0.1.4

### DIFF
--- a/metadata-proxy/Dockerfile
+++ b/metadata-proxy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:0.1
+FROM gcr.io/google-containers/debian-base-amd64:0.2
 LABEL maintainer "ihmccreery@google.com"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/metadata-proxy/Makefile
+++ b/metadata-proxy/Makefile
@@ -16,13 +16,13 @@
 
 # TAG is the version to build and push to.
 PREFIX = gcr.io/google-containers
-TAG = 0.1.3
+TAG = 0.1.4
 
 build:
 	# We explicitly add "--pull" flag to always fetch the latest version
 	# of the base image. This is necessary to avoid using cached local
 	# versions of image e.g. when updating insecure base images.
-	docker build --pull -t ${PREFIX}/metadata-proxy:$(TAG) .
+	docker build --no-cache --pull -t ${PREFIX}/metadata-proxy:$(TAG) .
 
 push: build
 	gcloud docker -- push ${PREFIX}/metadata-proxy:$(TAG)


### PR DESCRIPTION
Without `--no-cache`, the `apt-get update` commands were being cached and not updating properly.