### PR TITLE
Change golint path to fix travis failures

### DIFF
--- a/hack/install-verify-tools.sh
+++ b/hack/install-verify-tools.sh
@@ -23,7 +23,7 @@ GO_VERSION=($(go version))
 
 # golint only works for golang 1.5+
 if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.1|go1.2|go1.3|go1.4') ]]; then
-  go get -u github.com/golang/lint/golint
+  go get -u golang.org/x/lint/golint
 fi
 
 go get -u github.com/tools/godep


### PR DESCRIPTION
I noticed that the builds on my  PR (#2965) were failing for no good reason. This seems to be due to a URL change (see https://github.com/golang/lint/issues/415).