### PR TITLE
Keepalived 2.0.10 + vlan handling mechanism

### DIFF
--- a/keepalived-vip/Changelog
+++ b/keepalived-vip/Changelog
@@ -1,4 +1,9 @@
 
+## 0.12
+- Update keepalived to 2.0.10
+- Custom interface handling 
+- Vlan handling
+
 ## 0.9
 - Update godeps
 - Update keepalived to 1.2.24

--- a/keepalived-vip/Dockerfile
+++ b/keepalived-vip/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
   iproute2 \
   ipvsadm \
+  vlan \
   bash && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
@@ -39,8 +40,10 @@ RUN mkdir -p /etc/keepalived && \
   ln -s /keepalived/sbin/keepalived /usr/sbin && \
   ln -s /keepalived/bin/genhash /usr/sbin
 
-COPY kube-keepalived-vip /
-COPY keepalived.tmpl /
+# Ordered COPY in less likely to change to more likely for better
+# use of caching during build and push
 COPY keepalived.conf /etc/keepalived
+COPY keepalived.tmpl /
+COPY kube-keepalived-vip /
 
 ENTRYPOINT ["/kube-keepalived-vip"]

--- a/keepalived-vip/Makefile
+++ b/keepalived-vip/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any release builds, current "latest" is 0.11
-TAG = 0.11
+TAG = 0.12
 PREFIX = staging-k8s.gcr.io/kube-keepalived-vip
 BUILD_IMAGE = build-keepalived
 TEMP_GOPATH = ${GOPATH}:${GOPATH}/src/k8s.io/kubernetes/staging
@@ -24,6 +24,7 @@ push: container
 
 clean:
 	rm -f kube-keepalived-vip
+	rm -f keepalived.tar.gz
 
 update-godeps:
 	GOPATH=$(TEMP_GOPATH) godep save ./...

--- a/keepalived-vip/build/Dockerfile
+++ b/keepalived-vip/build/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash
 
 COPY build.sh /build.sh
 
-ENV VERSION 1.4.2
-ENV SHA256 84d35d4bbc95bf86c476f892e68bd0b14119e8b66127a985ecda48cb1859ffc6
+ENV VERSION 2.0.10
+ENV SHA256 8cfd31307e69fb6fc3417da4c67de8040b97c3e5fc67ebd7ffbe6c53aef22c8b
 
 RUN /build.sh

--- a/keepalived-vip/keepalived.go
+++ b/keepalived-vip/keepalived.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"syscall"
 	"text/template"
+	"net"
 
 	"github.com/golang/glog"
 	k8sexec "k8s.io/kubernetes/pkg/util/exec"
