### PR TITLE
[keepalived-vip] add keepalived-cloud-provider as related project

### DIFF
--- a/keepalived-vip/README.md
+++ b/keepalived-vip/README.md
@@ -402,3 +402,5 @@ virtual_server 10.4.0.50 80 {
 - https://github.com/kobolog/gorb
 - https://github.com/qmsk/clusterf
 - https://github.com/osrg/gobgp
+- https://github.com/munnerz/keepalived-cloud-provider
+


### PR DESCRIPTION
As the keepalived-cloud-provider is referenced in the [official documentation][1] and it uses the `kube-keepalived-vip`. I would like to add it as a related project.

[1]: https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#examples