### PR TITLE
Directly write on-start and on-change script output to stdout

### DIFF
--- a/peer-finder/Makefile
+++ b/peer-finder/Makefile
@@ -17,13 +17,13 @@ all: push
 TAG = 0.1
 PREFIX = staging-k8s.gcr.io/peer-finder
 
-server: peer-finder.go
+peer-finder: peer-finder.go
 	CGO_ENABLED=0 go build -a -installsuffix cgo --ldflags '-w' ./peer-finder.go
 
-release: server
+release: peer-finder
 	gsutil cp peer-finder gs://kubernetes-release/pets/peer-finder
 
-container: server
+container: peer-finder
 	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container

--- a/peer-finder/peer-finder.go
+++ b/peer-finder/peer-finder.go
@@ -18,6 +18,7 @@ limitations under the License.
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -29,7 +30,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"bufio"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )


### PR DESCRIPTION
We had a problem with a hanging on-start script, and peer-finder waited for the script to terminate before writing it's output to stdout. This change directly writes the output to stdout as it happens, making it way easier to debug hanging startup scripts.