### PR TITLE
Update Zookeeper Docker Container to 3.4.13 and Ubuntu 18.04

### DIFF
--- a/statefulsets/zookeeper/Dockerfile
+++ b/statefulsets/zookeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV ZK_USER=zookeeper \
     ZK_DATA_DIR=/var/lib/zookeeper/data \
@@ -10,14 +10,14 @@ ARG ZK_DIST=zookeeper-3.4.13
 
 RUN set -x \
     && apt-get update \
-    && apt-get install -y openjdk-8-jre-headless wget netcat-openbsd \
+    && apt-get install -y openjdk-8-jre-headless wget gpg netcat-openbsd \
     && wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz" \
     && wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && wget -qO- https://dist.apache.org/repos/dist/release/zookeeper/KEYS | gpg --import - \
     && gpg --batch --verify "$ZK_DIST.tar.gz.asc" "$ZK_DIST.tar.gz" \
     && tar -xzf "$ZK_DIST.tar.gz" -C /opt \
-    && rm -r "$GNUPGHOME" "$ZK_DIST.tar.gz" "$ZK_DIST.tar.gz.asc" \
+    && rm -rf "$GNUPGHOME" "$ZK_DIST.tar.gz" "$ZK_DIST.tar.gz.asc" \
     && ln -s /opt/$ZK_DIST /opt/zookeeper \
     && rm -rf /opt/zookeeper/CHANGES.txt \
     /opt/zookeeper/README.txt \
@@ -36,7 +36,7 @@ RUN set -x \
     /opt/zookeeper/$ZK_DIST.jar.asc \
     /opt/zookeeper/$ZK_DIST.jar.md5 \
     /opt/zookeeper/$ZK_DIST.jar.sha1 \
-    && apt-get autoremove -y wget \
+    && apt-get autoremove -y wget gpg \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy configuration generator script to bin

--- a/statefulsets/zookeeper/Dockerfile
+++ b/statefulsets/zookeeper/Dockerfile
@@ -6,8 +6,7 @@ ENV ZK_USER=zookeeper \
     ZK_LOG_DIR=/var/log/zookeeper \
     JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
-ARG GPG_KEY=C823E3E5B12AF29C67F81976F5CECB3CB5E9BD2D
-ARG ZK_DIST=zookeeper-3.4.10
+ARG ZK_DIST=zookeeper-3.4.13
 
 RUN set -x \
     && apt-get update \
@@ -15,7 +14,7 @@ RUN set -x \
     && wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz" \
     && wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-key "$GPG_KEY" \
+    && wget -qO- https://dist.apache.org/repos/dist/release/zookeeper/KEYS | gpg --import - \
     && gpg --batch --verify "$ZK_DIST.tar.gz.asc" "$ZK_DIST.tar.gz" \
     && tar -xzf "$ZK_DIST.tar.gz" -C /opt \
     && rm -r "$GNUPGHOME" "$ZK_DIST.tar.gz" "$ZK_DIST.tar.gz.asc" \

--- a/statefulsets/zookeeper/Dockerfile
+++ b/statefulsets/zookeeper/Dockerfile
@@ -10,7 +10,7 @@ ARG ZK_DIST=zookeeper-3.4.13
 
 RUN set -x \
     && apt-get update \
-    && apt-get install -y openjdk-8-jre-headless wget gpg netcat-openbsd \
+    && apt-get install -y openjdk-8-jre-headless wget gpg netcat \
     && wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz" \
     && wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz.asc" \
     && export GNUPGHOME="$(mktemp -d)" \

--- a/statefulsets/zookeeper/Makefile
+++ b/statefulsets/zookeeper/Makefile
@@ -1,4 +1,4 @@
-VERSION=v3
+VERSION=v4
 PROJECT_ID=google_samples
 PROJECT=gcr.io/${PROJECT_ID}
 

