### PR TITLE
Fixes kafka stateful set configuration for proper directory entry in …

### DIFF
--- a/statefulsets/kafka/kafka.yaml
+++ b/statefulsets/kafka/kafka.yaml
@@ -74,7 +74,7 @@ spec:
         - "exec kafka-server-start.sh /opt/kafka/config/server.properties --override broker.id=${HOSTNAME##*-} \
           --override listeners=PLAINTEXT://:9093 \
           --override zookeeper.connect=zk-0.zk-svc.default.svc.cluster.local:2181,zk-1.zk-svc.default.svc.cluster.local:2181,zk-2.zk-svc.default.svc.cluster.local:2181 \
-          --override log.dir=/var/lib/kafka \
+          --override log.dirs=/var/lib/kafka \
           --override auto.create.topics.enable=true \
           --override auto.leader.rebalance.enable=true \
           --override background.threads=10 \


### PR DESCRIPTION
…overrides section in run server

Motivation: according to [trunc code](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaConfig.scala#L1117) (which describes in quite a vague fashion in [official documentation](https://kafka.apache.org/documentation/#brokerconfigs)) log.dir section of configuration is used as a topic log directory if and only if log.dirs is not present. However, default /opt/kafka_2.11-0.10.2.0/config/server.properties from current gcr.io/google-samples/k8skafka contains entry of log.dirs=/tmp/kafka-logs, so override does nothing useful and in fact is very misleading, producing probable data loss, when mounting external volume to /var/lib/kafka.