### PR TITLE
add timeout to exec-healthz

### DIFF
--- a/exec-healthz/cmd/exechealthz/exechealthz_test.go
+++ b/exec-healthz/cmd/exechealthz/exechealthz_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/clock"
-	"k8s.io/kubernetes/pkg/util/exec"
-	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/exec"
 )
 
 var (


### PR DESCRIPTION
Hi,

It is a PR to show the idea that it maybe good to introduce `timeout` option.

The command itself sometimes hangs up for some reasons (e.g. network IO) and may run forever. It should be good to implement timeout in commands; however sometimes it is difficult to make changes to commands and cover every cases. Since timeout could be a general case, I would like to see it is implemented in `exec-healthz`.

Note: this is a just workable code sample to show what I want to do. It could break tests, dependency and minimum required version of golang and packages. (Sorry that I am not familiar with policies and rules of this repo and cannot make a perfect PR; also saw this project is moving)