### PR TITLE
scratch-debugger: fix mounted path for socket

### DIFF
--- a/scratch-debugger/debug.sh
+++ b/scratch-debugger/debug.sh
@@ -113,7 +113,7 @@ case ${ARCH} in
     exit 1
 esac
 
-DOCKERCMD="/mnt/rootfs/usr/bin/docker -H unix:///run/docker.sock"
+DOCKERCMD="/mnt/rootfs/usr/bin/docker -H unix:///mnt/rootfs/run/docker.sock"
 
 # Command for installing busybox image from the debugger container into the target container.
 INSTALLCMD="set -x;" # Print commands, for debugging.


### PR DESCRIPTION
The manifest file for the debug container makes the host's docker socket
available on /mnt/rootfs/var/run/docker.sock, but the script still tries to
use non-existing /run/docker.sock on the container's fs.

/cc @tallclair