### PR TITLE
Keepalived 2.0.10 + vlan handling mechanism

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -20,6 +20,7 @@ config-file-path
 configuration-name
 current-release-pr
 custom-error-service
+custom-interface
 datasource
 default-backend-service
 default-return-code

--- a/keepalived-vip/Changelog
+++ b/keepalived-vip/Changelog
@@ -1,4 +1,9 @@
 
+## 0.12
+- Update keepalived to 2.0.10
+- Custom interface handling 
+- Vlan handling
+
 ## 0.9
 - Update godeps
 - Update keepalived to 1.2.24

--- a/keepalived-vip/Dockerfile
+++ b/keepalived-vip/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
   iproute2 \
   ipvsadm \
+  vlan \
   bash && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
@@ -39,8 +40,10 @@ RUN mkdir -p /etc/keepalived && \
   ln -s /keepalived/sbin/keepalived /usr/sbin && \
   ln -s /keepalived/bin/genhash /usr/sbin
 
-COPY kube-keepalived-vip /
-COPY keepalived.tmpl /
+# Ordered COPY in less likely to change to more likely for better
+# use of caching during build and push
 COPY keepalived.conf /etc/keepalived
+COPY keepalived.tmpl /
+COPY kube-keepalived-vip /
 
 ENTRYPOINT ["/kube-keepalived-vip"]

--- a/keepalived-vip/Makefile
+++ b/keepalived-vip/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any release builds, current "latest" is 0.11
-TAG = 0.11
+TAG = 0.12
 PREFIX = staging-k8s.gcr.io/kube-keepalived-vip
 BUILD_IMAGE = build-keepalived
 TEMP_GOPATH = ${GOPATH}:${GOPATH}/src/k8s.io/kubernetes/staging
@@ -24,6 +24,7 @@ push: container
 
 clean:
 	rm -f kube-keepalived-vip
+	rm -f keepalived.tar.gz
 
 update-godeps:
 	GOPATH=$(TEMP_GOPATH) godep save ./...

--- a/keepalived-vip/build/Dockerfile
+++ b/keepalived-vip/build/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash
 
 COPY build.sh /build.sh
 
-ENV VERSION 1.4.2
-ENV SHA256 84d35d4bbc95bf86c476f892e68bd0b14119e8b66127a985ecda48cb1859ffc6
+ENV VERSION 2.0.10
+ENV SHA256 8cfd31307e69fb6fc3417da4c67de8040b97c3e5fc67ebd7ffbe6c53aef22c8b
 
 RUN /build.sh

--- a/keepalived-vip/controller.go
+++ b/keepalived-vip/controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	utildbus "k8s.io/kubernetes/pkg/util/dbus"
+	k8sexec "k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/util/intstr"
@@ -77,6 +78,9 @@ type vip struct {
 	Protocol  string
 	LVSMethod string
 	Backends  []service
+	VlanId    int
+	Subnet    int
+	Gateway   string
 }
 
 type vipByNameIPPort []vip
@@ -101,6 +105,22 @@ func (c vipByNameIPPort) Less(i, j int) bool {
 	return iPort < jPort
 }
 
