### PR TITLE
Remove docker benchmark from node-perf-dash.

### DIFF
--- a/node-perf-dash/README.md
+++ b/node-perf-dash/README.md
@@ -50,7 +50,7 @@ $MY_TEST_RESULT_PATH/
 
 You display the desired data by selecting
 
-* **Job**: select the test project (e.g. _kubelet-benchmark-gce-e2e-ci_, _continuous-node-e2e-docker-benchmark_)
+* **Job**: select the test project (e.g. _ci-kubernetes-node-kubelet-benchmark_)
 * **test**: display data for a test by selecting the short test name, or selecting test options one by one
 * **image/machine**: select from the available images and machine type (capacity in format _cpu:1core,memory:3.5G_)
 * **build**: periodic benchmark tests are running with incremental build number, node-perf-dash collects latest test data using total build count specified by _--builds_, you can change the range of builds in dashboar (see https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/benchmark/benchmark-config.yam)

--- a/node-perf-dash/node-perf-dash-deployment.yaml
+++ b/node-perf-dash/node-perf-dash-deployment.yaml
@@ -22,7 +22,7 @@ spec:
           -   --builds=30
           -   --datasource=google-gcs
           -   --tracing=true
-          -   --jenkins-job=ci-kubernetes-node-kubelet-benchmark,ci-kubernetes-node-docker-benchmark,ci-cri-containerd-node-e2e-benchmark
+          -   --jenkins-job=ci-kubernetes-node-kubelet-benchmark,ci-cri-containerd-node-e2e-benchmark
         imagePullPolicy: Always
         name: node-perf-dash
         ports:

--- a/node-perf-dash/parser.go
+++ b/node-perf-dash/parser.go
@@ -330,13 +330,6 @@ func formatNodeName(labels map[string]string, job string) string {
 
 	machine = parts[0] + "-" + parts[1] + "-" + parts[2]
 
-	// GCI image name (gci-test-00-0000-0-0) is changed across build, drop the
-	// suffix for daily build (000-0-0) and keep milestone (test-gci-00)
-	// TODO(coufon): we should change test framework to use a consistent name.
-	if job == "continuous-node-e2e-docker-benchmark" && parts[3] == "gci" {
-		lastPart -= 3
-	}
-
 	result := ""
 	for _, part := range parts[3:lastPart] {
 		result += part + "-"


### PR DESCRIPTION
`ci-kubernetes-node-docker-benchmark` does not exist anymore.

Signed-off-by: Lantao Liu <lantaol@google.com>