### PR TITLE
Update nginx-slim link

### DIFF
--- a/images/nginx-slim/README.md
+++ b/images/nginx-slim/README.md
@@ -1,3 +1,3 @@
 The `nginx-slim` image has moved to the
-[kubernetes/ingress](https://github.com/kubernetes/ingress/tree/master/images/nginx-slim)
+[kubernetes/ingress](https://github.com/kubernetes/ingress/tree/master/images/nginx)
 repository.


### PR DESCRIPTION
The link to nginx-slim image is changed.
This PR aims to update this link.