### PR TITLE
scratch-debugger: Ensure /docker-cli directory exists

### DIFF
--- a/scratch-debugger/debug.sh
+++ b/scratch-debugger/debug.sh
@@ -118,8 +118,10 @@ DOCKERCMD="/docker-cli/docker/docker -H unix:///mnt/docker.sock"
 
 # Command for installing busybox image from the debugger container into the target container.
 INSTALLCMD="set -x;" # Print commands, for debugging.
+# Create directory for docker
+INSTALLCMD="${INSTALLCMD} mkdir -p /docker-cli"
 # Download docker client
-INSTALLCMD="${INSTALLCMD} wget -qO/docker-cli/docker.tgz ${DOCKER_DOWNLOAD_URL}"
+INSTALLCMD="${INSTALLCMD} && wget -qO/docker-cli/docker.tgz ${DOCKER_DOWNLOAD_URL}"
 # Extract docker client
 INSTALLCMD="${INSTALLCMD} && tar zxvf /docker-cli/docker.tgz -C /docker-cli"
 # Create the directory structure for the install.


### PR DESCRIPTION
This diff addresses #2903 by ensuring that the `/docker-cli` exists. Presently, if the directory doesn't exists, the `wget` command will fail because it can't download docker into the directory.