### PR TITLE
Zookeeper: Typo fix in purge interval property

### DIFF
--- a/statefulsets/zookeeper/zkGenConfig.sh
+++ b/statefulsets/zookeeper/zkGenConfig.sh
@@ -99,7 +99,7 @@ function create_config() {
     echo "minSessionTimeout=$ZK_MIN_SESSION_TIMEOUT" >> $ZK_CONFIG_FILE
     echo "maxSessionTimeout=$ZK_MAX_SESSION_TIMEOUT" >> $ZK_CONFIG_FILE
     echo "autopurge.snapRetainCount=$ZK_SNAP_RETAIN_COUNT" >> $ZK_CONFIG_FILE
-    echo "autopurge.purgeInteval=$ZK_PURGE_INTERVAL" >> $ZK_CONFIG_FILE
+    echo "autopurge.purgeInterval=$ZK_PURGE_INTERVAL" >> $ZK_CONFIG_FILE
 
     if [ $ZK_REPLICAS -gt 1 ]; then
         print_servers >> $ZK_CONFIG_FILE


### PR DESCRIPTION
Fix typo in the `autopurge.purgeInterval` property

Auto purge task is not getting scheduled because of the typo in this property

fixes #2942