### PR TITLE
The `--api-servers` is no longer supported by Kubelet 1.9, use the `kubelet.kubeconfig` approach.

### DIFF
--- a/init/systemd/environ/kubelet
+++ b/init/systemd/environ/kubelet
@@ -10,5 +10,8 @@ KUBELET_ADDRESS="--address=127.0.0.1"
 # You may leave this blank to use the actual hostname
 KUBELET_HOSTNAME="--hostname-override=127.0.0.1"
 
+# Edit the kubelet.kubeconfig to have correct cluster server address
+KUBELET_KUBECONFIG=/etc/kubernetes/kubelet.kubeconfig
+
 # Add your own!
 KUBELET_ARGS="--cgroup-driver=systemd --fail-swap-on=false"

--- a/init/systemd/environ/kubelet.kubeconfig
+++ b/init/systemd/environ/kubelet.kubeconfig
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      server: http://127.0.0.1:8080/
+    name: local
+contexts:
+  - context:
+      cluster: local
+    name: local
+current-context: local
+

--- a/init/systemd/kubelet.service
+++ b/init/systemd/kubelet.service
@@ -11,7 +11,7 @@ EnvironmentFile=-/etc/kubernetes/kubelet
 ExecStart=/usr/bin/kubelet \
 	    $KUBE_LOGTOSTDERR \
 	    $KUBE_LOG_LEVEL \
-	    $KUBELET_API_SERVER \
+	    $KUBELET_KUBECONFIG \
 	    $KUBELET_ADDRESS \
 	    $KUBELET_PORT \
 	    $KUBELET_HOSTNAME \


### PR DESCRIPTION
Addressing (partially) https://github.com/kubernetes/website/issues/7521 and https://bugzilla.redhat.com/show_bug.cgi?id=1549151.