### PR TITLE
[keepalived-vip] Document workaround for running `modprobe ip_vs` on CentOS

### DIFF
--- a/keepalived-vip/vip-daemonset.yaml
+++ b/keepalived-vip/vip-daemonset.yaml
@@ -9,6 +9,24 @@ spec:
         name: kube-keepalived-vip
     spec:
       hostNetwork: true
+      # kube-keepalived-vip use a `modprobe ip_vs`, see
+      # https://github.com/kubernetes/contrib/blob/8be3a141fd0d753ddcd8cbc23b74cbdd430394ba/keepalived-vip/utils.go#L232
+      # which might not work on non-ubuntu system. When running this on CentOS,
+      # use the following initContainer as workaround.
+      # initContainers:
+      #   - image: centos:7
+      #     name: kube-keepalived-vip-modprobe
+      #     imagePullPolicy: Always
+      #     securityContext:
+      #       privileged: true
+      #     volumeMounts:
+      #       - mountPath: /lib/modules
+      #         name: modules
+      #         readOnly: true
+      #       - mountPath: /dev
+      #         name: dev
+      #     command: ['modprobe']
+      #     args: ['ip_vs']
       containers:
         - image: k8s.gcr.io/kube-keepalived-vip:0.11
           name: kube-keepalived-vip


### PR DESCRIPTION
When running `keepalived-vip:0.11` on a CentOS 7 the Pod keeps crashing with the following error:

```
F1115 10:26:38.489907       1 main.go:108] unexpected error: exit status 1
goroutine 1 [running]:
k8s.io/contrib/keepalived-vip/vendor/github.com/golang/glog.stacks(0xc4201fdf00, 0xc420091130, 0x4b, 0xa1)
        /usr/local/google/home/mikedanese/go/src/k8s.io/contrib/keepalived-vip/vendor/github.com/golang/glog/glog.go:766 +0xa7
k8s.io/contrib/keepalived-vip/vendor/github.com/golang/glog.(*loggingT).output(0x1e2a9c0, 0xc400000003, 0xc420090fd0, 0x1d9086d, 0x7, 0x6c, 0x0)
        /usr/local/google/home/mikedanese/go/src/k8s.io/contrib/keepalived-vip/vendor/github.com/golang/glog/glog.go:717 +0x348
k8s.io/contrib/keepalived-vip/vendor/github.com/golang/glog.(*loggingT).printf(0x1e2a9c0, 0xc400000003, 0x157a081, 0x14, 0xc42057dee8, 0x1, 0x1)
        /usr/local/google/home/mikedanese/go/src/k8s.io/contrib/keepalived-vip/vendor/github.com/golang/glog/glog.go:655 +0x14f
k8s.io/contrib/keepalived-vip/vendor/github.com/golang/glog.Fatalf(0x157a081, 0x14, 0xc42057dee8, 0x1, 0x1)
        /usr/local/google/home/mikedanese/go/src/k8s.io/contrib/keepalived-vip/vendor/github.com/golang/glog/glog.go:1145 +0x67
main.main()
        /usr/local/google/home/mikedanese/go/src/k8s.io/contrib/keepalived-vip/main.go:108 +0x32e
```

Diving in deeper the issue seems to be related to the `modprobe ip_vs` from https://github.com/kubernetes/contrib/blob/8be3a141fd0d753ddcd8cbc23b74cbdd430394ba/keepalived-vip/utils.go#L232

When running this manually inside the container this returns the following error:
```
root@172:/# modprobe ip_vs; echo $?
modprobe: ERROR: could not insert 'ip_vs': Exec format error
1
```
I don't know what exactly causes this error, but it seems to be an incompatibility between the 'container' modprobe and the 'host' modprobe:

```
# container
root@172:/# uname -a
Linux 172.28.128.30 3.10.0-693.5.2.el7.x86_64 #1 SMP Fri Oct 20 20:32:50 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
root@172:/# modprobe --version
kmod version 22
-XZ -ZLIB -EXPERIMENTAL 
```

```
# host
[root@172 ~]# modprobe --version
kmod version 20
```

So I've tried this workaround using an `initContainer`, which actually works as expected.