### PR TITLE
Rescheduler considers pods critical only when they are in kube-system namespace

### DIFF
--- a/rescheduler/rescheduler.go
+++ b/rescheduler/rescheduler.go
@@ -459,15 +459,12 @@ func filterCriticalDaemonSetPods(allPods []*v1.Pod, podsBeingProcessed *podSet) 
 }
 
 func isCriticalPod(pod *v1.Pod) bool {
-	return isCritical(pod.Namespace, pod.Annotations) || (pod.Spec.Priority != nil && isCriticalPodBasedOnPriority(*pod.Spec.Priority))
+	return pod.Namespace == kubeapi.NamespaceSystem &&
+		(isCritical(pod.Annotations) || (pod.Spec.Priority != nil && isCriticalPodBasedOnPriority(*pod.Spec.Priority)))
 }
 
 // isCritical returns true if parameters bear the critical pod annotation
-func isCritical(ns string, annotations map[string]string) bool {
-	// Critical pods are restricted to "kube-system" namespace as of now.
-	if ns != kubeapi.NamespaceSystem {
-		return false
-	}
+func isCritical(annotations map[string]string) bool {
 	val, ok := annotations[criticalPodAnnotation]
 	if ok && val == "" {
 		return true


### PR DESCRIPTION
Rescheduler has always considered pods only in kube-system namespace as critical pods. Recently, we made a change to consider pods with highest priority levels as critical as well. This PR ensures that such pods are considered as critical when they have such high priorities AND they are in kube-system namespace. This could help reduce possibility of malfunction in clusters under resource pressure where regular users have created pods with critical priorities in non-system namespaces.