### PR TITLE
Use {{ bin_dir }}/etcdctl instead hardcoded /usr/bin/etcdctl

### DIFF
--- a/ansible/roles/etcd/tasks/etcd-install-github-release.yml
+++ b/ansible/roles/etcd/tasks/etcd-install-github-release.yml
@@ -18,7 +18,7 @@
 - name: Create symlinks
   file:
     src: /usr/local/etcd-v{{ etcd_version }}-linux-{{ (ansible_architecture == 'x86_64') | ternary('amd64', ansible_architecture) }}/{{ item }}
-    dest: /usr/bin/{{ item }}
+    dest: "{{ bin_dir }}/{{ item }}"
     state: link
   with_items:
     - etcd


### PR DESCRIPTION
We have an inconsistency in symbolic links creation. 

1. https://github.com/kubernetes/contrib/blob/master/ansible/roles/flannel/tasks/github-release.yml#L26
```
    dest: "{{ bin_dir }}/{{ item }}"
```

2. https://github.com/kubernetes/contrib/blob/master/ansible/roles/master/tasks/download_bins.yml#L33
```
    dest: "{{ bin_dir }}/{{ item }}"
```

And we have hardcoded `bin_dir` in `etcd-install-github-release.yml`: 
```
    dest: /usr/bin/{{ item }}
```
