### PR TITLE
Fix for ingress-nginx auth example

### DIFF
--- a/ingress/controllers/nginx/OWNERS
+++ b/ingress/controllers/nginx/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- venezia
+reviewers:
+- venezia

--- a/ingress/controllers/nginx/examples/auth/README.md
+++ b/ingress/controllers/nginx/examples/auth/README.md
@@ -37,11 +37,11 @@ metadata:
   name: ingress-with-auth
   annotations:
     # type of authentication
-    ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-type: basic
     # name of the secret that contains the user/password definitions
-    ingress.kubernetes.io/auth-secret: basic-auth
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth
     # message to display with an appropiate context why the authentication is required
-    ingress.kubernetes.io/auth-realm: "Authentication Required - foo"
+    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - foo"
 spec:
   rules:
   - host: foo.bar.com


### PR DESCRIPTION
[ingress-nginx v0.9.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.9.0) changed default annotation prefixes.  This PR updates the documentation so it is correct for default installations of ingress-nginx versions release after 12/4/2017