### PR TITLE
restart policy should be 'always'

### DIFF
--- a/init/systemd/kubelet.service
+++ b/init/systemd/kubelet.service
@@ -17,7 +17,7 @@ ExecStart=/usr/bin/kubelet \
 	    $KUBELET_HOSTNAME \
 	    $KUBE_ALLOW_PRIV \
 	    $KUBELET_ARGS
-Restart=on-failure
+Restart=always
 KillMode=process
 
 [Install]


### PR DESCRIPTION
The 'on-failure' restart policy means that if the kublet exits 'normally', it will not be restarted.  Problem is that systemd considers processes that are killed due to unhandled SIGPIPE as 'clean exits'.  See the 'Restart=' section of https://www.freedesktop.org/software/systemd/man/systemd.service.html, in particular:
"clean exit means an exit code of 0, or one of the signals SIGHUP, SIGINT, SIGTERM or SIGPIPE"
"If set to on-failure, the service will be restarted when the process .. is terminated by a signal (including on core dump, but *excluding the aforementioned four signals*)"
I saw this happen on my own cluster.  Kubelet got a SIGPIPE somehow, and exited, but because the systemd restart policy was 'on-failure', it didn't restart.