### PR TITLE
Modify the sample error description

### DIFF
--- a/keepalived-vip/README.md
+++ b/keepalived-vip/README.md
@@ -246,7 +246,7 @@ vrrp_instance vips {
 
 
   virtual_ipaddress {
-    172.17.4.90
+    10.4.0.50
   }
 }
 
@@ -340,7 +340,7 @@ vrrp_instance vips {
 
 
   virtual_ipaddress {
-    172.17.4.90
+    10.4.0.50
   }
 }
 


### PR DESCRIPTION
virtual_ipaddress  should same as virtual_server  in /etc/keepalived/keepalived.conf


Signed-off-by: LinWengang <linwengang@chinacloud.com.cn>