### PR TITLE
Utils - fixing ListDirs method

### DIFF
--- a/test-utils/utils/utils.go
+++ b/test-utils/utils/utils.go
@@ -282,7 +282,7 @@ func (u *Utils) CheckFinishedStatus(job string, buildNumber int) (bool, error) {
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		glog.Errorf("Failed to read the response for %v/%v/%v: %v", job, buildNumber, "finished.json", err)
-		return false, err
+		return false, fmt.Errorf("non-success response: %v", response.StatusCode)
 	}
 	err = json.Unmarshal(body, &result)
 	if err != nil {


### PR DESCRIPTION
Fixing https://github.com/kubernetes/contrib/pull/3005 
- Fixing broken code
- Adding nextPageToken hanlding.

`ExpandListDirURL` can be safely deleted - it was added in #3005. 