### PR TITLE
Use -domain and -ns flags when performing lookup

### DIFF
--- a/peer-finder/peer-finder.go
+++ b/peer-finder/peer-finder.go
@@ -127,7 +127,7 @@ func main() {
 	}
 
 	myName := strings.Join([]string{hostname, *svc, domainName}, ".")
-	svcFqdn := strings.Join([]string{ *svc, domainName}, ".")
+	svcFqdn := strings.Join([]string{*svc, domainName}, ".")
 	script := *onStart
 	if script == "" {
 		script = *onChange

--- a/peer-finder/peer-finder.go
+++ b/peer-finder/peer-finder.go
@@ -127,13 +127,14 @@ func main() {
 	}
 
 	myName := strings.Join([]string{hostname, *svc, domainName}, ".")
+	svcFqdn := strings.Join([]string{ *svc, domainName}, ".")
 	script := *onStart
 	if script == "" {
 		script = *onChange
 		log.Printf("No on-start supplied, on-change %v will be applied on start.", script)
 	}
 	for newPeers, peers := sets.NewString(), sets.NewString(); script != ""; time.Sleep(pollPeriod) {
-		newPeers, err = lookup(*svc)
+		newPeers, err = lookup(svcFqdn)
 		if err != nil {
 			log.Printf("%v", err)
 			continue


### PR DESCRIPTION
In previous version of peer-finder if you specify -domain or -ns it doesn't actually look in those domains and namespaces. This PR switches the lookup from using just `$svc` to using `$svc.$ns.svc.$domain`. 

Note that due to [go 1.11 not supporting compressed hostnames in SRV records](https://groups.google.com/forum/#!topic/golang-nuts/vAbjprJNPV0) building this on go 1.11 will cause it to no work when using kube-dns.
I have successfully tested it with go 1.10.4 connecting to a kube-dns instance.