### PR TITLE
Update links

### DIFF
--- a/ingress/controllers/gce/examples/health_checks/README.md
+++ b/ingress/controllers/gce/examples/health_checks/README.md
@@ -1,5 +1,5 @@
 **The Ingress controller examples have moved to the
-[kubernetes/ingress](https://github.com/kubernetes/ingress) repository.**
+[kubernetes/ingress-gce](https://github.com/kubernetes/ingress-gce) repository.**
 
 # Simple HTTP health check example
 

--- a/ingress/controllers/gce/examples/https/README.md
+++ b/ingress/controllers/gce/examples/https/README.md
@@ -1,5 +1,5 @@
 **The Ingress controller examples have moved to the
-[kubernetes/ingress](https://github.com/kubernetes/ingress) repository.**
+[kubernetes/ingress-gce](https://github.com/kubernetes/ingress-gce) repository.**
 
 # Simple TLS example
 


### PR DESCRIPTION
Link gce examples to the gce ingress repo.

What are people's thoughts about removing the examples here and only keep the link?
I am not a fan of having duplicate docs floating around.