### PR TITLE
Remove api-servers from kubelet environment

### DIFF
--- a/init/systemd/environ/kubelet
+++ b/init/systemd/environ/kubelet
@@ -10,8 +10,5 @@ KUBELET_ADDRESS="--address=127.0.0.1"
 # You may leave this blank to use the actual hostname
 KUBELET_HOSTNAME="--hostname-override=127.0.0.1"
 
-# location of the api-server
-KUBELET_API_SERVER="--api-servers=http://127.0.0.1:8080"
-
 # Add your own!
 KUBELET_ARGS="--cgroup-driver=systemd"


### PR DESCRIPTION
In kubernetes 1.8.x the kubelet parameter "--api-servers" has been
removed, remove it from from the systemd environment.