### PR TITLE
add option to use notfy scripts for keepalived

### DIFF
--- a/keepalived-vip/Dockerfile
+++ b/keepalived-vip/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
   iproute2 \
   ipvsadm \
-  bash && \
+  bash \
+  curl && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/keepalived-vip/Dockerfile
+++ b/keepalived-vip/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   iproute2 \
   ipvsadm \
   bash \
+  jq \
   curl && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*

--- a/keepalived-vip/controller.go
+++ b/keepalived-vip/controller.go
@@ -337,6 +337,8 @@ func newIPVSController(kubeClient *unversioned.Client, namespace string, useUnic
 
 	neighbors := getNodeNeighbors(nodeInfo, clusterNodes)
 
+	notify := os.Getenv("KEEPALIVED_NOTIFY")
+
 	execer := exec.New()
 	dbus := utildbus.New()
 	iptInterface := utiliptables.New(execer, dbus, utiliptables.ProtocolIpv4)
@@ -352,6 +354,7 @@ func newIPVSController(kubeClient *unversioned.Client, namespace string, useUnic
 		ipt:         iptInterface,
 		vrid:        vrid,
 		vrrpVersion: vrrpVersion,
+		notify: notify,
 	}
 
 	ipvsc.syncQueue = NewTaskQueue(ipvsc.sync)

--- a/keepalived-vip/controller.go
+++ b/keepalived-vip/controller.go
@@ -354,7 +354,7 @@ func newIPVSController(kubeClient *unversioned.Client, namespace string, useUnic
 		ipt:         iptInterface,
 		vrid:        vrid,
 		vrrpVersion: vrrpVersion,
-		notify: notify,
+		notify:      notify,
 	}
 
 	ipvsc.syncQueue = NewTaskQueue(ipvsc.sync)

--- a/keepalived-vip/keepalived.go
+++ b/keepalived-vip/keepalived.go
@@ -51,6 +51,7 @@ type keepalived struct {
 	ipt         iptables.Interface
 	vrid        int
 	vrrpVersion int
+	notify      string
 }
 
 // WriteCfg creates a new keepalived configuration file.
@@ -76,6 +77,7 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	conf["useUnicast"] = k.useUnicast
 	conf["vrid"] = k.vrid
 	conf["vrrpVersion"] = k.vrrpVersion
+	conf["notify"] = k.notify
 
 	if glog.V(2) {
 		b, _ := json.Marshal(conf)

--- a/keepalived-vip/keepalived.tmpl
+++ b/keepalived-vip/keepalived.tmpl
@@ -16,6 +16,7 @@ vrrp_instance vips {
   track_interface {
     {{ $iface }}
   }
+  {{ if .notify }} notify {{ .notify }} {{ end }}
 
   {{ if .useUnicast }}
   unicast_src_ip {{ .myIP }}


### PR DESCRIPTION
Hi,
i modified keepalived-vip to add an option to use notify scripts. 
My change should be 100% backwards compatible to the previous behavior. 
It is enabled by mounting your notification script to the pod via a configmap, and then setting the env var `KEEPALIVED_NOTIFY` to the location where it is mounted. This will include  a line like:
`notify /opt/your-notify-script.sh` to the keepalived config.

I use this feature on cloud providers were you need a special api call to get an failover / floating IP routed to your machine.

I would like to have this merged so that I don't have to maintain a fork of keepalived-vip. 