### PR TITLE
Keepalived 2.0.10 + vlan handling mechanism

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -20,6 +20,7 @@ config-file-path
 configuration-name
 current-release-pr
 custom-error-service
+custom-interface
 datasource
 default-backend-service
 default-return-code

--- a/keepalived-vip/Changelog
+++ b/keepalived-vip/Changelog
@@ -1,4 +1,9 @@
 
+## 0.12
+- Update keepalived to 2.0.10
+- Custom interface handling 
+- Vlan handling
+
 ## 0.9
 - Update godeps
 - Update keepalived to 1.2.24

--- a/keepalived-vip/Dockerfile
+++ b/keepalived-vip/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
   iproute2 \
   ipvsadm \
+  vlan \
   bash && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
@@ -39,8 +40,10 @@ RUN mkdir -p /etc/keepalived && \
   ln -s /keepalived/sbin/keepalived /usr/sbin && \
   ln -s /keepalived/bin/genhash /usr/sbin
 
-COPY kube-keepalived-vip /
-COPY keepalived.tmpl /
+# Ordered COPY in less likely to change to more likely for better
+# use of caching during build and push
 COPY keepalived.conf /etc/keepalived
+COPY keepalived.tmpl /
+COPY kube-keepalived-vip /
 
 ENTRYPOINT ["/kube-keepalived-vip"]

--- a/keepalived-vip/Dockerfile
+++ b/keepalived-vip/Dockerfile
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/ubuntu-slim:0.5
+FROM quay.io/kubernetes-ingress-controller/debian-base-amd64:0.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  libssl1.0.0 \
+  libssl1.1 \
   libnl-3-200 \
   libnl-route-3-200 \
   libnl-genl-3-200 \
   iptables \
   libnfnetlink0 \
   libiptcdata0 \
-  libipset3 \
+  libipset11 \
   libipset-dev \
   libsnmp30 \
   kmod \
@@ -44,6 +44,7 @@ RUN mkdir -p /etc/keepalived && \
 # use of caching during build and push
 COPY keepalived.conf /etc/keepalived
 COPY keepalived.tmpl /
+COPY add-table /usr/local/sbin/
 COPY kube-keepalived-vip /
 
 ENTRYPOINT ["/kube-keepalived-vip"]

--- a/keepalived-vip/Makefile
+++ b/keepalived-vip/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any release builds, current "latest" is 0.11
-TAG = 0.11
+TAG = 0.12
 PREFIX = staging-k8s.gcr.io/kube-keepalived-vip
 BUILD_IMAGE = build-keepalived
 TEMP_GOPATH = ${GOPATH}:${GOPATH}/src/k8s.io/kubernetes/staging
@@ -24,6 +24,7 @@ push: container
 
 clean:
 	rm -f kube-keepalived-vip
+	rm -f keepalived.tar.gz
 
 update-godeps:
 	GOPATH=$(TEMP_GOPATH) godep save ./...

--- a/keepalived-vip/Makefile
+++ b/keepalived-vip/Makefile
@@ -1,8 +1,8 @@
 all: push
 
 # 0.0 shouldn't clobber any release builds, current "latest" is 0.11
-TAG = 0.12
-PREFIX = staging-k8s.gcr.io/kube-keepalived-vip
+TAG = 0.13
+PREFIX = budca/kube-keepalived-vip
 BUILD_IMAGE = build-keepalived
 TEMP_GOPATH = ${GOPATH}:${GOPATH}/src/k8s.io/kubernetes/staging
 
@@ -20,7 +20,7 @@ keepalived:
 	docker rm -f $(BUILD_IMAGE)
 
 push: container
-	gcloud docker -- push $(PREFIX):$(TAG)
+	docker push $(PREFIX):$(TAG)
 
 clean:
 	rm -f kube-keepalived-vip

--- a/keepalived-vip/add-table
+++ b/keepalived-vip/add-table
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <vlan id>" >&2
+  exit 1
+fi
+mkdir -p /etc/iproute2/rt_tables.d/
+echo "`expr 10000 + $1` vlan.$1" > /etc/iproute2/rt_tables.d/vlan.$1.conf