+// ListVlans return a list of unique vlan id present in vips
+func ListVlans(vips []vip) ([]int) {
+        vlans := []int{}
+        for _, vip := range vips {
+                present := false
+                for _, vlan := range vlans {
+                        if vlan == vip.VlanId {
+                                present = true
+                                break
+                         }
+                }
+                if !present && vip.VlanId != 0 { vlans = append(vlans,vip.VlanId) }
+        }
+        return vlans
+}
+
 // ipvsControllerController watches the kubernetes api and adds/removes
 // services from LVS throgh ipvsadmin.
 type ipvsControllerController struct {
@@ -114,6 +134,8 @@ type ipvsControllerController struct {
 	configMapName     string
 	ruCfg             []vip
 	ruMD5             string
+	iface             string
+	createdVlan       []string
 
 	// stopLock is used to enforce only a single call to Stop is active.
 	// Needed because we allow stopping through an http endpoint and
@@ -169,9 +191,9 @@ func (ipvsc *ipvsControllerController) getServices(cfgMap *api.ConfigMap) []vip 
 	svcs := []vip{}
 
 	// k -> IP to use
-	// v -> <namespace>/<service name>:<lvs method>
-	for externalIP, nsSvcLvs := range cfgMap.Data {
-		if nsSvcLvs == "" {
+	// v -> <namespace>/<service name>:<lvs method>:<vlan id>/<subnet>
+	for externalIP, nsSvcLvsVlan := range cfgMap.Data {
+		if nsSvcLvsVlan == "" {
 			// if target is empty string we will not forward to any service but
 			// instead just configure the IP on the machine and let it up to
 			// another Pod or daemon to bind to the IP address
@@ -182,18 +204,48 @@ func (ipvsc *ipvsControllerController) getServices(cfgMap *api.ConfigMap) []vip 
 				LVSMethod: "VIP",
 				Backends:  nil,
 				Protocol:  "TCP",
+				VlanId:    0,
+				Subnet:    32,
+				Gateway:   "",
 			})
 			glog.V(2).Infof("Adding VIP only service: %v", externalIP)
 			continue
 		}
 
-		ns, svc, lvsm, err := parseNsSvcLVS(nsSvcLvs)
+		ns, svc, lvsm, subnet, gateway, vlanId, err := parseNsSvcLbVlan(nsSvcLvsVlan)
+
+		// If no subnet is given, use /32
+		if subnet == 0 {
+			subnet = 32
+		 }
+
 		if err != nil {
 			glog.Warningf("%v", err)
 			continue
 		}
 
 		nsSvc := fmt.Sprintf("%v/%v", ns, svc)
+
+                if nsSvc == "/" {
+                        // Target was not empty but service is, so we will not forward
+                        // to any service but instead just configure the IP (with 
+                        // possible vlan and subnet) on the machine and let it up to
+                        // another Pod or daemon to bind to the IP address
+                        svcs = append(svcs, vip{
+                                Name:      "",
+                                IP:        externalIP,
+                                Port:      0,
+                                LVSMethod: "VIP",
+                                Backends:  nil,
+                                Protocol:  "TCP",
+                                VlanId:    vlanId,
+                                Subnet:    subnet,
+				Gateway:   gateway,
+                        })
+                        glog.V(2).Infof("Adding VIP only service: %v", externalIP)
+                        continue
+                }
+
 		svcObj, svcExists, err := ipvsc.svcLister.Indexer.GetByKey(nsSvc)
 		if err != nil {
 			glog.Warningf("error getting service %v: %v", nsSvc, err)
@@ -222,6 +274,9 @@ func (ipvsc *ipvsControllerController) getServices(cfgMap *api.ConfigMap) []vip 
 				LVSMethod: lvsm,
 				Backends:  ep,
 				Protocol:  fmt.Sprintf("%v", servicePort.Protocol),
+                                VlanId:    vlanId,
+                                Subnet:    subnet,
+				Gateway:   gateway,
 			})
 			glog.V(2).Infof("found service: %v:%v", s.Name, servicePort.Port)
 		}
@@ -258,6 +313,11 @@ func (ipvsc *ipvsControllerController) sync(key string) error {
 	svc := ipvsc.getServices(cfgMap)
 	ipvsc.ruCfg = svc
 
+	err = ipvsc.CreateVlanInterface()
+	if err != nil {
+		return err
+	}
+
 	err = ipvsc.keepalived.WriteCfg(svc)
 	if err != nil {
 		return err
@@ -293,14 +353,68 @@ func (ipvsc *ipvsControllerController) Stop() error {
 
 		ipvsc.keepalived.Stop()
 
+		ipvsc.CleanupVlanInterface()
+
 		return nil
 	}
 
 	return fmt.Errorf("shutdown already in progress")
 }
 
+// CreateVlanInterface create missing vlan interface for VIP binding with vlan id
+func (ipvsc *ipvsControllerController) CreateVlanInterface() error {
+	existingIfaces, err := ListInterfaces()
+	if err != nil {
+		glog.Fatalf("unexpected error: %v", err)
+		return err
+	}
+
+	if !in(existingIfaces,ipvsc.iface) {
+		return fmt.Errorf("interface %v not found", ipvsc.iface)
+	}
+
+	vlans := ListVlans(ipvsc.ruCfg)
+
+	if len(vlans) > 0 {
+		err := loadVlanModule()
+		if err != nil {
+			glog.Fatalf("unexpected error: %v", err)
+			return err
+	        }
+	}
+
+	for _, vlan := range vlans {
+		if !in(existingIfaces,fmt.Sprintf("%v.%v",ipvsc.iface,vlan)) {
+			_, err := k8sexec.New().Command("vconfig", "add", ipvsc.iface, fmt.Sprintf("%v",vlan)).CombinedOutput()
+			if err != nil {
+				glog.Warningf("could not add vlan id %v to %v: %v", vlan, ipvsc.iface, err)
+				return err
+			}
+			_, err = k8sexec.New().Command("ip","link","set","up","dev", fmt.Sprintf("%v.%v", ipvsc.iface, vlan)).CombinedOutput()
+                        if err != nil {
+                                glog.Warningf("could set up interface %v.%v: %v", ipvsc.iface, vlan, err)
+                                return err
+                        }
+			ipvsc.createdVlan = append(ipvsc.createdVlan,fmt.Sprintf("%v.%v", ipvsc.iface, vlan))
+		}
+	}
+
+	return nil
+}
+
+// CleanupVlanInterface lazy clean up of vlan interface created
+func (ipvsc *ipvsControllerController) CleanupVlanInterface() {
+	for _, iface := range ipvsc.createdVlan {
+		_, err := k8sexec.New().Command("vconfig", "rem", iface).CombinedOutput()
+		if err != nil {
+			glog.Infof("%v was created but could not be removed", iface)
+		}
+	}
+	return
+}
+
 // newIPVSController creates a new controller from the given config.
-func newIPVSController(kubeClient *unversioned.Client, namespace string, useUnicast bool, configMapName string, vrid int, vrrpVersion int) *ipvsControllerController {
+func newIPVSController(kubeClient *unversioned.Client, namespace string, useUnicast bool, configMapName string, vrid int, vrrpVersion int, customIface string) *ipvsControllerController {
 	ipvsc := ipvsControllerController{
 		client:            kubeClient,
 		reloadRateLimiter: flowcontrol.NewTokenBucketRateLimiter(reloadQPS, int(reloadQPS)),
@@ -352,7 +466,10 @@ func newIPVSController(kubeClient *unversioned.Client, namespace string, useUnic
 		ipt:         iptInterface,
 		vrid:        vrid,
 		vrrpVersion: vrrpVersion,
+		customIface: customIface,
 	}
+
+	ipvsc.iface = CoalesceString(customIface, nodeInfo.iface)
 
 	ipvsc.syncQueue = NewTaskQueue(ipvsc.sync)
 

--- a/keepalived-vip/keepalived.tmpl
+++ b/keepalived-vip/keepalived.tmpl
@@ -1,4 +1,4 @@
-{{ $iface := .iface }}{{ $netmask := .netmask }}
+{{ $iface := .iface }}{{ $netmask := .netmask }}{{ $customIface := .customIface }}
 
 global_defs {
   vrrp_version {{ .vrrpVersion }}
@@ -14,7 +14,8 @@ vrrp_instance vips {
   advert_int 1
 
   track_interface {
-    {{ $iface }}
+    {{ if $customIface }}{{ $customIface }}{{ end }}{{ range $v, $vlan := .vlans }}
+    {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}.{{ $vlan }}{{ end }}
   }
 
   {{ if .useUnicast }}
@@ -24,12 +25,17 @@ vrrp_instance vips {
   }
   {{ end }}
 
-  virtual_ipaddress { {{ range .vips }}
-    {{ . }}{{ end }}
+  virtual_ipaddress { {{ range $i, $vip := .vips }}
+    {{ $vip.IP }}/{{ $vip.Subnet }} dev {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}{{ if ne $vip.VlanId 0 }}.{{ $vip.VlanId }}{{ end }}{{ end }}
   }
+
+  virtual_routes { {{ range $i, $vip := .vips }}
+    {{ if $vip.Gateway }}{{ $vip.FullSubnet }} via {{ $vip.Gateway }} dev {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}{{ if ne $vip.VlanId 0 }}.{{ $vip.VlanId }}{{ end }}{{ end }}{{ end }}
+  }
+
 }
 
-{{ range $i, $svc := .svcs }}
+{{ range $j, $svc := .svcs }}
 {{ if eq $svc.LVSMethod "VIP" }}
 # VIP Service with no pods: {{ $svc.IP }}
 {{ else }}
@@ -41,7 +47,7 @@ virtual_server {{ $svc.IP }} {{ $svc.Port }} {
   persistence_timeout 1800
   protocol {{ $svc.Protocol }}
 
-  {{ range $j, $backend := $svc.Backends }}
+  {{ range $k, $backend := $svc.Backends }}
   real_server {{ $backend.IP }} {{ $backend.Port }} {
     weight 1
     TCP_CHECK {

--- a/keepalived-vip/main.go
+++ b/keepalived-vip/main.go
@@ -44,6 +44,7 @@ var (
 		with other keepalived instances`)
 
 	vrrpVersion = flags.Int("vrrp-version", 3, `Which VRRP version to use (2 or 3)`)
+	customIface = flags.String("custom-interface", "", `Optional custom interface to use for VIPs`)
 
 	configMapName = flags.String("services-configmap", "",
 		`Name of the ConfigMap that contains the definition of the services to expose.
@@ -124,7 +125,7 @@ func main() {
 	if *useUnicast {
 		glog.Info("keepalived will use unicast to sync the nodes")
 	}
-	ipvsc := newIPVSController(kubeClient, namespace, *useUnicast, *configMapName, *vrid, *vrrpVersion)
+	ipvsc := newIPVSController(kubeClient, namespace, *useUnicast, *configMapName, *vrid, *vrrpVersion, *customIface)
 	go ipvsc.epController.Run(wait.NeverStop)
 	go ipvsc.svcController.Run(wait.NeverStop)
 

--- a/keepalived-vip/utils_test.go
+++ b/keepalived-vip/utils_test.go
@@ -26,18 +26,25 @@ func TestParseNsSvcLVS(t *testing.T) {
 		Namespace     string
 		Service       string
 		ForwardMethod string
+		Subnet        int
+		Gateway       string
+		VlanId        int
 		ExpectedOk    bool
 	}{
-		"just service name":      {"echoheaders", "", "", "", true},
-		"missing namespace":      {"echoheaders:NAT", "", "", "", true},
-		"default forward method": {"default/echoheaders", "default", "echoheaders", "NAT", false},
-		"with forward method":    {"default/echoheaders:NAT", "default", "echoheaders", "NAT", false},
-		"DR as forward method":   {"default/echoheaders:DR", "default", "echoheaders", "DR", false},
-		"invalid forward method": {"default/echoheaders:AJAX", "", "", "", true},
+		"just service name":            {"echoheaders", "", "", "", 0, "", 0, true},
+		"missing namespace":            {"echoheaders:NAT", "", "", "", 0, "", 0, true},
+		"default forward method":       {"default/echoheaders", "default", "echoheaders", "NAT", 0, "", 0, false},
+		"with forward method":          {"default/echoheaders:NAT", "default", "echoheaders", "NAT", 0, "", 0, false},
+		"DR as forward method":         {"default/echoheaders:DR", "default", "echoheaders", "DR", 0, "", 0, false},
+		"invalid forward method":       {"default/echoheaders:AJAX", "", "", "", 0, "", 0, true},
+		"with subnet and default fw":   {"default/echoheaders::24", "default", "echoheaders", "NAT", 24, "", 0, false},
+		"with subnet and gateway":      {"default/echoheaders:DR:24:10.0.0.1", "default", "echoheaders", "DR", 24, "10.0.0.1", 0, false},
+		"with subnet and vlan only":    {"default/echoheaders::24::10", "default", "echoheaders", "NAT", 24, "", 10, false},
+		"with subnet, gw and vlan":     {"default/echoheaders::24:10.0.0.1:10", "default", "echoheaders", "NAT", 24, "10.0.0.1", 10, false},
 	}
 
 	for k, tc := range testcases {
-		ns, svc, lvs, err := parseNsSvcLVS(tc.Input)
+		ns, svc, lvs, subnet, gateway, vlanId, err := parseNsSvcLbVlan(tc.Input)
 
 		if tc.ExpectedOk && err == nil {
 			t.Errorf("%s: expected an error but valid information returned: %v ", k, tc.Input)
@@ -53,6 +60,18 @@ func TestParseNsSvcLVS(t *testing.T) {
 
 		if tc.ForwardMethod != lvs {
 			t.Errorf("%s: expected %v but returned %v - input %v", k, tc.ForwardMethod, lvs, tc.Input)
+		}
+
+		if tc.Subnet != subnet {
+			t.Errorf("%s: expected %v but returned %v - input %v", k, tc.Subnet, lvs, tc.Input)
+		}
+
+		if tc.Gateway != gateway {
+			t.Errorf("%s: expected %v but returned %v - input %v", k, tc.Gateway, lvs, tc.Input)
+		}
+
+		if tc.VlanId != vlanId {
+			t.Errorf("%s: expected %v but returned %v - input %v", k, tc.VlanId, lvs, tc.Input)
 		}
 	}
 }

--- a/keepalived-vip/vip-daemonset.yaml
+++ b/keepalived-vip/vip-daemonset.yaml
@@ -2,15 +2,30 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-keepalived-vip
+  labels: 
+    k8s-app: kube-keepalived-vip
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-keepalived-vip
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
-        name: kube-keepalived-vip
+        k8s-app: kube-keepalived-vip
     spec:
       hostNetwork: true
+      serviceAccount: kube-keepalived-vip
+      serviceAccountName: kube-keepalived-vip
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+	type: worker
+      tolerations:
+      #- key: node-role.kubernetes.io/master
+      #  effect: NoSchedule
       containers:
-        - image: k8s.gcr.io/kube-keepalived-vip:0.11
+        - image: k8s.gcr.io/kube-keepalived-vip:0.12
           name: kube-keepalived-vip
           imagePullPolicy: Always
           securityContext:
@@ -39,6 +54,8 @@ spec:
           #- --use-unicast=true
           # vrrp version can be set to 2.  Default 3.
           #- --vrrp-version=2
+          # optional custom interface for vip if different from kubernetes interface
+          #- --custom-interface=eth1
       volumes:
         - name: modules
           hostPath:
@@ -46,5 +63,3 @@ spec:
         - name: dev
           hostPath:
             path: /dev
-      nodeSelector:
-        type: worker

--- a/keepalived-vip/vip-rbac.yaml
+++ b/keepalived-vip/vip-rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-keepalived-vip
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-keepalived-vip
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - nodes
+  - endpoints
+  - services
+  - configmaps
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-keepalived-vip
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-keepalived-vip
+subjects:
+- kind: ServiceAccount
+  name: kube-keepalived-vip
+  namespace: default

--- a/keepalived-vip/vip-rc.yaml
+++ b/keepalived-vip/vip-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: k8s.gcr.io/kube-keepalived-vip:0.11
+      - image: k8s.gcr.io/kube-keepalived-vip:0.12
         name: kube-keepalived-vip
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
Following a rework of kube-keepalived-vip for a customer, we are contributing back the modifications.

    Upgrade to Keepalived 2.0.10 ==> According to keepalived.org, versions 2.x are the go-to versions where bugfixes and improvements happens (no backport).

    Custom interface handling ==> Ability to use an other interface rather than the internalIP/externalIP interface.

    Vlan handling. ==> Ability to create vlan tagged interfaces complete with subnet mask and gateway route.

This is my first contribution back to an open-source projet, i hope i wrote here everything needed, in any case, 2 additional sections exist in the README (Custom interface and Advanced configuration) explaining what happens.