### PR TITLE
The github.com/GoogleCloudPlatform/kubernetes is no more.

### DIFF
--- a/init/systemd/kube-apiserver.service
+++ b/init/systemd/kube-apiserver.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Kubernetes API Server
-Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Documentation=https://kubernetes.io/docs/concepts/overview/components/#kube-apiserver https://kubernetes.io/docs/reference/generated/kube-apiserver/
 After=network.target
 After=etcd.service
 

--- a/init/systemd/kube-controller-manager.service
+++ b/init/systemd/kube-controller-manager.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Kubernetes Controller Manager
-Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Documentation=https://kubernetes.io/docs/concepts/overview/components/#kube-controller-manager https://kubernetes.io/docs/reference/generated/kube-controller-manager/
 
 [Service]
 EnvironmentFile=-/etc/kubernetes/config

--- a/init/systemd/kube-proxy.service
+++ b/init/systemd/kube-proxy.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Kubernetes Kube-Proxy Server
-Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Documentation=https://kubernetes.io/docs/concepts/overview/components/#kube-proxy https://kubernetes.io/docs/reference/generated/kube-proxy/
 After=network.target
 
 [Service]

--- a/init/systemd/kube-scheduler.service
+++ b/init/systemd/kube-scheduler.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Kubernetes Scheduler Plugin
-Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Documentation=https://kubernetes.io/docs/concepts/overview/components/#kube-scheduler https://kubernetes.io/docs/reference/generated/kube-scheduler/
 
 [Service]
 EnvironmentFile=-/etc/kubernetes/config

--- a/init/systemd/kubelet.service
+++ b/init/systemd/kubelet.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Kubernetes Kubelet Server
-Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Documentation=https://kubernetes.io/docs/concepts/overview/components/#kubelet https://kubernetes.io/docs/reference/generated/kubelet/
 After=docker.service
 Requires=docker.service
 


### PR DESCRIPTION
It was renamed to https://github.com/kubernetes/kubernetes but the Kubernetes documentation seems to live at https://kubernetes.io.