--- a/keepalived-vip/build/Dockerfile
+++ b/keepalived-vip/build/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash
 
 COPY build.sh /build.sh
 
-ENV VERSION 1.4.2
-ENV SHA256 84d35d4bbc95bf86c476f892e68bd0b14119e8b66127a985ecda48cb1859ffc6
+ENV VERSION 2.0.10
+ENV SHA256 8cfd31307e69fb6fc3417da4c67de8040b97c3e5fc67ebd7ffbe6c53aef22c8b
 
 RUN /build.sh

--- a/keepalived-vip/build/Dockerfile
+++ b/keepalived-vip/build/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/ubuntu-slim:0.5
+FROM quay.io/kubernetes-ingress-controller/debian-base-amd64:0.1
 
-RUN apt-get update && apt-get install -y --no-install-recommends bash
+RUN clean-install bash
 
 COPY build.sh /build.sh
 

--- a/keepalived-vip/controller.go
+++ b/keepalived-vip/controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	utildbus "k8s.io/kubernetes/pkg/util/dbus"
 	"k8s.io/kubernetes/pkg/util/exec"
+	k8sexec "k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
@@ -77,6 +78,9 @@ type vip struct {
 	Protocol  string
 	LVSMethod string
 	Backends  []service
+	VlanId    int
+	Subnet    int
+	Gateway   string
 }
 
 type vipByNameIPPort []vip
@@ -101,6 +105,24 @@ func (c vipByNameIPPort) Less(i, j int) bool {
 	return iPort < jPort
 }
 
