### PR TITLE
Fix rescheduler docker tag push target

### DIFF
--- a/rescheduler/Makefile
+++ b/rescheduler/Makefile
@@ -54,10 +54,10 @@ container: .container-$(ARCH)
 	cd $(TEMP_DIR) && sed -i 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	docker build --pull -t ${MULTI_ARCH_IMG}:$(TAG) $(TEMP_DIR)
 
-push: .psuh-$(ARCH)
+push: .push-$(ARCH)
 .push-$(ARCH): .container-$(ARCH)
 	gcloud docker -- push $(MULTI_ARCH_IMG):$(TAG)
-ifeq ($(ARCH), amd64)
+ifeq ($(ARCH),amd64)
 	gcloud docker -- push $(IMAGE):$(TAG)
 endif
 


### PR DESCRIPTION
Fix typo in makefile, so that the default `gcr.io/google-containers/rescheduler:v0.3.2` image is available, not just `gcr.io/google-containers/rescheduler-amd64:v0.3.2`.
