### PR TITLE
staging-container: stop relying on host docker CLI

### DIFF
--- a/scratch-debugger/README.md
+++ b/scratch-debugger/README.md
@@ -22,6 +22,8 @@ Additionally, the following environment variables can be set:
 - `KUBECONTEXT` - The kubectl context to use (defaults to current context).
 - `DEBUGGER_NAME` - The name to use for the debug pod (defaults to `debugger`).
 - `ARCH` - The architecture Kubernetes is running on (defaults to `amd64`).
+- `DOCKER_DOWNLOAD_URL` - URL for downloading the docker release `.tgz` file
+  (see `debug.sh` for the default value).
 
 ## Example
 

--- a/scratch-debugger/debug.sh
+++ b/scratch-debugger/debug.sh
@@ -22,6 +22,7 @@ set -o pipefail
 TMP_SUBDIR="${TMP_SUBDIR:-debug-tools}"
 CONTEXT="${KUBECONTEXT:-}"
 ARCH="${ARCH:-amd64}"
+DOCKER_DOWNLOAD_URL="${DOCKER_DOWNLOAD_URL-https://download.docker.com/linux/static/stable/x86_64/docker-17.12.0-ce.tgz}"
 
 # Parse arguments & flags
 while [[ $# -gt 0 ]]; do
@@ -113,12 +114,16 @@ case ${ARCH} in
     exit 1
 esac
 
-DOCKERCMD="/mnt/rootfs/usr/bin/docker -H unix:///run/docker.sock"
+DOCKERCMD="/tmp/docker/docker -H unix:///mnt/docker.sock"
 
 # Command for installing busybox image from the debugger container into the target container.
 INSTALLCMD="set -x;" # Print commands, for debugging.
+# Download docker client
+INSTALLCMD="${INSTALLCMD} wget -qO/tmp/docker.tgz ${DOCKER_DOWNLOAD_URL}"
+# Extract docker client
+INSTALLCMD="${INSTALLCMD} && tar zxvf /tmp/docker.tgz -C /tmp"
 # Create the directory structure for the install.
-INSTALLCMD="${INSTALLCMD} mkdir -p ${INSTALL_DIR}"
+INSTALLCMD="${INSTALLCMD} && mkdir -p ${INSTALL_DIR}"
 # Copy the directory structure into the target container.
 INSTALLCMD="${INSTALLCMD} && ${DOCKERCMD} cp /tmp ${CONTAINER_ID}:/"
 # Copy the busybox binary into the install location.
@@ -146,19 +151,13 @@ spec:
         - "${INSTALLCMD}"
       # Mount the node FS for direct access to docker.
       volumeMounts:
-        - name: rootfs
-          mountPath: /mnt/rootfs
-          readOnly: true
-        - name: rootfs-run
-          mountPath: /mnt/rootfs/var/run
+        - name: docker-sock
+          mountPath: /mnt/docker.sock
           readOnly: true
   volumes:
-    - name: rootfs
+    - name: docker-sock
       hostPath:
-        path: /
-    - name: rootfs-run
-      hostPath:
-        path: /var/run
+        path: /var/run/docker.sock
 EOF
              )
 DEBUGGER_NAME=${DEBUGGER_NAME#pod/} # Remove pod/ prefix from name

--- a/scratch-debugger/debug.sh
+++ b/scratch-debugger/debug.sh
@@ -22,7 +22,7 @@ set -o pipefail
 TMP_SUBDIR="${TMP_SUBDIR:-debug-tools}"
 CONTEXT="${KUBECONTEXT:-}"
 ARCH="${ARCH:-amd64}"
-DOCKER_DOWNLOAD_URL="${DOCKER_DOWNLOAD_URL-https://download.docker.com/linux/static/stable/x86_64/docker-17.12.0-ce.tgz}"
+DOCKER_DOWNLOAD_URL="${DOCKER_DOWNLOAD_URL:-https://download.docker.com/linux/static/stable/x86_64/docker-17.12.0-ce.tgz}"
 
 # Parse arguments & flags
 while [[ $# -gt 0 ]]; do
@@ -114,14 +114,14 @@ case ${ARCH} in
     exit 1
 esac
 
-DOCKERCMD="/tmp/docker/docker -H unix:///mnt/docker.sock"
+DOCKERCMD="/docker-cli/docker/docker -H unix:///mnt/docker.sock"
 
 # Command for installing busybox image from the debugger container into the target container.
 INSTALLCMD="set -x;" # Print commands, for debugging.
 # Download docker client
-INSTALLCMD="${INSTALLCMD} wget -qO/tmp/docker.tgz ${DOCKER_DOWNLOAD_URL}"
+INSTALLCMD="${INSTALLCMD} wget -qO/docker-cli/docker.tgz ${DOCKER_DOWNLOAD_URL}"
 # Extract docker client
-INSTALLCMD="${INSTALLCMD} && tar zxvf /tmp/docker.tgz -C /tmp"
+INSTALLCMD="${INSTALLCMD} && tar zxvf /docker-cli/docker.tgz -C /docker-cli"
 # Create the directory structure for the install.
 INSTALLCMD="${INSTALLCMD} && mkdir -p ${INSTALL_DIR}"
 # Copy the directory structure into the target container.


### PR DESCRIPTION
This change supersedes #2320, #2321 and #2322:

- Stop relying on host docker: (1) it might be dynamically compiled and
  therefore might not work on busybox (2) it might not be at /usr/bin/docker.
- Removed mounting of entire host root filesystem to /mnt/rootfs as it's not
  needed anymore. Mounting only the /var/run/docker.sock now.
- Fixed a stderr redirection bug that caused log line to be saved as a file.

/assign @tallclair