### PR TITLE
Remove nginx-slim image path

### DIFF
--- a/images/nginx-slim/README.md
+++ b/images/nginx-slim/README.md
@@ -1,3 +1,0 @@
-The `nginx-slim` image has moved to the
-[kubernetes/ingress](https://github.com/kubernetes/ingress/tree/master/images/nginx-slim)
-repository.


### PR DESCRIPTION
Since the commit of kubernetes/ingress-nginx[1], the path has been
changed from images/nginx-slim to images/nginx. This commit updates
the path.

[1]: https://github.com/kubernetes/ingress-nginx/commit/811829de60f8e0c2c69e67a0e6044eab4a5b1627

fixes #2852 