### PR TITLE
scratch-container: allow customizing docker path

### DIFF
--- a/scratch-debugger/README.md
+++ b/scratch-debugger/README.md
@@ -22,6 +22,7 @@ Additionally, the following environment variables can be set:
 - `KUBECONTEXT` - The kubectl context to use (defaults to current context).
 - `DEBUGGER_NAME` - The name to use for the debug pod (defaults to `debugger`).
 - `ARCH` - The architecture Kubernetes is running on (defaults to `amd64`).
+- `HOST_DOCKERPATH` - Path to the `docker` CLI binary on the host (defaults to `/usr/bin/docker`).
 
 ## Example
 

--- a/scratch-debugger/debug.sh
+++ b/scratch-debugger/debug.sh
@@ -22,6 +22,7 @@ set -o pipefail
 TMP_SUBDIR="${TMP_SUBDIR:-debug-tools}"
 CONTEXT="${KUBECONTEXT:-}"
 ARCH="${ARCH:-amd64}"
+HOST_DOCKERPATH="${HOST_DOCKERPATH:-/usr/bin/docker}"
 
 # Parse arguments & flags
 while [[ $# -gt 0 ]]; do
@@ -113,7 +114,7 @@ case ${ARCH} in
     exit 1
 esac
 
-DOCKERCMD="/mnt/rootfs/usr/bin/docker -H unix:///run/docker.sock"
+DOCKERCMD="/mnt/rootfs/${HOST_DOCKERPATH#/} -H unix:///run/docker.sock"
 
 # Command for installing busybox image from the debugger container into the target container.
 INSTALLCMD="set -x;" # Print commands, for debugging.


### PR DESCRIPTION
scratch-container/debug.sh assumes the docker CLI on the guest OS will always
be at /usr/bin/docker. This is not the case in many distributions like Minikube
or Kubernetes on Docker (Linuxkit).

Making it customizable through HOST_DOCKERPATH variable.

This will conflict with PR #2821 as it makes edits to the same line. But I'll resolve them depending on which one gets merged first.

/cc @tallclair 