### PR TITLE
[keepalived-vip] typo in IP address and virtual_ipaddress should same as virtual_server

### DIFF
--- a/keepalived-vip/README.md
+++ b/keepalived-vip/README.md
@@ -52,14 +52,14 @@ _keepalived_ should be considered a complement to, and not a replacement for HAP
                                         |      ___________________
                                         |     |                   |
                                         |     | VIP: Unassigned   |
-Public ----(example.com = 10.4.0.50)----|-----| Host IP: 10.4.0.3 |
+Public ----(example.com = 10.4.0.50)----|-----| Host IP: 10.4.0.4 |
                                         |     | Role: Slave       |
                                         |     |___________________|
                                         |
                                         |      ___________________
                                         |     |                   |
                                         |     | VIP: Unassigned   |
-                                        |-----| Host IP: 10.4.0.3 |
+                                        |-----| Host IP: 10.4.0.5 |
                                               | Role: Slave       |
                                               |___________________|
 ```
@@ -246,7 +246,7 @@ vrrp_instance vips {
 
 
   virtual_ipaddress {
-    172.17.4.90
+    10.4.0.50
   }
 }
 
@@ -340,7 +340,7 @@ vrrp_instance vips {
 
 
   virtual_ipaddress {
-    172.17.4.90
+     10.4.0.50
   }
 }
 


### PR DESCRIPTION
virtual_ipaddress should same as virtual_server in /etc/keepalived/keepalived.conf  and  typo in IP address

Signed-off-by: LinWengang <linwengang@chinacloud.com.cn>