### PR TITLE
Improve graph visibility and minor cleanups.

### DIFF
--- a/perfdash/.gitignore
+++ b/perfdash/.gitignore
@@ -1,0 +1,2 @@
+/.idea/
+/perfdash

--- a/perfdash/google-gcs-downloader.go
+++ b/perfdash/google-gcs-downloader.go
@@ -55,11 +55,11 @@ func (g *GoogleGCSDownloader) getData() (TestToBuildData, error) {
 				artifacts, err := g.GoogleGCSBucketUtils.ListFilesInBuild(
 					job, buildNumber, fmt.Sprintf("artifacts/%v_%v", filePrefix, strings.ToLower(test)))
 				if err != nil || len(artifacts) == 0 {
-					fmt.Printf("Error while looking for data in build %v: %v", buildNumber, err)
+					fmt.Printf("Error while looking for data in build %v: %v\n", buildNumber, err)
 					continue
 				}
 				if len(artifacts) > 1 {
-					fmt.Printf("WARNING: found multiple files with data, reading only one")
+					fmt.Printf("WARNING: found multiple files with data, reading only one\n")
 				}
 				metricsFilename := artifacts[0][strings.LastIndex(artifacts[0], "/")+1:]
 				testDataResponse, err := g.GoogleGCSBucketUtils.GetFileFromJenkinsGoogleBucket(job, buildNumber, fmt.Sprintf("artifacts/%v", metricsFilename))
@@ -71,7 +71,7 @@ func (g *GoogleGCSDownloader) getData() (TestToBuildData, error) {
 				defer testDataBody.Close()
 				data, err := ioutil.ReadAll(testDataBody)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "Error when reading response Body: %v", err)
+					fmt.Fprintf(os.Stderr, "Error when reading response Body: %v\n", err)
 					continue
 				}
 				parseTestOutput(data, buildNumber, job, test, result)

--- a/perfdash/perfdash.go
+++ b/perfdash/perfdash.go
@@ -43,7 +43,7 @@ func main() {
 	flag.Parse()
 
 	if *builds > maxBuilds || *builds < 0 {
-		fmt.Printf("Invalid builds number: %d", *builds)
+		fmt.Printf("Invalid number of builds: %d, setting to %d\n", *builds, maxBuilds)
 		*builds = maxBuilds
 	}
 
@@ -64,7 +64,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error formating data: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Printf("Result: %v", string(prettyResult))
+		fmt.Printf("Result: %v\n", string(prettyResult))
 		return
 	}
 

--- a/perfdash/www/angular-chart.js
+++ b/perfdash/www/angular-chart.js
@@ -17,12 +17,12 @@
   Chart.defaults.global.multiTooltipTemplate = '<%if (datasetLabel){%><%=datasetLabel%>: <%}%><%= value %>';
   Chart.defaults.global.colours = [
     '#97BBCD', // blue
-    '#DCDCDC', // light grey
+    '#4D5360', // dark grey
     '#F7464A', // red
     '#46BFBD', // green
     '#FDB45C', // yellow
     '#949FB1', // grey
-    '#4D5360'  // dark grey
+    '#DCDCDC', // light grey
   ];
 
   var usingExcanvas = typeof window.G_vmlCanvasManager === 'object' &&

--- a/perfdash/www/script.js
+++ b/perfdash/www/script.js
@@ -55,7 +55,7 @@ PerfDashApp.prototype.labelChanged = function() {
         return;
     }
     // All the unit should be the same
-    this.options= {scaleLabel: "<%=value%> "+result[0].unit};
+    this.options = {scaleLabel: "<%=value%> "+result[0].unit};
     angular.forEach(result[0].data, function(value, name) {
         this.seriesData.push(this.getStream(result, name));
         this.series.push(name);

--- a/perfdash/www/script.js
+++ b/perfdash/www/script.js
@@ -56,7 +56,13 @@ PerfDashApp.prototype.labelChanged = function() {
     }
     // All the unit should be the same
     this.options = {scaleLabel: "<%=value%> "+result[0].unit};
-    angular.forEach(result[0].data, function(value, name) {
+    // Start with higher percentiles, since their values are usually strictly higher
+    // than lower percentiles, which avoids obscuring graph data. It also orders data
+    // in the onHover labels more naturally.
+    var seriesLabels = Object.keys(result[0].data);
+    seriesLabels.sort();
+    seriesLabels.reverse();
+    angular.forEach(seriesLabels, function(name) {
         this.seriesData.push(this.getStream(result, name));
         this.series.push(name);
     }, this);


### PR DESCRIPTION
When adding timeseries to graph, start with higher percentiles, since their
values are usually strictly higher than lower percentiles, which avoids
obscuring graph data.

It also orders data in the onHover labels more naturally.

Swap grey colors for a more visible 90th percentile.

Add .gitignore, missing whitespace and newlines.