### PR TITLE
Add deprecation warning for ansible project

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,5 +1,7 @@
 # Kubernetes Ansible
 
+**DEPRECATED**: See repo https://github.com/kubernetes-incubator/kubespray
+
 This playbook and set of roles set up a Kubernetes cluster onto machines. They
 can be real hardware, VMs, things in a public cloud, etc. Anything that you can connect to via SSH.
 


### PR DESCRIPTION
The https://github.com/kubernetes-incubator/kubespray seems to be the successor of the `ansible`-folder. So mark this folder as deprecated and link to the new one.