+// ListVlans return a list of unique vlan id present in vips
+func ListVlans(vips []vip) []int {
+	vlans := []int{}
+	for _, vip := range vips {
+		present := false
+		for _, vlan := range vlans {
+			if vlan == vip.VlanId {
+				present = true
+				break
+			}
+		}
+		if !present && vip.VlanId != 0 {
+			vlans = append(vlans, vip.VlanId)
+		}
+	}
+	return vlans
+}
+
 // ipvsControllerController watches the kubernetes api and adds/removes
 // services from LVS throgh ipvsadmin.
 type ipvsControllerController struct {
@@ -114,6 +136,8 @@ type ipvsControllerController struct {
 	configMapName     string
 	ruCfg             []vip
 	ruMD5             string
+	iface             string
+	createdVlan       []string
 
 	// stopLock is used to enforce only a single call to Stop is active.
 	// Needed because we allow stopping through an http endpoint and
@@ -169,9 +193,9 @@ func (ipvsc *ipvsControllerController) getServices(cfgMap *api.ConfigMap) []vip 
 	svcs := []vip{}
 
 	// k -> IP to use
-	// v -> <namespace>/<service name>:<lvs method>
-	for externalIP, nsSvcLvs := range cfgMap.Data {
-		if nsSvcLvs == "" {
+	// v -> <namespace>/<service name>:<lvs method>:<vlan id>/<subnet>
+	for externalIP, nsSvcLvsVlan := range cfgMap.Data {
+		if nsSvcLvsVlan == "" {
 			// if target is empty string we will not forward to any service but
 			// instead just configure the IP on the machine and let it up to
 			// another Pod or daemon to bind to the IP address
@@ -182,18 +206,48 @@ func (ipvsc *ipvsControllerController) getServices(cfgMap *api.ConfigMap) []vip 
 				LVSMethod: "VIP",
 				Backends:  nil,
 				Protocol:  "TCP",
+				VlanId:    0,
+				Subnet:    32,
+				Gateway:   "",
 			})
 			glog.V(2).Infof("Adding VIP only service: %v", externalIP)
 			continue
 		}
 
-		ns, svc, lvsm, err := parseNsSvcLVS(nsSvcLvs)
+		ns, svc, lvsm, subnet, gateway, vlanId, err := parseNsSvcLbVlan(nsSvcLvsVlan)
+
+		// If no subnet is given, use /32
+		if subnet == 0 {
+			subnet = 32
+		}
+
 		if err != nil {
 			glog.Warningf("%v", err)
 			continue
 		}
 
 		nsSvc := fmt.Sprintf("%v/%v", ns, svc)
+
+		if nsSvc == "/" {
+			// Target was not empty but service is, so we will not forward
+			// to any service but instead just configure the IP (with
+			// possible vlan and subnet) on the machine and let it up to
+			// another Pod or daemon to bind to the IP address
+			svcs = append(svcs, vip{
+				Name:      "",
+				IP:        externalIP,
+				Port:      0,
+				LVSMethod: "VIP",
+				Backends:  nil,
+				Protocol:  "TCP",
+				VlanId:    vlanId,
+				Subnet:    subnet,
+				Gateway:   gateway,
+			})
+			glog.V(2).Infof("Adding VIP only service: %v", externalIP)
+			continue
+		}
+
 		svcObj, svcExists, err := ipvsc.svcLister.Indexer.GetByKey(nsSvc)
 		if err != nil {
 			glog.Warningf("error getting service %v: %v", nsSvc, err)
@@ -222,6 +276,9 @@ func (ipvsc *ipvsControllerController) getServices(cfgMap *api.ConfigMap) []vip 
 				LVSMethod: lvsm,
 				Backends:  ep,
 				Protocol:  fmt.Sprintf("%v", servicePort.Protocol),
+				VlanId:    vlanId,
+				Subnet:    subnet,
+				Gateway:   gateway,
 			})
 			glog.V(2).Infof("found service: %v:%v", s.Name, servicePort.Port)
 		}
@@ -258,6 +315,11 @@ func (ipvsc *ipvsControllerController) sync(key string) error {
 	svc := ipvsc.getServices(cfgMap)
 	ipvsc.ruCfg = svc
 
+	err = ipvsc.CreateVlanInterface()
+	if err != nil {
+		return err
+	}
+
 	err = ipvsc.keepalived.WriteCfg(svc)
 	if err != nil {
 		return err
@@ -293,14 +355,68 @@ func (ipvsc *ipvsControllerController) Stop() error {
 
 		ipvsc.keepalived.Stop()
 
+		ipvsc.CleanupVlanInterface()
+
 		return nil
 	}
 
 	return fmt.Errorf("shutdown already in progress")
 }
 
+// CreateVlanInterface create missing vlan interface for VIP binding with vlan id
+func (ipvsc *ipvsControllerController) CreateVlanInterface() error {
+	existingIfaces, err := ListInterfaces()
+	if err != nil {
+		glog.Fatalf("unexpected error: %v", err)
+		return err
+	}
+
+	if !in(existingIfaces, ipvsc.iface) {
+		return fmt.Errorf("interface %v not found", ipvsc.iface)
+	}
+
+	vlans := ListVlans(ipvsc.ruCfg)
+
+	if len(vlans) > 0 {
+		err := loadVlanModule()
+		if err != nil {
+			glog.Fatalf("unexpected error: %v", err)
+			return err
+		}
+	}
+
+	for _, vlan := range vlans {
+		if !in(existingIfaces, fmt.Sprintf("%v.%v", ipvsc.iface, vlan)) {
+			_, err := k8sexec.New().Command("vconfig", "add", ipvsc.iface, fmt.Sprintf("%v", vlan)).CombinedOutput()
+			if err != nil {
+				glog.Warningf("could not add vlan id %v to %v: %v", vlan, ipvsc.iface, err)
+				return err
+			}
+			_, err = k8sexec.New().Command("ip", "link", "set", "up", "dev", fmt.Sprintf("%v.%v", ipvsc.iface, vlan)).CombinedOutput()
+			if err != nil {
+				glog.Warningf("could set up interface %v.%v: %v", ipvsc.iface, vlan, err)
+				return err
+			}
+			ipvsc.createdVlan = append(ipvsc.createdVlan, fmt.Sprintf("%v.%v", ipvsc.iface, vlan))
+		}
+	}
+
+	return nil
+}
+
+// CleanupVlanInterface lazy clean up of vlan interface created
+func (ipvsc *ipvsControllerController) CleanupVlanInterface() {
+	for _, iface := range ipvsc.createdVlan {
+		_, err := k8sexec.New().Command("vconfig", "rem", iface).CombinedOutput()
+		if err != nil {
+			glog.Infof("%v was created but could not be removed", iface)
+		}
+	}
+	return
+}
+
 // newIPVSController creates a new controller from the given config.
-func newIPVSController(kubeClient *unversioned.Client, namespace string, useUnicast bool, configMapName string, vrid int, vrrpVersion int) *ipvsControllerController {
+func newIPVSController(kubeClient *unversioned.Client, namespace string, useUnicast bool, configMapName string, vrid int, vrrpVersion int, customIface string) *ipvsControllerController {
 	ipvsc := ipvsControllerController{
 		client:            kubeClient,
 		reloadRateLimiter: flowcontrol.NewTokenBucketRateLimiter(reloadQPS, int(reloadQPS)),
@@ -352,7 +468,10 @@ func newIPVSController(kubeClient *unversioned.Client, namespace string, useUnic
 		ipt:         iptInterface,
 		vrid:        vrid,
 		vrrpVersion: vrrpVersion,
+		customIface: customIface,
 	}
+
+	ipvsc.iface = CoalesceString(customIface, nodeInfo.iface)
 
 	ipvsc.syncQueue = NewTaskQueue(ipvsc.sync)
 

--- a/keepalived-vip/keepalived.go
+++ b/keepalived-vip/keepalived.go
@@ -19,6 +19,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"syscall"
@@ -36,6 +37,25 @@ const (
 
 var keepalivedTmpl = "keepalived.tmpl"
 
+// VipInfo structure for VIP (since we no longer just handle ip addresses)
+type VipInfo struct {
+	IP         string
+	Subnet     int
+	VlanId     int
+	Gateway    string
+	FullSubnet string
+}
+
+// moved from utils.go to keep next to VipInfo structure
+func appendIfMissing(slice []VipInfo, item VipInfo) []VipInfo {
+	for _, elem := range slice {
+		if elem == item {
+			return slice
+		}
+	}
+	return append(slice, item)
+}
+
 type keepalived struct {
 	iface       string
 	ip          string
@@ -45,12 +65,14 @@ type keepalived struct {
 	neighbors   []string
 	useUnicast  bool
 	started     bool
-	vips        []string
+	vips        []VipInfo
+	vlans       []int
 	tmpl        *template.Template
 	cmd         *exec.Cmd
 	ipt         iptables.Interface
 	vrid        int
 	vrrpVersion int
+	customIface string
 }
 
 // WriteCfg creates a new keepalived configuration file.
@@ -63,6 +85,7 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	defer w.Close()
 
 	k.vips = getVIPs(svcs)
+	k.vlans = ListVlans(svcs)
 
 	conf := make(map[string]interface{})
 	conf["iptablesChain"] = iptablesChain
@@ -70,12 +93,14 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	conf["myIP"] = k.ip
 	conf["netmask"] = k.netmask
 	conf["svcs"] = svcs
-	conf["vips"] = getVIPs(svcs)
+	conf["vips"] = k.vips
+	conf["vlans"] = k.vlans
 	conf["nodes"] = k.neighbors
 	conf["priority"] = k.priority
 	conf["useUnicast"] = k.useUnicast
 	conf["vrid"] = k.vrid
 	conf["vrrpVersion"] = k.vrrpVersion
+	conf["customIface"] = k.customIface
 
 	if glog.V(2) {
 		b, _ := json.Marshal(conf)
@@ -87,10 +112,11 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 
 // getVIPs returns a list of the virtual IP addresses to be used in keepalived
 // without duplicates (a service can use more than one port)
-func getVIPs(svcs []vip) []string {
-	result := []string{}
+func getVIPs(svcs []vip) []VipInfo {
+	result := []VipInfo{}
 	for _, svc := range svcs {
-		result = appendIfMissing(result, svc.IP)
+		_, ipnet, _ := net.ParseCIDR(fmt.Sprintf("%v/%v", svc.IP, svc.Subnet))
+		result = appendIfMissing(result, VipInfo{IP: svc.IP, Subnet: svc.Subnet, VlanId: svc.VlanId, Gateway: svc.Gateway, FullSubnet: fmt.Sprintf("%v", ipnet)})
 	}
 
 	return result
@@ -170,9 +196,13 @@ func resetIPVS() error {
 	return nil
 }
 
-func (k *keepalived) removeVIP(vip string) error {
+func (k *keepalived) removeVIP(vip VipInfo) error {
 	glog.Infof("removing configured VIP %v", vip)
-	out, err := k8sexec.New().Command("ip", "addr", "del", vip+"/32", "dev", k.iface).CombinedOutput()
+	iface := CoalesceString(k.customIface, k.iface)
+	if vip.VlanId != 0 {
+		iface = fmt.Sprintf("%v.%v", iface, vip.VlanId)
+	}
+	out, err := k8sexec.New().Command("ip", "addr", "del", fmt.Sprintf("%v/%v", vip.IP, vip.Subnet), "dev", iface).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error reloading keepalived: %v\n%s", err, out)
 	}

--- a/keepalived-vip/keepalived.go
+++ b/keepalived-vip/keepalived.go
@@ -150,6 +150,7 @@ func (k *keepalived) Start() {
 
 	if err := k.cmd.Wait(); err != nil {
 		glog.Fatalf("keepalived error: %v", err)
+                //select { }
 	}
 }
 
@@ -210,8 +211,14 @@ func (k *keepalived) removeVIP(vip VipInfo) error {
 }
 
 func (k *keepalived) loadTemplate() error {
-	tmpl, err := template.ParseFiles(keepalivedTmpl)
+        funcMap := template.FuncMap{
+		"tableid": func(i int) int {
+			return i + 10000
+		},
+	}
+	tmpl, err := template.New(keepalivedTmpl).Funcs(funcMap).ParseFiles(keepalivedTmpl)
 	if err != nil {
+                glog.Errorf("error parsing template: %v", err)
 		return err
 	}
 	k.tmpl = tmpl

--- a/keepalived-vip/keepalived.tmpl
+++ b/keepalived-vip/keepalived.tmpl
@@ -30,7 +30,14 @@ vrrp_instance vips {
   }
 
   virtual_routes { {{ range $i, $vip := .vips }}
-    {{ if $vip.Gateway }}{{ $vip.FullSubnet }} via {{ $vip.Gateway }} dev {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}{{ if ne $vip.VlanId 0 }}.{{ $vip.VlanId }}{{ end }}{{ end }}{{ end }}
+  {{ if and ($vip.Gateway) (ne $vip.VlanId 0) }}  {{ $vip.FullSubnet }} dev {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}.{{ $vip.VlanId }} src {{ $vip.IP }} table {{ tableid $vip.VlanId }}
+    default via {{ $vip.Gateway }} table {{ tableid $vip.VlanId }} no_track{{ end }}
+  {{ end }}
+  }
+
+  virtual_rules { {{ range $i, $vip := .vips }}
+  {{ if and ($vip.Gateway) (ne $vip.VlanId 0) }}  from {{ $vip.IP }} table {{ tableid $vip.VlanId }}{{ end }}
+  {{ end }}
   }
 
 }

--- a/keepalived-vip/keepalived.tmpl
+++ b/keepalived-vip/keepalived.tmpl
@@ -1,4 +1,4 @@
-{{ $iface := .iface }}{{ $netmask := .netmask }}
+{{ $iface := .iface }}{{ $netmask := .netmask }}{{ $customIface := .customIface }}
 
 global_defs {
   vrrp_version {{ .vrrpVersion }}
@@ -14,7 +14,8 @@ vrrp_instance vips {
   advert_int 1
 
   track_interface {
-    {{ $iface }}
+    {{ if $customIface }}{{ $customIface }}{{ end }}{{ range $v, $vlan := .vlans }}
+    {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}.{{ $vlan }}{{ end }}
   }
 
   {{ if .useUnicast }}
@@ -24,12 +25,17 @@ vrrp_instance vips {
   }
   {{ end }}
 
-  virtual_ipaddress { {{ range .vips }}
-    {{ . }}{{ end }}
+  virtual_ipaddress { {{ range $i, $vip := .vips }}
+    {{ $vip.IP }}/{{ $vip.Subnet }} dev {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}{{ if ne $vip.VlanId 0 }}.{{ $vip.VlanId }}{{ end }}{{ end }}
   }
+
+  virtual_routes { {{ range $i, $vip := .vips }}
+    {{ if $vip.Gateway }}{{ $vip.FullSubnet }} via {{ $vip.Gateway }} dev {{ if $customIface }}{{ $customIface }}{{ else }}{{ $iface }}{{ end }}{{ if ne $vip.VlanId 0 }}.{{ $vip.VlanId }}{{ end }}{{ end }}{{ end }}
+  }
+
 }
 
-{{ range $i, $svc := .svcs }}
+{{ range $j, $svc := .svcs }}
 {{ if eq $svc.LVSMethod "VIP" }}
 # VIP Service with no pods: {{ $svc.IP }}
 {{ else }}
@@ -41,7 +47,7 @@ virtual_server {{ $svc.IP }} {{ $svc.Port }} {
   persistence_timeout 1800
   protocol {{ $svc.Protocol }}
 
-  {{ range $j, $backend := $svc.Backends }}
+  {{ range $k, $backend := $svc.Backends }}
   real_server {{ $backend.IP }} {{ $backend.Port }} {
     weight 1
     TCP_CHECK {

--- a/keepalived-vip/main.go
+++ b/keepalived-vip/main.go
@@ -44,6 +44,7 @@ var (
 		with other keepalived instances`)
 
 	vrrpVersion = flags.Int("vrrp-version", 3, `Which VRRP version to use (2 or 3)`)
+	customIface = flags.String("custom-interface", "", `Optional custom interface to use for VIPs`)
 
 	configMapName = flags.String("services-configmap", "",
 		`Name of the ConfigMap that contains the definition of the services to expose.
@@ -124,7 +125,7 @@ func main() {
 	if *useUnicast {
 		glog.Info("keepalived will use unicast to sync the nodes")
 	}
-	ipvsc := newIPVSController(kubeClient, namespace, *useUnicast, *configMapName, *vrid, *vrrpVersion)
+	ipvsc := newIPVSController(kubeClient, namespace, *useUnicast, *configMapName, *vrid, *vrrpVersion, *customIface)
 	go ipvsc.epController.Run(wait.NeverStop)
 	go ipvsc.svcController.Run(wait.NeverStop)
 

--- a/keepalived-vip/utils.go
+++ b/keepalived-vip/utils.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,16 +40,36 @@ import (
 )
 
 var (
-	invalidIfaces = []string{"lo", "docker0", "flannel.1", "cbr0"}
-	nsSvcLbRegex  = regexp.MustCompile(`(.*)/(.*):(.*)|(.*)/(.*)`)
-	vethRegex     = regexp.MustCompile(`^veth.*`)
-	lvsRegex      = regexp.MustCompile(`NAT|DR`)
+	invalidIfaces    = []string{"lo", "docker0", "flannel.1", "cbr0"}
+	nsSvcLbVlanRegex = regexp.MustCompile(`^(.*)/(.*):(.*?):(.*?):(.*?):(.*?)$|^(.*)/(.*):(.*?):(.*?):(.*?)$|^(.*)/(.*):(.*?):(.*?)$|^(.*)/(.*):(.*?)$|^(.*)/(.*)$`)
+	vethRegex        = regexp.MustCompile(`^veth.*`)
+	lvsRegex         = regexp.MustCompile(`NAT|DR`)
 )
 
 type nodeInfo struct {
 	iface   string
 	ip      string
 	netmask int
+}
+
+// CoalesceString returns the first non empty string
+func CoalesceString(str ...string) string {
+	for _, s := range str {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// Check if element is present in array
+func in(arr []string, val string) bool {
+	for i := 0; i < len(arr); i++ {
+		if arr[i] == val {
+			return true
+		}
+	}
+	return false
 }
 
 // getNetworkInfo returns information of the node where the pod is running
@@ -176,6 +197,20 @@ func ipByInterface(name string) (string, int, error) {
 	return "", 32, errors.New("Found no IPv4 addresses.")
 }
 
+// ListInterfaces return a list of all interfaces on the host
+func ListInterfaces() ([]string, error) {
+	result := []string{}
+	ifaces, err := netInterfaces()
+	if err != nil {
+		return result, err
+	}
+
+	for _, iface := range ifaces {
+		result = append(result, iface.Name)
+	}
+	return result, nil
+}
+
 type stringSlice []string
 
 // pos returns the position of a string in a slice.
@@ -247,6 +282,18 @@ func loadIPVModule() error {
 	return err
 }
 
+// loadVlanModule load module require to use vlan
+func loadVlanModule() error {
+	out, err := k8sexec.New().Command("modprobe", "8021q").CombinedOutput()
+	if err != nil {
+		glog.V(2).Infof("Error loading 8021q: %s, %v", string(out), err)
+		return err
+	}
+
+	_, err = os.Stat("/proc/net/vlan")
+	return err
+}
+
 // changeSysctl changes the required network setting in /proc to get
 // keepalived working in the local system.
 func changeSysctl() error {
@@ -260,15 +307,6 @@ func changeSysctl() error {
 	return nil
 }
 
-func appendIfMissing(slice []string, item string) []string {
-	for _, elem := range slice {
-		if elem == item {
-			return slice
-		}
-	}
-	return append(slice, item)
-}
-
 func parseNsName(input string) (string, string, error) {
 	nsName := strings.Split(input, "/")
 	if len(nsName) != 2 {
@@ -278,33 +316,28 @@ func parseNsName(input string) (string, string, error) {
 	return nsName[0], nsName[1], nil
 }
 
-func parseNsSvcLVS(input string) (string, string, string, error) {
-	nsSvcLb := nsSvcLbRegex.FindStringSubmatch(input)
-	if len(nsSvcLb) != 6 {
-		return "", "", "", fmt.Errorf("invalid format (namespace/service name[:NAT|DR]) found in '%v'", input)
+func parseNsSvcLbVlan(input string) (string, string, string, int, string, int, error) {
+	nsSvcLbVlan := nsSvcLbVlanRegex.FindStringSubmatch(input)
+	if len(nsSvcLbVlan) != 21 {
+		return "", "", "", 0, "", 0, fmt.Errorf("invalid format (namespace/service name[:NAT|DR][:subnet][:gateway][:vlan id]) found in '%v'", input)
 	}
 
-	ns := nsSvcLb[1]
-	svc := nsSvcLb[2]
-	kind := nsSvcLb[3]
-
-	if ns == "" {
-		ns = nsSvcLb[4]
-	}
-
-	if svc == "" {
-		svc = nsSvcLb[5]
-	}
+	ns := CoalesceString(nsSvcLbVlan[1], nsSvcLbVlan[7], nsSvcLbVlan[12], nsSvcLbVlan[16], nsSvcLbVlan[19])
+	svc := CoalesceString(nsSvcLbVlan[2], nsSvcLbVlan[8], nsSvcLbVlan[13], nsSvcLbVlan[17], nsSvcLbVlan[20])
+	kind := CoalesceString(nsSvcLbVlan[3], nsSvcLbVlan[9], nsSvcLbVlan[14], nsSvcLbVlan[18])
+	subnet, _ := strconv.Atoi(CoalesceString(nsSvcLbVlan[4], nsSvcLbVlan[10], nsSvcLbVlan[15]))
+	gateway := CoalesceString(nsSvcLbVlan[5], nsSvcLbVlan[11])
+	vlanId, _ := strconv.Atoi(nsSvcLbVlan[6])
 
 	if kind == "" {
 		kind = "NAT"
 	}
 
 	if !lvsRegex.MatchString(kind) {
-		return "", "", "", fmt.Errorf("invalid LVS method. Only NAT and DR are supported: %v", kind)
+		return "", "", "", 0, "", 0, fmt.Errorf("invalid LVS method. Only NAT and DR are supported: %v", kind)
 	}
 
-	return ns, svc, kind, nil
+	return ns, svc, kind, subnet, gateway, vlanId, nil
 }
 
 type nodeSelector map[string]string

--- a/keepalived-vip/vip-daemonset.yaml
+++ b/keepalived-vip/vip-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       #- key: node-role.kubernetes.io/master
       #  effect: NoSchedule
       containers:
-        - image: k8s.gcr.io/kube-keepalived-vip:0.12
+        - image: k8s.gcr.io/kube-keepalived-vip:0.13
           name: kube-keepalived-vip
           imagePullPolicy: Always
           securityContext:

--- a/keepalived-vip/vip-daemonset.yaml
+++ b/keepalived-vip/vip-daemonset.yaml
@@ -2,15 +2,30 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-keepalived-vip
+  labels: 
+    k8s-app: kube-keepalived-vip
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-keepalived-vip
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
-        name: kube-keepalived-vip
+        k8s-app: kube-keepalived-vip
     spec:
       hostNetwork: true
+      serviceAccount: kube-keepalived-vip
+      serviceAccountName: kube-keepalived-vip
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+	type: worker
+      tolerations:
+      #- key: node-role.kubernetes.io/master
+      #  effect: NoSchedule
       containers:
-        - image: k8s.gcr.io/kube-keepalived-vip:0.11
+        - image: k8s.gcr.io/kube-keepalived-vip:0.12
           name: kube-keepalived-vip
           imagePullPolicy: Always
           securityContext:
@@ -39,6 +54,8 @@ spec:
           #- --use-unicast=true
           # vrrp version can be set to 2.  Default 3.
           #- --vrrp-version=2
+          # optional custom interface for vip if different from kubernetes interface
+          #- --custom-interface=eth1
       volumes:
         - name: modules
           hostPath:
@@ -46,5 +63,3 @@ spec:
         - name: dev
           hostPath:
             path: /dev
-      nodeSelector:
-        type: worker

--- a/keepalived-vip/vip-rbac.yaml
+++ b/keepalived-vip/vip-rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-keepalived-vip
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-keepalived-vip
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - nodes
+  - endpoints
+  - services
+  - configmaps
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-keepalived-vip
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-keepalived-vip
+subjects:
+- kind: ServiceAccount
+  name: kube-keepalived-vip
+  namespace: default

--- a/keepalived-vip/vip-rc.yaml
+++ b/keepalived-vip/vip-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: k8s.gcr.io/kube-keepalived-vip:0.11
+      - image: k8s.gcr.io/kube-keepalived-vip:0.12
         name: kube-keepalived-vip
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
Following a rework of kube-keepalived-vip for a customer, we are contributing back the modifications.

    Upgrade to Keepalived 2.0.10 ==> According to keepalived.org, versions 2.x are the go-to versions where bugfixes and improvements happens (no backport).

    Custom interface handling ==> Ability to use an other interface rather than the internalIP/externalIP interface.

    Vlan handling. ==> Ability to create vlan tagged interfaces complete with subnet mask and gateway route.

This is my first contribution back to an open-source projet, i hope i wrote here everything needed, in any case, 2 additional sections exist in the README (Custom interface and Advanced configuration) explaining what happens.