### PR TITLE
isLeader endpoint for leader election

### DIFF
--- a/election/example/main.go
+++ b/election/example/main.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	kubectl_util "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	kubectlUtil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 var (
@@ -56,7 +56,7 @@ func makeClient() (*client.Client, error) {
 			return nil, err
 		}
 	} else {
-		clientConfig := kubectl_util.DefaultClientConfig(flags)
+		clientConfig := kubectlUtil.DefaultClientConfig(flags)
 		if cfg, err = clientConfig.ClientConfig(); err != nil {
 			return nil, err
 		}
@@ -69,7 +69,7 @@ type LeaderData struct {
 	Name string `json:"name"`
 }
 
-func webHandler(res http.ResponseWriter, req *http.Request) {
+func webHandler(res http.ResponseWriter, _ *http.Request) {
 	data, err := json.Marshal(leader)
 	if err != nil {
 		res.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
We are using the leader election containers in my project, but we want to make it as easy as possible for our developers to find out if a pod is the leader. Hence the `/isLeader` endpoint.

This is also based on problems where we have had a new leader for a set of pods, but the other (non-leader) pods reported that the deleted leader was still the leader, and not the newly created pod.

Flow:
- starting 3 pods (A, B, C)
- B is leader
- deleting B
- starting D
- D is selected as new leader
- A and C both report B to be the leader via `localhost:4040` endpoint, but logs (`kubectl logs`)
 the correct leader (D)
- D reports itself to be the leader, both via endpoint and logs

Deleting one or both A and C, creating a new E and/or F, make them report the correct leader from the endpoint.