### PR TITLE
Tolerance data populating error

### DIFF
--- a/node-perf-dash/parser.go
+++ b/node-perf-dash/parser.go
@@ -68,7 +68,7 @@ func Parse(allTestData map[string]TestToBuildData, testInfo *TestInfo, job strin
 	for buildNumber := lastBuildNumber; buildNumber >= startBuildNumber; buildNumber-- {
 		fmt.Printf("Fetching build %v... (Job: %s)\n", buildNumber, job)
 		if err := populateDataForOneBuild(allTestData[job], testInfo, job, buildNumber, source); err != nil {
-			return err
+			fmt.Printf("%+v\n", err)
 		}
 	}
 


### PR DESCRIPTION
If there is error during data populating, we need to skip the wrong build and continue on the next.