### PR TITLE
fix absend response by adding small delay in zookeeper check scripts

### DIFF
--- a/statefulsets/zookeeper/zkMetrics.sh
+++ b/statefulsets/zookeeper/zkMetrics.sh
@@ -15,4 +15,4 @@
 
 
 ZK_CLIENT_PORT=${ZK_CLIENT_PORT:-2181}
-echo mntr | nc localhost $ZK_CLIENT_PORT >& 1
+echo mntr | nc -q 1 localhost $ZK_CLIENT_PORT >& 1

--- a/statefulsets/zookeeper/zkOk.sh
+++ b/statefulsets/zookeeper/zkOk.sh
@@ -18,7 +18,7 @@
 # healthy, or 1 if the server fails to respond.
 
 ZK_CLIENT_PORT=${ZK_CLIENT_PORT:-2181}
-OK=$(echo ruok | nc 127.0.0.1 $ZK_CLIENT_PORT)
+OK=$(echo ruok | nc -q 1 127.0.0.1 $ZK_CLIENT_PORT)
 if [ "$OK" == "imok" ]; then
 	exit 0
 else


### PR DESCRIPTION
Running the pipes will close nc after sending commands immediately, which might not let zk time to respond to the request. Given a small delay fix false positives.

Not waiting for the response will (in case of zkOk) result in a lot of failing liveness probes and will restart the pod unnecessarily.