@@ -36,6 +37,25 @@ const (
 
 var keepalivedTmpl = "keepalived.tmpl"
 
+// Structure for VIP (since we no longer just handle ip addresses)
+type VipInfo struct {
+        IP          string
+        Subnet      int
+        VlanId      int
+	Gateway     string
+	FullSubnet  string
+}
+
+// moved from utils.go to keep next to VipInfo structure
+func appendIfMissing(slice []VipInfo, item VipInfo) []VipInfo {
+        for _, elem := range slice {
+                if elem == item {
+                        return slice
+                }
+        }
+        return append(slice, item)
+}
+
 type keepalived struct {
 	iface       string
 	ip          string
@@ -45,12 +65,15 @@ type keepalived struct {
 	neighbors   []string
 	useUnicast  bool
 	started     bool
-	vips        []string
+	vips        []VipInfo
+	vlans       []int
 	tmpl        *template.Template
 	cmd         *exec.Cmd
 	ipt         iptables.Interface
 	vrid        int
 	vrrpVersion int
+	customIface string
+
 }
 
 // WriteCfg creates a new keepalived configuration file.
@@ -63,6 +86,7 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	defer w.Close()
 
 	k.vips = getVIPs(svcs)
+	k.vlans = ListVlans(svcs)
 
 	conf := make(map[string]interface{})
 	conf["iptablesChain"] = iptablesChain
@@ -70,12 +94,14 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	conf["myIP"] = k.ip
 	conf["netmask"] = k.netmask
 	conf["svcs"] = svcs
-	conf["vips"] = getVIPs(svcs)
+	conf["vips"] = k.vips
+	conf["vlans"] = k.vlans
 	conf["nodes"] = k.neighbors
 	conf["priority"] = k.priority
 	conf["useUnicast"] = k.useUnicast
 	conf["vrid"] = k.vrid
 	conf["vrrpVersion"] = k.vrrpVersion
+	conf["customIface"] = k.customIface
 
 	if glog.V(2) {
 		b, _ := json.Marshal(conf)
@@ -87,10 +113,11 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 
 // getVIPs returns a list of the virtual IP addresses to be used in keepalived
 // without duplicates (a service can use more than one port)
-func getVIPs(svcs []vip) []string {
-	result := []string{}
+func getVIPs(svcs []vip) []VipInfo {
+	result := []VipInfo{}
 	for _, svc := range svcs {
-		result = appendIfMissing(result, svc.IP)
+		_, ipnet, _ := net.ParseCIDR(fmt.Sprintf("%v/%v",svc.IP,svc.Subnet))
+		result = appendIfMissing(result, VipInfo{IP: svc.IP, Subnet: svc.Subnet, VlanId: svc.VlanId, Gateway: svc.Gateway, FullSubnet: fmt.Sprintf("%v",ipnet)})
 	}
 
 	return result
@@ -170,9 +197,13 @@ func resetIPVS() error {
 	return nil
 }
 
-func (k *keepalived) removeVIP(vip string) error {
+func (k *keepalived) removeVIP(vip VipInfo) error {
 	glog.Infof("removing configured VIP %v", vip)
-	out, err := k8sexec.New().Command("ip", "addr", "del", vip+"/32", "dev", k.iface).CombinedOutput()
+	iface := CoalesceString(k.customIface, k.iface)
+	if vip.VlanId != 0 {
+		iface = fmt.Sprintf("%v.%v", iface, vip.VlanId)
+	}
+	out, err := k8sexec.New().Command("ip", "addr", "del", fmt.Sprintf("%v/%v",vip.IP,vip.Subnet), "dev", iface).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error reloading keepalived: %v\n%s", err, out)
 	}
@@ -187,3 +218,4 @@ func (k *keepalived) loadTemplate() error {
 	k.tmpl = tmpl
 	return nil
 }
+

--- a/keepalived-vip/keepalived.tmpl
+++ b/keepalived-vip/keepalived.tmpl
@@ -1,4 +1,4 @@
-{{ $iface := .iface }}{{ $netmask := .netmask }}
+{{ $iface := .iface }}{{ $netmask := .netmask }}{{ $customIface := .customIface }}
 
 global_defs {
   vrrp_version {{ .vrrpVersion }}
@@ -14,7 +14,8 @@ vrrp_instance vips {
   advert_int 1
 
   track_interface {
-    {{ $iface }}
+    {{ if $customIface }}{{ $customIface }}{{ end }}{{ range $v, $vlan := .vlans }}
+    {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}.{{ $vlan }}{{ end }}
   }
 
   {{ if .useUnicast }}
@@ -24,12 +25,17 @@ vrrp_instance vips {
   }
   {{ end }}
 
-  virtual_ipaddress { {{ range .vips }}
-    {{ . }}{{ end }}
+  virtual_ipaddress { {{ range $i, $vip := .vips }}
+    {{ $vip.IP }}/{{ $vip.Subnet }} dev {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}{{ if ne $vip.VlanId 0 }}.{{ $vip.VlanId }}{{ end }}{{ end }}
   }
+
+  virtual_routes { {{ range $i, $vip := .vips }}
+    {{ if $vip.Gateway }}{{ $vip.FullSubnet }} via {{ $vip.Gateway }} dev {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}{{ if ne $vip.VlanId 0 }}.{{ $vip.VlanId }}{{ end }}{{ end }}{{ end }}
+  }
+
 }
 
-{{ range $i, $svc := .svcs }}
+{{ range $j, $svc := .svcs }}
 {{ if eq $svc.LVSMethod "VIP" }}
 # VIP Service with no pods: {{ $svc.IP }}
 {{ else }}
@@ -41,7 +47,7 @@ virtual_server {{ $svc.IP }} {{ $svc.Port }} {
   persistence_timeout 1800
   protocol {{ $svc.Protocol }}
 
-  {{ range $j, $backend := $svc.Backends }}
+  {{ range $k, $backend := $svc.Backends }}
   real_server {{ $backend.IP }} {{ $backend.Port }} {
     weight 1
     TCP_CHECK {

--- a/keepalived-vip/main.go
+++ b/keepalived-vip/main.go
@@ -44,6 +44,7 @@ var (
 		with other keepalived instances`)
 
 	vrrpVersion = flags.Int("vrrp-version", 3, `Which VRRP version to use (2 or 3)`)
+	customIface = flags.String("custom-interface", "", `Optional custom interface to use for VIPs`)
 
 	configMapName = flags.String("services-configmap", "",
 		`Name of the ConfigMap that contains the definition of the services to expose.
@@ -124,7 +125,7 @@ func main() {
 	if *useUnicast {
 		glog.Info("keepalived will use unicast to sync the nodes")
 	}
-	ipvsc := newIPVSController(kubeClient, namespace, *useUnicast, *configMapName, *vrid, *vrrpVersion)
+	ipvsc := newIPVSController(kubeClient, namespace, *useUnicast, *configMapName, *vrid, *vrrpVersion, *customIface)
 	go ipvsc.epController.Run(wait.NeverStop)
 	go ipvsc.svcController.Run(wait.NeverStop)
 

--- a/keepalived-vip/utils_test.go
+++ b/keepalived-vip/utils_test.go
@@ -26,18 +26,25 @@ func TestParseNsSvcLVS(t *testing.T) {
 		Namespace     string
 		Service       string
 		ForwardMethod string
+		Subnet        int
+		Gateway       string
+		VlanId        int
 		ExpectedOk    bool
 	}{
-		"just service name":      {"echoheaders", "", "", "", true},
-		"missing namespace":      {"echoheaders:NAT", "", "", "", true},
-		"default forward method": {"default/echoheaders", "default", "echoheaders", "NAT", false},
-		"with forward method":    {"default/echoheaders:NAT", "default", "echoheaders", "NAT", false},
-		"DR as forward method":   {"default/echoheaders:DR", "default", "echoheaders", "DR", false},
-		"invalid forward method": {"default/echoheaders:AJAX", "", "", "", true},
+		"just service name":            {"echoheaders", "", "", "", 0, "", 0, true},
+		"missing namespace":            {"echoheaders:NAT", "", "", "", 0, "", 0, true},
+		"default forward method":       {"default/echoheaders", "default", "echoheaders", "NAT", 0, "", 0, false},
+		"with forward method":          {"default/echoheaders:NAT", "default", "echoheaders", "NAT", 0, "", 0, false},
+		"DR as forward method":         {"default/echoheaders:DR", "default", "echoheaders", "DR", 0, "", 0, false},
+		"invalid forward method":       {"default/echoheaders:AJAX", "", "", "", 0, "", 0, true},
+		"with subnet and default fw":   {"default/echoheaders::24", "default", "echoheaders", "NAT", 24, "", 0, false},
+		"with subnet and gateway":      {"default/echoheaders:DR:24:10.0.0.1", "default", "echoheaders", "DR", 24, "10.0.0.1", 0, false},
+		"with subnet and vlan only":    {"default/echoheaders::24::10", "default", "echoheaders", "NAT", 24, "", 10, false},
+		"with subnet, gw and vlan":     {"default/echoheaders::24:10.0.0.1:10", "default", "echoheaders", "NAT", 24, "10.0.0.1", 10, false},
 	}
 
 	for k, tc := range testcases {
-		ns, svc, lvs, err := parseNsSvcLVS(tc.Input)
+		ns, svc, lvs, subnet, gateway, vlanId, err := parseNsSvcLbVlan(tc.Input)
 
 		if tc.ExpectedOk && err == nil {
 			t.Errorf("%s: expected an error but valid information returned: %v ", k, tc.Input)
@@ -53,6 +60,18 @@ func TestParseNsSvcLVS(t *testing.T) {
 
 		if tc.ForwardMethod != lvs {
 			t.Errorf("%s: expected %v but returned %v - input %v", k, tc.ForwardMethod, lvs, tc.Input)
+		}
+
+		if tc.Subnet != subnet {
+			t.Errorf("%s: expected %v but returned %v - input %v", k, tc.Subnet, lvs, tc.Input)
+		}
+
+		if tc.Gateway != gateway {
+			t.Errorf("%s: expected %v but returned %v - input %v", k, tc.Gateway, lvs, tc.Input)
+		}
+
+		if tc.VlanId != vlanId {
+			t.Errorf("%s: expected %v but returned %v - input %v", k, tc.VlanId, lvs, tc.Input)
 		}
 	}
 }

--- a/keepalived-vip/vip-daemonset.yaml
+++ b/keepalived-vip/vip-daemonset.yaml
@@ -2,15 +2,30 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-keepalived-vip
+  labels: 
+    k8s-app: kube-keepalived-vip
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-keepalived-vip
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
-        name: kube-keepalived-vip
+        k8s-app: kube-keepalived-vip
     spec:
       hostNetwork: true
+      serviceAccount: kube-keepalived-vip
+      serviceAccountName: kube-keepalived-vip
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+	type: worker
+      tolerations:
+      #- key: node-role.kubernetes.io/master
+      #  effect: NoSchedule
       containers:
-        - image: k8s.gcr.io/kube-keepalived-vip:0.11
+        - image: k8s.gcr.io/kube-keepalived-vip:0.12
           name: kube-keepalived-vip
           imagePullPolicy: Always
           securityContext:
@@ -39,6 +54,8 @@ spec:
           #- --use-unicast=true
           # vrrp version can be set to 2.  Default 3.
           #- --vrrp-version=2
+          # optional custom interface for vip if different from kubernetes interface
+          #- --custom-interface=eth1
       volumes:
         - name: modules
           hostPath:
@@ -46,5 +63,3 @@ spec:
         - name: dev
           hostPath:
             path: /dev
-      nodeSelector:
-        type: worker

--- a/keepalived-vip/vip-rbac.yaml
+++ b/keepalived-vip/vip-rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-keepalived-vip
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-keepalived-vip
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - nodes
+  - endpoints
+  - services
+  - configmaps
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-keepalived-vip
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-keepalived-vip
+subjects:
+- kind: ServiceAccount
+  name: kube-keepalived-vip
+  namespace: default

--- a/keepalived-vip/vip-rc.yaml
+++ b/keepalived-vip/vip-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: k8s.gcr.io/kube-keepalived-vip:0.11
+      - image: k8s.gcr.io/kube-keepalived-vip:0.12
         name: kube-keepalived-vip
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
Following a rework of kube-keepalived-vip for a customer, we are contributing back the modifications.

1) Upgrade to Keepalived 2.0.10 ==> According to keepalived.org, versions 2.x are the go-to versions where bugfixes and improvements happens (no backport).

2) Custom interface handling ==> Ability to use an other interface rather than the internalIP/externalIP interface.

3) Vlan handling. ==> Ability to create vlan tagged interfaces complete with subnet mask and gateway route.

This is my first contribution back to an open-source projet, i hope i wrote here everything needed, in any case, 2 additional sections exist in the README (Custom interface and Advanced configuration) explaining what happens.