### PR TITLE
scratch-debugger: Fix stderr redirection syntax

### DIFF
--- a/scratch-debugger/debug.sh
+++ b/scratch-debugger/debug.sh
@@ -179,7 +179,7 @@ while [[ ! ${PHASE} =~ (Succeeded|Failed) ]]; do
   PHASE=$(${KUBECTL} get pod -a ${DEBUGGER_NAME} -o jsonpath='{.status.phase}')
 done
 if [[ ${PHASE} == "Failed" ]]; then
-  echo 2> "Pod failed:"
+  echo >&2 "Pod failed:"
   ${KUBECTL} logs ${DEBUGGER_NAME}
   exit 1
 fi


### PR DESCRIPTION
This was causing a file named 'Pod failed:' to be created when debug.sh failed

  