### PR TITLE
Add ci-cri-containerd-node-e2e-benchmark to node-perf-dash.

### DIFF
--- a/node-perf-dash/node-perf-dash-deployment.yaml
+++ b/node-perf-dash/node-perf-dash-deployment.yaml
@@ -22,7 +22,7 @@ spec:
           -   --builds=30
           -   --datasource=google-gcs
           -   --tracing=true
-          -   --jenkins-job=ci-kubernetes-node-kubelet-benchmark,ci-kubernetes-node-docker-benchmark
+          -   --jenkins-job=ci-kubernetes-node-kubelet-benchmark,ci-kubernetes-node-docker-benchmark,ci-cri-containerd-node-e2e-benchmark
         imagePullPolicy: Always
         name: node-perf-dash
         ports:


### PR DESCRIPTION
Add ci-cri-containerd-node-e2e-benchmark to node performance dashboard.