--- a/statefulsets/zookeeper/README.md
+++ b/statefulsets/zookeeper/README.md
@@ -4,14 +4,14 @@ This project contains a Docker image meant to facilitate the deployment of
 [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/). 
 ## Limitations
 1. Scaling is not currently supported. An ensemble's membership can not be updated in a safe way 
-in ZooKeeper 3.4.10 (The current stable release).
+in ZooKeeper 3.4.13 (The current stable release).
 2. Observers are currently not supported. Contributions are welcome.
 3. Persistent Volumes must be used. emptyDirs will likely result in a loss of data.
 
 ## Docker Image
 The docker image contained in this repository is comprised of a base Ubuntu 16.04 image using the latest
 release of the OpenJDK JRE based on the 1.8 JVM (JDK 8u111) and the latest stable release of 
-ZooKeeper, 3.4.10. Ubuntu is a much larger image than BusyBox or Alpine, but these images contain
+ZooKeeper, 3.4.13. Ubuntu is a much larger image than BusyBox or Alpine, but these images contain
 mucl or ulibc. This requires a custom version of OpenJDK to be built against a libc runtime other 
 than glibc. No vendor of the ZooKeeper software supplies or verifies the software against such a 
 JVM, and, while Alpine or BusyBox would provide smaller images, we have prioritized a well known 
@@ -74,7 +74,7 @@ configuration below.
 containers:
       - name: k8szk
         imagePullPolicy: Always
-        image: gcr.io/google_samples/k8szk:v3
+        image: gcr.io/google_samples/k8szk:v4
         ports:
         - containerPort: 2181
           name: client

--- a/statefulsets/zookeeper/README.md
+++ b/statefulsets/zookeeper/README.md
@@ -9,13 +9,13 @@ in ZooKeeper 3.4.13 (The current stable release).
 3. Persistent Volumes must be used. emptyDirs will likely result in a loss of data.
 
 ## Docker Image
-The docker image contained in this repository is comprised of a base Ubuntu 16.04 image using the latest
-release of the OpenJDK JRE based on the 1.8 JVM (JDK 8u111) and the latest stable release of 
-ZooKeeper, 3.4.13. Ubuntu is a much larger image than BusyBox or Alpine, but these images contain
-mucl or ulibc. This requires a custom version of OpenJDK to be built against a libc runtime other 
-than glibc. No vendor of the ZooKeeper software supplies or verifies the software against such a 
-JVM, and, while Alpine or BusyBox would provide smaller images, we have prioritized a well known 
-environment.
+The docker image contained in this repository is comprised of a base Ubuntu 18.04 image using the 
+release of the OpenJDK JRE based on the 1.8 JVM from the Ubuntu repositories and the latest stable 
+release of ZooKeeper, 3.4.13. Ubuntu is a much larger image than BusyBox or Alpine, but these 
+images contain mucl or ulibc. This requires a custom version of OpenJDK to be built against a libc 
+runtime other than glibc. No vendor of the ZooKeeper software supplies or verifies the software 
+against such a JVM, and, while Alpine or BusyBox would provide smaller images, we have prioritized 
+a well known environment.
 
 The image is built such that the ZooKeeper process is designated to run as a non-root user. By default, 
 this user is zookeeper. The ZooKeeper package is installed into the /opt/zookeeper directory, all 

--- a/statefulsets/zookeeper/zookeeper.yaml
+++ b/statefulsets/zookeeper/zookeeper.yaml
@@ -63,7 +63,7 @@ spec:
       containers:
       - name: k8szk
         imagePullPolicy: Always
-        image: gcr.io/google_samples/k8szk:v3
+        image: gcr.io/google_samples/k8szk:v4
         resources:
           requests:
             memory: "2Gi"


### PR DESCRIPTION
I noticed that the Zookeeper container in this repository was a few versions out of date and while I was there I upgraded it to Ubuntu 18.04 from 16.04. I am running this in my environment and it works properly.

Built image here for convenient testing: https://hub.docker.com/r/cablespaghetti/k8szk