### PR TITLE
[zookeeper] 3.4.9 -> 3.4.10

### DIFF
--- a/statefulsets/zookeeper/Dockerfile
+++ b/statefulsets/zookeeper/Dockerfile
@@ -7,7 +7,7 @@ ENV ZK_USER=zookeeper \
     JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 ARG GPG_KEY=C823E3E5B12AF29C67F81976F5CECB3CB5E9BD2D
-ARG ZK_DIST=zookeeper-3.4.9
+ARG ZK_DIST=zookeeper-3.4.10
 
 RUN set -x \
     && apt-get update \

--- a/statefulsets/zookeeper/Makefile
+++ b/statefulsets/zookeeper/Makefile
@@ -1,4 +1,4 @@
-VERSION=v2
+VERSION=v3
 PROJECT_ID=google_samples
 PROJECT=gcr.io/${PROJECT_ID}
 

--- a/statefulsets/zookeeper/README.md
+++ b/statefulsets/zookeeper/README.md
@@ -4,14 +4,14 @@ This project contains a Docker image meant to facilitate the deployment of
 [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/). 
 ## Limitations
 1. Scaling is not currently supported. An ensemble's membership can not be updated in a safe way 
-in ZooKeeper 3.4.9 (The current stable release).
+in ZooKeeper 3.4.10 (The current stable release).
 2. Observers are currently not supported. Contributions are welcome.
 3. Persistent Volumes must be used. emptyDirs will likely result in a loss of data.
 
 ## Docker Image
 The docker image contained in this repository is comprised of a base Ubuntu 16.04 image using the latest
 release of the OpenJDK JRE based on the 1.8 JVM (JDK 8u111) and the latest stable release of 
-ZooKeeper, 3.4.9. Ubuntu is a much larger image than BusyBox or Alpine, but these images contain 
+ZooKeeper, 3.4.10. Ubuntu is a much larger image than BusyBox or Alpine, but these images contain
 mucl or ulibc. This requires a custom version of OpenJDK to be built against a libc runtime other 
 than glibc. No vendor of the ZooKeeper software supplies or verifies the software against such a 
 JVM, and, while Alpine or BusyBox would provide smaller images, we have prioritized a well known 
@@ -74,7 +74,7 @@ configuration below.
 containers:
       - name: k8szk
         imagePullPolicy: Always
-        image: gcr.io/google_samples/k8szk:v1
+        image: gcr.io/google_samples/k8szk:v3
         ports:
         - containerPort: 2181
           name: client

--- a/statefulsets/zookeeper/zookeeper.yaml
+++ b/statefulsets/zookeeper/zookeeper.yaml
@@ -63,7 +63,7 @@ spec:
       containers:
       - name: k8szk
         imagePullPolicy: Always
-        image: gcr.io/google_samples/k8szk:v2
+        image: gcr.io/google_samples/k8szk:v3
         resources:
           requests:
             memory: "2Gi"


### PR DESCRIPTION
Hi,

zookeeper `3.4.10` has been released as the latest stable. Many frameworks[0] & datastores[1] using zk has upgraded their client library to `3.4.10`, hence it will be good to build an k8szk image of 3.4.10. This PR adds the required changes.

[0] - https://github.com/lagom/lagom/pull/986
[1] - https://github.com/apache/kafka/commit/c2d17c830ca309a4e3989981a47790209955273c